### PR TITLE
Align development preview versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is in early **v0.1-dev** development.
+OrbitFabric is currently published as a **v0.1.0 development preview**.
 
 The current vertical slice is functional:
 
@@ -99,7 +99,7 @@ Mission Model YAML
 
 ## What OrbitFabric Is Not
 
-OrbitFabric v0.1 is not:
+OrbitFabric v0.1.0 development preview is not:
 
 - a flight-ready onboard runtime;
 - a replacement for cFS or F Prime;
@@ -182,7 +182,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.1.0
+orbitfabric 0.1.0.dev0
 ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # OrbitFabric — Architecture
 
-Version: 0.1-draft  
-Status: Draft  
+Version: 0.1.0.dev0  
+Status: Development preview  
 Scope: MVP v0.1 architecture  
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # OrbitFabric — Roadmap
 
-Version: 0.1-draft  
-Status: Draft  
-Scope: v0.1 to v0.5 planning  
+Version: 0.1.0.dev0  
+Status: Development preview  
+Scope: v0.1 to v0.5 planning   
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.1.0"
+version = "0.1.0.dev0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.0.dev0"

--- a/tests/test_lint_json_report.py
+++ b/tests/test_lint_json_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 from orbitfabric.lint.engine import LintEngine
 from orbitfabric.lint.json_report import lint_report_to_dict
@@ -21,7 +22,7 @@ def test_lint_report_to_dict_for_clean_demo_mission() -> None:
     payload = lint_report_to_dict(model, report)
 
     assert payload["tool"] == "orbitfabric-lint"
-    assert payload["version"] == "0.1.0"
+    assert payload["version"] == __version__
     assert payload["mission"] == "demo-3u"
     assert payload["model_version"] == "0.1.0"
     assert payload["result"] == "passed"

--- a/tests/test_sim_json_report.py
+++ b/tests/test_sim_json_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 from orbitfabric.model.scenario_loader import ScenarioLoader
 from orbitfabric.sim.json_report import simulation_result_to_dict
@@ -21,7 +22,7 @@ def test_simulation_result_to_dict_for_demo_scenario() -> None:
     payload = simulation_result_to_dict(result)
 
     assert payload["tool"] == "orbitfabric-sim"
-    assert payload["version"] == "0.1.0"
+    assert payload["version"] == __version__
     assert payload["mission"] == "demo-3u"
     assert payload["scenario"] == "battery_low_during_payload"
     assert payload["result"] == "passed"


### PR DESCRIPTION
## Summary

Align OrbitFabric development preview versioning across package metadata, runtime version output, documentation and tests.

## Changes

- Set package version to `0.1.0.dev0`.
- Set runtime `__version__` to `0.1.0.dev0`.
- Update README wording to describe the current state as a v0.1.0 development preview.
- Update expected CLI version output.
- Update architecture and roadmap document headers from draft wording to development preview wording.
- Update JSON report tests to assert against the package `__version__` instead of a hardcoded version string.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric --version`

Expected CLI output:

    orbitfabric 0.1.0.dev0

Closes #1.