### PR TITLE
Add published documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ orbitfabric/
 
 ## Documentation
 
+Published documentation is available at:
+
+```text
+https://farotech.github.io/orbitfabric/
+```
+
 Project documentation lives under:
 
 ```text


### PR DESCRIPTION
## Summary

Add the published GitHub Pages documentation URL to the README.

## Changes

- Link the public OrbitFabric documentation site from the README.
- Keep the existing local documentation source references.

## Validation

- `mkdocs build --strict`
- `ruff check .`
- `pytest`

Refs #2.