### PR TITLE
Add quickstart and demo walkthrough docs

### DIFF
--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -1,0 +1,274 @@
+# Demo Walkthrough
+
+This page explains the current OrbitFabric demo mission:
+
+```text
+examples/demo-3u/
+```
+
+The demo is synthetic and clean-room. It is not based on a real spacecraft, private mission, proprietary bus map, private payload or operational log.
+
+---
+
+## 1. Demo purpose
+
+The `demo-3u` mission demonstrates the OrbitFabric vertical slice:
+
+```text
+Define once. Validate. Simulate. Test. Document. Integrate.
+```
+
+The goal is not to model a real CubeSat.
+
+The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation and deterministic scenario execution.
+
+---
+
+## 2. Demo structure
+
+The demo lives under:
+
+```text
+examples/demo-3u/
+├── mission/
+│   ├── spacecraft.yaml
+│   ├── subsystems.yaml
+│   ├── modes.yaml
+│   ├── telemetry.yaml
+│   ├── commands.yaml
+│   ├── events.yaml
+│   ├── faults.yaml
+│   ├── packets.yaml
+│   └── policies.yaml
+└── scenarios/
+    └── battery_low_during_payload.yaml
+```
+
+The `mission/` directory contains the Mission Model.
+
+The `scenarios/` directory contains executable operational scenarios.
+
+---
+
+## 3. Mission Model files
+
+### `spacecraft.yaml`
+
+Defines the synthetic spacecraft identity and Mission Model version.
+
+### `subsystems.yaml`
+
+Defines the demo subsystems:
+
+```text
+obc
+eps
+payload
+radio
+```
+
+These are generic synthetic subsystem abstractions.
+
+### `modes.yaml`
+
+Defines the operational modes:
+
+```text
+BOOT
+NOMINAL
+PAYLOAD_ACTIVE
+DEGRADED
+SAFE
+MAINTENANCE
+```
+
+It also defines allowed mode transitions.
+
+### `telemetry.yaml`
+
+Defines telemetry items such as:
+
+```text
+obc.mode
+eps.battery.voltage
+eps.battery.current
+payload.acquisition.active
+radio.downlink.available
+```
+
+Telemetry items include source subsystem, type, unit, sampling, criticality, persistence and downlink priority.
+
+### `commands.yaml`
+
+Defines commands such as:
+
+```text
+payload.start_acquisition
+payload.stop_acquisition
+eps.get_status
+radio.downlink_housekeeping
+```
+
+Commands define target subsystem, arguments, allowed modes, ACK policy, timeout, risk, emitted events and expected effects.
+
+### `events.yaml`
+
+Defines events emitted by commands and faults.
+
+### `faults.yaml`
+
+Defines synthetic fault logic.
+
+The key fault in the demo is:
+
+```text
+eps.battery_low_fault
+```
+
+It monitors:
+
+```text
+eps.battery.voltage
+```
+
+and triggers a recovery action when voltage remains below a synthetic warning threshold.
+
+### `packets.yaml`
+
+Defines synthetic packet groupings for generated documentation and future integration artifacts.
+
+### `policies.yaml`
+
+Defines allowed policy values used by the model.
+
+---
+
+## 4. Scenario: battery low during payload operation
+
+The executable scenario is:
+
+```text
+examples/demo-3u/scenarios/battery_low_during_payload.yaml
+```
+
+It starts in:
+
+```text
+NOMINAL
+```
+
+with initial telemetry:
+
+```text
+obc.mode = NOMINAL
+eps.battery.voltage = 7.4
+eps.battery.current = 0.4
+payload.acquisition.active = false
+radio.downlink.available = true
+```
+
+---
+
+## 5. Scenario timeline
+
+The scenario demonstrates this operational sequence:
+
+```text
+payload.start_acquisition
+→ payload.acquisition_started
+→ NOMINAL -> PAYLOAD_ACTIVE
+→ battery voltage degradation
+→ eps.battery_low
+→ PAYLOAD_ACTIVE -> DEGRADED
+→ payload.stop_acquisition AUTO_DISPATCHED
+→ payload.acquisition_stopped
+→ payload.acquisition.active = false
+→ SCENARIO PASSED
+```
+
+---
+
+## 6. Run the scenario
+
+```bash
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+---
+
+## 7. Generate scenario outputs
+
+```bash
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+```
+
+Generated files:
+
+```text
+generated/reports/battery_low_during_payload_report.json
+generated/logs/battery_low_during_payload.log
+```
+
+---
+
+## 8. What the simulator checks
+
+During execution, OrbitFabric checks that:
+
+- commands exist in the Mission Model;
+- commands are allowed in the current mode;
+- expected command effects are applied;
+- events are emitted;
+- telemetry injections update simulation state;
+- fault conditions are evaluated;
+- mode transitions occur;
+- auto-dispatched recovery commands are recorded;
+- scenario expectations pass.
+
+---
+
+## 9. Expected final state
+
+At the end of the scenario:
+
+```text
+mode = DEGRADED
+payload.acquisition.active = false
+scenario_status = PASSED
+```
+
+The important behavior is the contract-level recovery path:
+
+```text
+EPS warning fault
+  -> transition to DEGRADED
+  -> auto-dispatch payload.stop_acquisition
+  -> payload acquisition inactive
+```
+
+---
+
+## 10. Clean-room boundary
+
+This demo is deliberately synthetic.
+
+It must not include:
+
+- real mission names;
+- private subsystem architectures;
+- private bus maps;
+- private payload protocols;
+- real thresholds from private missions;
+- real operational procedures;
+- real telemetry logs;
+- real anomaly sequences.
+
+The demo exists to prove OrbitFabric's architecture, not to approximate a real spacecraft.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,207 @@
+# Quickstart
+
+This guide shows how to run the current OrbitFabric development preview locally.
+
+OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
+
+The current vertical slice demonstrates:
+
+```text
+Mission Model YAML
+  -> structural validation
+  -> semantic lint
+  -> generated Markdown docs
+  -> scenario loading
+  -> deterministic scenario execution
+  -> JSON reports
+  -> simulation log
+```
+
+OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
+
+---
+
+## 1. Requirements
+
+OrbitFabric currently requires:
+
+```text
+Python 3.11 or newer
+Git
+```
+
+The CI validates Python 3.11 and Python 3.12.
+
+---
+
+## 2. Clone the repository
+
+```bash
+git clone https://github.com/FAROTECH/orbitfabric.git
+cd orbitfabric
+```
+
+---
+
+## 3. Create a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+On Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+```
+
+---
+
+## 4. Install OrbitFabric for local development
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev]"
+```
+
+---
+
+## 5. Verify the CLI
+
+```bash
+orbitfabric --version
+orbitfabric --help
+```
+
+Expected version for the current development preview:
+
+```text
+orbitfabric 0.1.0.dev0
+```
+
+---
+
+## 6. Run code quality checks
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+```
+
+All checks should pass.
+
+---
+
+## 7. Run Mission Model lint
+
+```bash
+orbitfabric lint examples/demo-3u/mission/
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+Generate a JSON lint report:
+
+```bash
+orbitfabric lint examples/demo-3u/mission/ \
+  --json generated/reports/lint_report.json
+```
+
+Generated output:
+
+```text
+generated/reports/lint_report.json
+```
+
+---
+
+## 8. Generate mission documentation
+
+```bash
+orbitfabric gen docs examples/demo-3u/mission/
+```
+
+Generated output:
+
+```text
+generated/docs/
+├── telemetry.md
+├── commands.md
+├── events.md
+├── faults.md
+├── modes.md
+└── packets.md
+```
+
+Generated mission documentation is derived from the validated Mission Model.
+
+Do not edit generated files manually.
+
+---
+
+## 9. Run the demo scenario
+
+```bash
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+Generate both JSON report and timeline log:
+
+```bash
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+```
+
+Generated outputs:
+
+```text
+generated/reports/battery_low_during_payload_report.json
+generated/logs/battery_low_during_payload.log
+```
+
+---
+
+## 10. What this proves
+
+The current demo proves that OrbitFabric can:
+
+- load a multi-file YAML Mission Model;
+- validate its structure;
+- run semantic lint rules;
+- generate Markdown documentation;
+- load a scenario;
+- execute a deterministic operational sequence;
+- emit events;
+- apply a fault-triggered mode transition;
+- auto-dispatch a recovery command;
+- produce JSON reports and logs.
+
+---
+
+## 11. What this does not prove
+
+The current demo does not prove:
+
+- flight readiness;
+- real-time behavior;
+- hardware integration;
+- CCSDS, PUS or CFDP compliance;
+- compatibility with cFS, F Prime, Yamcs or OpenC3;
+- orbital, attitude, power or thermal dynamics;
+- qualification for operational spacecraft use.
+
+Those are intentionally outside the current v0.1.0 development preview scope.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ nav:
       - Architecture: ARCHITECTURE.md
       - Roadmap: ROADMAP.md
       - Development Guide: DEVELOPMENT.md
+      - Quickstart: QUICKSTART.md
+      - Demo Walkthrough: DEMO_WALKTHROUGH.md
   - Reference:
       - Mission Model v0.1: reference/mission-model-v0.1.md
   - ADR:


### PR DESCRIPTION
## Summary

Add public-facing Quickstart and demo walkthrough documentation for the current OrbitFabric vertical slice.

## Changes

- Add `docs/QUICKSTART.md`.
- Add `docs/DEMO_WALKTHROUGH.md`.
- Link both pages from `mkdocs.yml`.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`

Closes #3.