### PR TITLE
Add warnings-as-errors lint option

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -63,6 +63,13 @@ def lint(
             help="Write a machine-readable lint report to this JSON file.",
         ),
     ] = None,
+    warnings_as_errors: Annotated[
+        bool,
+        typer.Option(
+            "--warnings-as-errors",
+            help="Fail lint when warning-level findings are present.",
+        ),
+    ] = False,
 ) -> None:
     """Validate and semantically lint a Mission Model."""
     typer.echo("OrbitFabric Mission Lint v0.1")
@@ -81,6 +88,10 @@ def lint(
     if json_output is not None:
         write_lint_report_json(model, report, json_output)
         typer.echo(f"\nJSON report written to: {json_output}")
+
+    if warnings_as_errors and report.warning_count > 0:
+        typer.echo("\nWarnings are treated as errors.")
+        raise typer.Exit(code=1)
 
     if report.has_errors:
         raise typer.Exit(code=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from orbitfabric.cli import app
@@ -29,3 +32,44 @@ def test_lint_loads_demo_mission() -> None:
     assert "Mission: demo-3u" in result.output
     assert "No findings." in result.output
     assert "Result: PASSED" in result.output
+
+def test_lint_with_warnings_passes_by_default(tmp_path: Path) -> None:
+    mission_dir = _copy_demo_mission_with_warning(tmp_path)
+
+    result = runner.invoke(app, ["lint", str(mission_dir)])
+
+    assert result.exit_code == 0
+    assert "OF-CMD-005" in result.output
+    assert "warnings: 1" in result.output
+    assert "Result: PASSED WITH WARNINGS" in result.output
+
+
+def test_lint_with_warnings_as_errors_fails(tmp_path: Path) -> None:
+    mission_dir = _copy_demo_mission_with_warning(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            str(mission_dir),
+            "--warnings-as-errors",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "OF-CMD-005" in result.output
+    assert "warnings: 1" in result.output
+    assert "Warnings are treated as errors." in result.output
+
+
+def _copy_demo_mission_with_warning(tmp_path: Path) -> Path:
+    source = Path("examples/demo-3u/mission")
+    mission_dir = tmp_path / "mission"
+    shutil.copytree(source, mission_dir)
+
+    commands_path = mission_dir / "commands.yaml"
+    commands = commands_path.read_text(encoding="utf-8")
+    commands = commands.replace("    timeout_ms: 1000\n", "", 1)
+    commands_path.write_text(commands, encoding="utf-8")
+
+    return mission_dir


### PR DESCRIPTION
## Summary

Add a `--warnings-as-errors` option to `orbitfabric lint`.

## Changes

- Add `--warnings-as-errors` to the lint CLI command.
- Preserve the current default behavior where warnings do not fail lint.
- Fail lint with exit code 1 when warnings are present and `--warnings-as-errors` is enabled.
- Add CLI tests for default warning behavior and strict warning behavior.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric lint examples/demo-3u/mission/`
- `orbitfabric lint examples/demo-3u/mission/ --warnings-as-errors`

Closes #5.