### PR TITLE
Fix docs index code fence

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,4 @@ Mission Model
   -> documentation
   -> scenario simulation
   -> future runtime and ground artifacts
+```


### PR DESCRIPTION
## Summary

Fix an unclosed Markdown code fence in the documentation homepage.

## Changes

- Close the `text` code block in `docs/index.md`.

## Validation

- `mkdocs build --strict`

Refs #2.