### PR TITLE
Upload generated CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,19 @@ jobs:
 
       - name: Build documentation site
         run: mkdocs build --strict
+
+      - name: Upload generated reports and logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: orbitfabric-generated-reports-${{ matrix.python-version }}
+          path: |
+            generated/reports/*.json
+            generated/logs/*.log
+          if-no-files-found: error
+
+      - name: Upload generated mission docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: orbitfabric-generated-docs-${{ matrix.python-version }}
+          path: generated/docs/
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Upload generated OrbitFabric reports, logs and mission documentation as GitHub Actions artifacts during CI.

## Changes

- Upload generated lint and simulation JSON reports.
- Upload generated simulation log.
- Upload generated mission Markdown documentation.
- Use Python-version-specific artifact names for the CI matrix.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
- `orbitfabric gen docs examples/demo-3u/mission/`
- `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`

Closes #6.