### PR TITLE
Add scenario validation command

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -28,6 +28,8 @@ app = typer.Typer(
 gen_app = typer.Typer(help="Generate artifacts from a Mission Model.")
 app.add_typer(gen_app, name="gen")
 
+validate_app = typer.Typer(help="Validate OrbitFabric inputs without executing them.")
+app.add_typer(validate_app, name="validate")
 
 @app.callback()
 def main(
@@ -144,6 +146,35 @@ def gen_docs(
 
     typer.echo("\nResult: PASSED")
 
+@validate_app.command("scenario")
+def validate_scenario(
+    scenario_file: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            help="Scenario YAML file to validate.",
+        ),
+    ],
+) -> None:
+    """Validate a scenario without executing it."""
+    typer.echo("OrbitFabric Scenario Validation v0.1")
+
+    try:
+        loaded = ScenarioLoader().load(scenario_file)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"\nScenario: {loaded.scenario.scenario.id}")
+    typer.echo(f"Mission: {loaded.mission_model.spacecraft.id}")
+    typer.echo(f"Model version: {loaded.mission_model.spacecraft.model_version}")
+    typer.echo(f"Initial mode: {loaded.scenario.initial_state.mode}")
+    typer.echo(f"Steps: {len(loaded.scenario.steps)}")
+
+    typer.echo("\nResult: PASSED")
 
 @app.command()
 def sim(

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -37,3 +38,44 @@ def test_scenario_loader_rejects_missing_file() -> None:
         ScenarioLoader().load(Path("missing-scenario.yaml"))
 
     assert exc_info.value.diagnostics[0].code == "OF-SCN-000"
+
+def test_validate_scenario_cli_loads_demo_scenario() -> None:
+    result = runner.invoke(app, ["validate", "scenario", str(DEMO_SCENARIO)])
+
+    assert result.exit_code == 0
+    assert "OrbitFabric Scenario Validation v0.1" in result.output
+    assert "Scenario: battery_low_during_payload" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Initial mode: NOMINAL" in result.output
+    assert "Steps: 13" in result.output
+    assert "Result: PASSED" in result.output
+    assert "Timeline:" not in result.output
+    assert "COMMAND payload.start_acquisition" not in result.output
+
+
+def test_validate_scenario_cli_rejects_unknown_command(tmp_path: Path) -> None:
+    scenario_path = _copy_demo_scenario_with_unknown_command(tmp_path)
+
+    result = runner.invoke(app, ["validate", "scenario", str(scenario_path)])
+
+    assert result.exit_code == 1
+    assert "OF-SCN-001" in result.output
+    assert "unknown command" in result.output
+    assert "Result: FAILED" in result.output
+
+
+def _copy_demo_scenario_with_unknown_command(tmp_path: Path) -> Path:
+    source = Path("examples/demo-3u")
+    demo_dir = tmp_path / "demo-3u"
+    shutil.copytree(source, demo_dir)
+
+    scenario_path = demo_dir / "scenarios" / "battery_low_during_payload.yaml"
+    scenario = scenario_path.read_text(encoding="utf-8")
+    scenario = scenario.replace(
+        "command: payload.start_acquisition",
+        "command: payload.unknown_command",
+        1,
+    )
+    scenario_path.write_text(scenario, encoding="utf-8")
+
+    return scenario_path


### PR DESCRIPTION
## Summary

Add a dedicated `orbitfabric validate scenario` command.

## Changes

- Add a `validate` CLI group.
- Add `orbitfabric validate scenario <scenario-file>`.
- Reuse the existing scenario loading and reference validation path.
- Print a concise scenario validation summary.
- Ensure validation does not execute the scenario timeline.
- Add CLI tests for valid and invalid scenarios.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml`
- `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml`

Closes #17.