### PR TITLE
Add mission inspection command

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -31,6 +31,9 @@ app.add_typer(gen_app, name="gen")
 validate_app = typer.Typer(help="Validate OrbitFabric inputs without executing them.")
 app.add_typer(validate_app, name="validate")
 
+inspect_app = typer.Typer(help="Inspect OrbitFabric models and inputs.")
+app.add_typer(inspect_app, name="inspect")
+
 @app.callback()
 def main(
     version: Annotated[
@@ -146,6 +149,32 @@ def gen_docs(
 
     typer.echo("\nResult: PASSED")
 
+@inspect_app.command("mission")
+def inspect_mission(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory to inspect.",
+        ),
+    ],
+) -> None:
+    """Inspect a Mission Model without linting or generating artifacts."""
+    typer.echo("OrbitFabric Mission Inspection v0.1")
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    _print_loaded_model_summary(model)
+
+    typer.echo("\nResult: PASSED")
+    
 @validate_app.command("scenario")
 def validate_scenario(
     scenario_file: Annotated[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,33 @@ def test_lint_loads_demo_mission() -> None:
     assert "No findings." in result.output
     assert "Result: PASSED" in result.output
 
+def test_inspect_mission_loads_demo_mission() -> None:
+    result = runner.invoke(app, ["inspect", "mission", "examples/demo-3u/mission"])
+
+    assert result.exit_code == 0
+    assert "OrbitFabric Mission Inspection v0.1" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Model version: 0.1.0" in result.output
+    assert "subsystems: 4" in result.output
+    assert "modes: 6" in result.output
+    assert "telemetry:" in result.output
+    assert "commands:" in result.output
+    assert "events:" in result.output
+    assert "faults:" in result.output
+    assert "packets:" in result.output
+    assert "Result: PASSED" in result.output
+    assert "Findings:" not in result.output
+
+def test_inspect_mission_rejects_invalid_mission(tmp_path: Path) -> None:
+    mission_dir = _copy_demo_mission_missing_required_file(tmp_path)
+
+    result = runner.invoke(app, ["inspect", "mission", str(mission_dir)])
+
+    assert result.exit_code == 1
+    assert "OF-SYN-002" in result.output
+    assert "required Mission Model file is missing" in result.output
+    assert "Result: FAILED" in result.output
+
 def test_lint_with_warnings_passes_by_default(tmp_path: Path) -> None:
     mission_dir = _copy_demo_mission_with_warning(tmp_path)
 
@@ -73,3 +100,12 @@ def _copy_demo_mission_with_warning(tmp_path: Path) -> Path:
     commands_path.write_text(commands, encoding="utf-8")
 
     return mission_dir
+
+def _copy_demo_mission_missing_required_file(tmp_path: Path) -> Path:
+    source = Path("examples/demo-3u/mission")
+    mission_dir = tmp_path / "mission"
+    shutil.copytree(source, mission_dir)
+
+    (mission_dir / "telemetry.yaml").unlink()
+
+    return mission_dir 


### PR DESCRIPTION
## Summary

Add a dedicated `orbitfabric inspect mission` command.

## Changes

- Add an `inspect` CLI group.
- Add `orbitfabric inspect mission <mission-dir>`.
- Reuse the existing Mission Model loader.
- Reuse the existing loaded model summary output.
- Add CLI tests for valid and invalid Mission Model inspection.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric inspect mission examples/demo-3u/mission/`
- `orbitfabric lint examples/demo-3u/mission/`
- `orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml`

Closes #18.