### PR TITLE
Clarify OrbitFabric versioning model

### DIFF
--- a/docs/reference/mission-model-v0.1.md
+++ b/docs/reference/mission-model-v0.1.md
@@ -255,7 +255,7 @@ spacecraft:
 | `class` | string | yes | Spacecraft class, for example `cubesat`, `picosat`, `smallsat`. |
 | `form_factor` | string | no | Physical form factor, for example `1U`, `3U`, `6U`. |
 | `mission_type` | string | no | Mission category, for example `technology_demonstrator`. |
-| `model_version` | string | yes | OrbitFabric Mission Model version. |
+| `model_version` | string | yes | Mission Model contract version declared by this mission. |
 
 ### 5.4 Example
 

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -1,0 +1,158 @@
+# Versioning Model
+
+This page explains how OrbitFabric uses version numbers.
+
+OrbitFabric currently distinguishes between:
+
+- the OrbitFabric tool/package version;
+- the Mission Model version declared by a mission;
+- the version field written into generated JSON reports.
+
+These versions are related, but they are not the same thing.
+
+---
+
+## OrbitFabric tool/package version
+
+The OrbitFabric tool/package version identifies the version of the Python package and CLI.
+
+It is defined in:
+
+```text
+pyproject.toml
+src/orbitfabric/__init__.py
+```
+
+It is shown by:
+
+```bash
+orbitfabric --version
+```
+
+Example:
+
+```text
+orbitfabric 0.1.0.dev0
+```
+
+This version answers the question:
+
+```text
+Which version of the OrbitFabric tool generated, validated or executed this artifact?
+```
+
+Generated JSON reports use this version in their top-level `version` field.
+
+---
+
+## Mission Model version
+
+The Mission Model version is declared inside the mission YAML.
+
+For the current multi-file Mission Model, it is stored in:
+
+```text
+spacecraft.yaml
+```
+
+Example:
+
+```yaml
+spacecraft:
+  id: demo-3u
+  name: Demo 3U Spacecraft
+  model_version: 0.1.0
+```
+
+This version answers the question:
+
+```text
+Which Mission Model contract version does this mission declare?
+```
+
+It is part of the mission data contract.
+
+It is not the same as the OrbitFabric Python package version.
+
+---
+
+## Generated JSON report version
+
+Generated JSON reports include the OrbitFabric tool/package version.
+
+Example:
+
+```json
+{
+  "tool": "orbitfabric-lint",
+  "version": "0.1.0.dev0",
+  "mission": {
+    "id": "demo-3u",
+    "model_version": "0.1.0"
+  }
+}
+```
+
+The top-level `version` identifies the OrbitFabric tool that produced the report.
+
+The nested `mission.model_version` identifies the Mission Model version declared by the mission.
+
+---
+
+## Why the versions differ
+
+During development previews, OrbitFabric may evolve faster than the Mission Model contract.
+
+For example:
+
+```text
+OrbitFabric tool/package version: 0.1.0.dev0
+Mission Model version:           0.1.0
+```
+
+This is valid.
+
+It means:
+
+- the tool is still a development preview;
+- the mission declares the v0.1 Mission Model contract;
+- generated artifacts record both pieces of information.
+
+---
+
+## Current v0.1 rule
+
+For the current development preview:
+
+| Version field | Meaning |
+|---|---|
+| `orbitfabric --version` | OrbitFabric CLI/package version. |
+| JSON report top-level `version` | OrbitFabric tool version that produced the report. |
+| `spacecraft.model_version` | Mission Model contract version declared by the mission. |
+| JSON report `mission.model_version` | Mission Model version copied from mission YAML. |
+
+---
+
+## What not to assume
+
+Do not assume that:
+
+- the OrbitFabric package version and Mission Model version are always identical;
+- a Mission Model version bump always requires a Python package major/minor bump;
+- a Python package patch/dev version always changes the Mission Model contract;
+- generated artifacts are valid without checking both tool version and mission model version.
+
+---
+
+## Future direction
+
+Future versions may introduce a more explicit schema versioning mechanism.
+
+Possible future additions include:
+
+- a dedicated Mission Model schema version field;
+- schema migration helpers;
+- compatibility checks between tool version and Mission Model version;
+- JSON Schema export for Mission Model validation.
+
+These are not part of the current v0.1.0 development preview.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Demo Walkthrough: DEMO_WALKTHROUGH.md
   - Reference:
       - Mission Model v0.1: reference/mission-model-v0.1.md
+      - Versioning Model: reference/versioning.md
       - Lint Rules v0.1: reference/lint-rules-v0.1.md
 
   - ADR:


### PR DESCRIPTION
## Summary

Document the OrbitFabric versioning model and clarify the difference between the tool/package version and the Mission Model version declared by a mission.

## Changes

- Add `docs/reference/versioning.md`.
- Link the versioning page from `mkdocs.yml`.
- Clarify the meaning of `spacecraft.model_version` in the Mission Model reference.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`

Closes #19.