### PR TITLE
Preserve diagnostic suggestions

### DIFF
--- a/src/orbitfabric/model/errors.py
+++ b/src/orbitfabric/model/errors.py
@@ -13,6 +13,7 @@ class ModelDiagnostic:
     file: str | None = None
     domain: str | None = None
     object_id: str | None = None
+    suggestion: str | None = None
 
     def format(self) -> str:
         parts = [self.severity, self.code]
@@ -24,6 +25,10 @@ class ModelDiagnostic:
             parts.append(self.object_id)
 
         parts.append(self.message)
+
+        if self.suggestion:
+            parts.append(f"Suggestion: {self.suggestion}")
+
         return " ".join(parts)
 
 

--- a/src/orbitfabric/model/scenario_loader.py
+++ b/src/orbitfabric/model/scenario_loader.py
@@ -61,6 +61,7 @@ class ScenarioLoader:
                         domain=finding.domain,
                         object_id=finding.object_id,
                         message=finding.message,
+                        suggestion=finding.suggestion,
                     )
                     for finding in reference_findings
                 ]

--- a/tests/test_model_diagnostic.py
+++ b/tests/test_model_diagnostic.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from orbitfabric.model.errors import ModelDiagnostic
+
+
+def test_model_diagnostic_format_includes_suggestion() -> None:
+    diagnostic = ModelDiagnostic(
+        severity="ERROR",
+        code="OF-SCN-001",
+        file="scenario.yaml",
+        domain="scenario",
+        object_id="battery_low_during_payload",
+        message="scenario command references unknown command 'payload.unknown_command'",
+        suggestion="Use a command defined in commands.yaml.",
+    )
+
+    assert diagnostic.format() == (
+        "ERROR OF-SCN-001 scenario.yaml battery_low_during_payload "
+        "scenario command references unknown command 'payload.unknown_command' "
+        "Suggestion: Use a command defined in commands.yaml."
+    )

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -67,6 +67,7 @@ def test_validate_scenario_cli_rejects_unknown_command(tmp_path: Path) -> None:
     assert result.exit_code == 1
     assert "OF-SCN-001" in result.output
     assert "unknown command" in result.output
+    assert "Suggestion: Use a command defined in commands.yaml." in result.output
     assert "Result: FAILED" in result.output
 
 
@@ -136,6 +137,7 @@ def test_scenario_loader_rejects_invalid_references(
     codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
 
     assert expected_code in codes
+    assert any(diagnostic.suggestion for diagnostic in exc_info.value.diagnostics)
 
 
 def test_scenario_loader_rejects_missing_required_top_level_key(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Improve diagnostic consistency by preserving actionable suggestions when scenario reference findings are converted into model diagnostics.

## Changes

- Add `suggestion` to `ModelDiagnostic`.
- Include diagnostic suggestions in `ModelDiagnostic.format()`.
- Preserve `LintFinding.suggestion` when scenario reference findings are converted to `ModelDiagnostic`.
- Add tests for formatted model diagnostics and scenario validation suggestions.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml`

Refs #23.