### PR TITLE
Add loader diagnostic suggestions

### DIFF
--- a/src/orbitfabric/model/loader.py
+++ b/src/orbitfabric/model/loader.py
@@ -40,6 +40,7 @@ class MissionModelLoader:
                         code="OF-SYN-001",
                         file=str(mission_dir),
                         message="mission path does not exist or is not a directory",
+                        suggestion="Pass an existing Mission Model directory.",
                     )
                 ]
             )
@@ -54,6 +55,7 @@ class MissionModelLoader:
                         code="OF-SYN-002",
                         file=filename,
                         message="required Mission Model file is missing",
+                        suggestion=f"Add the required Mission Model file '{filename}'.",
                     )
                 )
                 continue
@@ -98,6 +100,7 @@ class MissionModelLoader:
                     code="OF-SYN-003",
                     file=display_name,
                     message=f"invalid YAML: {exc}",
+                    suggestion="Fix YAML syntax.",
                 )
             )
             return None
@@ -109,6 +112,7 @@ class MissionModelLoader:
                     code="OF-SYN-004",
                     file=display_name,
                     message="YAML file is empty",
+                    suggestion="Add the required top-level YAML mapping.",
                 )
             )
             return None
@@ -120,6 +124,7 @@ class MissionModelLoader:
                     code="OF-SYN-005",
                     file=display_name,
                     message="YAML file must contain a mapping at the top level",
+                    suggestion="Use a YAML mapping at the top level.",
                 )
             )
             return None
@@ -142,6 +147,7 @@ class MissionModelLoader:
                         file=filename,
                         domain=key,
                         message=f"missing required top-level key '{key}'",
+                        suggestion=f"Add the required top-level key '{key}'.",
                     )
                 )
 
@@ -154,6 +160,7 @@ class MissionModelLoader:
                         file=filename,
                         domain=key,
                         message=f"unexpected top-level key '{key}'",
+                        suggestion=f"Remove or rename the unexpected top-level key '{key}'.",
                     )
                 )
 
@@ -169,6 +176,7 @@ class MissionModelLoader:
                     code="OF-STR-003",
                     domain=location or None,
                     message=message,
+                    suggestion="Fix the invalid Mission Model field.",
                 )
             )
 
@@ -248,6 +256,7 @@ class MissionModelLoader:
                         domain=domain,
                         object_id=value,
                         message="duplicate ID is not allowed within a domain",
+                        suggestion=f"Rename or remove duplicate ID '{value}'.",
                     )
                 )
             seen.add(value)

--- a/src/orbitfabric/model/scenario_loader.py
+++ b/src/orbitfabric/model/scenario_loader.py
@@ -30,6 +30,7 @@ class ScenarioLoader:
                         code="OF-SCN-000",
                         file=str(scenario_file),
                         message="scenario path does not exist or is not a file",
+                        suggestion="Pass an existing scenario YAML file.",
                     )
                 ]
             )
@@ -248,6 +249,7 @@ class ScenarioLoader:
                     code="OF-SCN-008",
                     file=str(scenario_file),
                     message=f"invalid scenario YAML: {exc}",
+                    suggestion="Fix scenario YAML syntax.",
                 )
             )
             return {}
@@ -259,6 +261,7 @@ class ScenarioLoader:
                     code="OF-SCN-009",
                     file=str(scenario_file),
                     message="scenario YAML file is empty",
+                    suggestion="Add scenario content.",
                 )
             )
             return {}
@@ -270,6 +273,7 @@ class ScenarioLoader:
                     code="OF-SCN-010",
                     file=str(scenario_file),
                     message="scenario YAML file must contain a top-level mapping",
+                    suggestion="Use a YAML mapping at the top level.",
                 )
             )
             return {}
@@ -289,6 +293,7 @@ class ScenarioLoader:
                         code="OF-SCN-011",
                         domain="scenario",
                         message=f"missing required top-level key '{key}'",
+                        suggestion=f"Add the required scenario top-level key '{key}'.",
                     )
                 )
 
@@ -300,6 +305,10 @@ class ScenarioLoader:
                         code="OF-SCN-012",
                         domain="scenario",
                         message=f"unexpected top-level key '{key}'",
+                        suggestion=(
+                            "Remove or rename the unexpected scenario "
+                            f"top-level key '{key}'."
+                        ),
                     )
                 )
 
@@ -315,6 +324,7 @@ class ScenarioLoader:
                     code="OF-SCN-013",
                     domain=location or None,
                     message=message,
+                    suggestion="Fix the invalid scenario field.",
                 )
             )
 

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -30,6 +30,10 @@ def test_missing_mission_directory_fails() -> None:
 
     assert exc_info.value.diagnostics[0].code == "OF-SYN-001"
 
+    assert exc_info.value.diagnostics[0].suggestion == (
+        "Pass an existing Mission Model directory."
+    )
+
 
 def test_missing_required_file_fails(tmp_path: Path) -> None:
     mission_dir = tmp_path / "mission"
@@ -40,3 +44,12 @@ def test_missing_required_file_fails(tmp_path: Path) -> None:
 
     codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
     assert "OF-SYN-002" in codes
+
+    suggestions = {    
+        diagnostic.suggestion
+        for diagnostic in exc_info.value.diagnostics
+        if diagnostic.code == "OF-SYN-002"
+    }
+
+    assert suggestions
+    assert all(suggestion is not None for suggestion in suggestions)

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -159,6 +159,10 @@ initial_state:
 
     assert exc_info.value.diagnostics[0].code == "OF-SCN-011"
 
+    assert exc_info.value.diagnostics[0].suggestion == (
+        "Add the required scenario top-level key 'steps'."
+    )
+
 
 def test_scenario_loader_rejects_unexpected_top_level_key(tmp_path: Path) -> None:
     scenario_path = tmp_path / "unexpected-key.yaml"
@@ -181,6 +185,9 @@ unexpected: true
 
     assert exc_info.value.diagnostics[0].code == "OF-SCN-012"
 
+    assert exc_info.value.diagnostics[0].suggestion == (
+        "Remove or rename the unexpected scenario top-level key 'unexpected'."
+    )
 
 def _copy_demo_scenario_with_replacement(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Improve diagnostic consistency by adding actionable suggestions to Mission Model and scenario loader diagnostics.

## Changes

- Add suggestions for Mission Model path, YAML and structural diagnostics.
- Add suggestions for duplicate Mission Model IDs.
- Add suggestions for scenario path, YAML and top-level key diagnostics.
- Add tests for representative loader diagnostic suggestions.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric inspect mission examples/demo-3u/mission/`
- `orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml`

Refs #23.