### PR TITLE
Prepare v0.2.0 development preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is currently published as a **v0.1.0 development preview**.
+OrbitFabric is currently published as a **v0.2.0 development preview**.
 
 The current vertical slice is functional:
 
@@ -61,7 +61,7 @@ Current verified baseline:
 
 ```text
 ruff check .  -> passing
-pytest        -> 34 tests passing
+pytest        -> passing
 ```
 
 ---
@@ -89,6 +89,7 @@ Mission Model YAML
   -> semantic lint
   -> JSON lint report
   -> generated Markdown docs
+  -> scenario validation
   -> scenario loading
   -> deterministic scenario execution
   -> simulation JSON report
@@ -99,7 +100,7 @@ Mission Model YAML
 
 ## What OrbitFabric Is Not
 
-OrbitFabric v0.1.0 development preview is not:
+OrbitFabric v0.2.0 development preview is not:
 
 - a flight-ready onboard runtime;
 - a replacement for cFS or F Prime;
@@ -182,7 +183,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.1.0.dev0
+orbitfabric 0.2.0.dev0
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.1.0.dev0"
+version = "0.2.0.dev0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.2.0.dev0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 
 runner = CliRunner()
@@ -14,7 +15,7 @@ def test_version() -> None:
     result = runner.invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert "orbitfabric 0.1.0" in result.output
+    assert f"orbitfabric {__version__}" in result.output
 
 
 def test_help() -> None:


### PR DESCRIPTION
## Summary

Prepare the OrbitFabric v0.2.0 development preview after completing the model hardening milestone.

## Changes

- Update package version to `0.2.0.dev0`.
- Update runtime `__version__` to `0.2.0.dev0`.
- Update README status and expected CLI output.
- Mention explicit scenario validation in the current vertical slice.
- Keep Mission Model `model_version` unchanged at `0.1.0`.
- Update version-related CLI test to assert against package `__version__`.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`
- `orbitfabric --version`
- `orbitfabric inspect mission examples/demo-3u/mission/`
- `orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml`
- `orbitfabric lint examples/demo-3u/mission/`
- `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml`

Closes #31.