### PR TITLE
Fix v0.2 public version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is currently published as a **v0.2.0 development preview**.
+OrbitFabric is currently published as a v0.2.0.dev0 development preview.
 
 The current vertical slice is functional:
 
@@ -112,7 +112,7 @@ OrbitFabric v0.2.0 development preview is not:
 - a CubeSat tutorial;
 - a ground segment.
 
-Those may become future integration targets or generated artifacts, but they are not the core of v0.1.
+Those may become future integration targets or generated artifacts, but they are not part of the current development preview.
 
 ---
 
@@ -300,7 +300,7 @@ Current expected baseline:
 
 ```text
 ruff check .  -> All checks passed
-pytest        -> 34 passed
+pytest        -> passing
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -11,6 +11,8 @@ Mission Model YAML
   -> structural validation
   -> semantic lint
   -> generated Markdown docs
+  -> mission inspection
+  -> scenario validation
   -> scenario loading
   -> deterministic scenario execution
   -> JSON reports
@@ -78,7 +80,7 @@ orbitfabric --help
 Expected version for the current development preview:
 
 ```text
-orbitfabric 0.1.0.dev0
+orbitfabric 0.2.0.dev0
 ```
 
 ---
@@ -95,7 +97,35 @@ All checks should pass.
 
 ---
 
-## 7. Run Mission Model lint
+## 7. Inspect the demo Mission Model
+
+```bash
+orbitfabric inspect mission examples/demo-3u/mission/
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+---
+
+## 8. Validate the demo scenario without executing it
+
+```bash
+orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+---
+
+## 9. Run Mission Model lint
 
 ```bash
 orbitfabric lint examples/demo-3u/mission/
@@ -122,7 +152,7 @@ generated/reports/lint_report.json
 
 ---
 
-## 8. Generate mission documentation
+## 10. Generate mission documentation
 
 ```bash
 orbitfabric gen docs examples/demo-3u/mission/
@@ -146,7 +176,7 @@ Do not edit generated files manually.
 
 ---
 
-## 9. Run the demo scenario
+## 11. Run the demo scenario
 
 ```bash
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
@@ -175,7 +205,7 @@ generated/logs/battery_low_during_payload.log
 
 ---
 
-## 10. What this proves
+## 12. What this proves
 
 The current demo proves that OrbitFabric can:
 
@@ -183,6 +213,8 @@ The current demo proves that OrbitFabric can:
 - validate its structure;
 - run semantic lint rules;
 - generate Markdown documentation;
+- inspect a Mission Model summary;
+- validate a scenario without executing it;
 - load a scenario;
 - execute a deterministic operational sequence;
 - emit events;
@@ -192,7 +224,7 @@ The current demo proves that OrbitFabric can:
 
 ---
 
-## 11. What this does not prove
+## 13. What this does not prove
 
 The current demo does not prove:
 
@@ -204,4 +236,4 @@ The current demo does not prove:
 - orbital, attitude, power or thermal dynamics;
 - qualification for operational spacecraft use.
 
-Those are intentionally outside the current v0.1.0 development preview scope.
+Those are intentionally outside the current v0.2.0 development preview scope.


### PR DESCRIPTION
## Summary

Fix public-facing version references after the v0.2.0.dev0 development preview release.

## Changes

- Update README status wording to `v0.2.0.dev0`.
- Remove stale v0.1 wording from the README current preview description.
- Avoid hardcoded pytest count in README.
- Update Quickstart expected CLI version to `orbitfabric 0.2.0.dev0`.
- Add v0.2 CLI commands to the Quickstart flow.
- Update Quickstart scope wording from v0.1.0 to v0.2.0.

## Validation

- `ruff check .`
- `pytest`
- `mkdocs build --strict`