### PR TITLE
model: add optional payloads domain

### DIFF
--- a/examples/demo-3u/mission/payloads.yaml
+++ b/examples/demo-3u/mission/payloads.yaml
@@ -1,0 +1,25 @@
+payloads:
+  - id: demo_iod_payload
+    subsystem: payload
+    profile: iod
+    lifecycle:
+      initial_state: READY
+      states:
+        - OFF
+        - READY
+        - ACQUIRING
+        - FAULT
+    telemetry:
+      produced:
+        - payload.acquisition.active
+    commands:
+      accepted:
+        - payload.start_acquisition
+        - payload.stop_acquisition
+    events:
+      generated:
+        - payload.acquisition_started
+        - payload.acquisition_stopped
+    faults:
+      possible: []
+    description: Synthetic IOD payload contract used to demonstrate payload-specific mission data grouping.

--- a/examples/demo-3u/mission/payloads.yaml
+++ b/examples/demo-3u/mission/payloads.yaml
@@ -3,12 +3,12 @@ payloads:
     subsystem: payload
     profile: iod
     lifecycle:
-      initial_state: READY
+      initial_state: "READY"
       states:
-        - OFF
-        - READY
-        - ACQUIRING
-        - FAULT
+        - "OFF"
+        - "READY"
+        - "ACQUIRING"
+        - "FAULT"
     telemetry:
       produced:
         - payload.acquisition.active

--- a/src/orbitfabric/model/loader.py
+++ b/src/orbitfabric/model/loader.py
@@ -22,6 +22,10 @@ REQUIRED_FILES: dict[str, tuple[str, ...]] = {
     "policies.yaml": ("policies",),
 }
 
+OPTIONAL_FILES: dict[str, tuple[str, ...]] = {
+    "payloads.yaml": ("payloads",),
+}
+
 
 class MissionModelLoader:
     """Loads a Mission Model from a canonical OrbitFabric mission directory."""
@@ -60,15 +64,15 @@ class MissionModelLoader:
                 )
                 continue
 
-            loaded = self._load_yaml_file(file_path, filename, diagnostics)
-            if loaded is None:
+            self._load_model_file(file_path, filename, expected_keys, diagnostics, data)
+
+        for filename, expected_keys in OPTIONAL_FILES.items():
+            file_path = mission_dir / filename
+
+            if not file_path.exists():
                 continue
 
-            self._validate_expected_keys(filename, loaded, expected_keys, diagnostics)
-
-            for key in expected_keys:
-                if key in loaded:
-                    data[key] = loaded[key]
+            self._load_model_file(file_path, filename, expected_keys, diagnostics, data)
 
         if diagnostics:
             raise MissionModelError(diagnostics)
@@ -83,6 +87,24 @@ class MissionModelLoader:
             raise MissionModelError(duplicate_diagnostics)
 
         return model
+
+    def _load_model_file(
+        self,
+        file_path: Path,
+        filename: str,
+        expected_keys: tuple[str, ...],
+        diagnostics: list[ModelDiagnostic],
+        data: dict[str, Any],
+    ) -> None:
+        loaded = self._load_yaml_file(file_path, filename, diagnostics)
+        if loaded is None:
+            return
+
+        self._validate_expected_keys(filename, loaded, expected_keys, diagnostics)
+
+        for key in expected_keys:
+            if key in loaded:
+                data[key] = loaded[key]
 
     def _load_yaml_file(
         self,
@@ -225,6 +247,13 @@ class MissionModelLoader:
                 domain="packets",
                 file="packets.yaml",
                 values=[item.id for item in model.packets],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="payloads",
+                file="payloads.yaml",
+                values=[item.id for item in model.payloads],
             )
         )
         diagnostics.extend(

--- a/src/orbitfabric/model/mission.py
+++ b/src/orbitfabric/model/mission.py
@@ -25,6 +25,7 @@ TelemetryType = Literal[
 ]
 
 PacketType = Literal["json", "binary_compact", "ccsds_like"]
+PayloadProfile = Literal["iod", "mission_specific"]
 
 
 class StrictModel(BaseModel):
@@ -158,6 +159,39 @@ class Packet(StrictModel):
     description: str | None = None
 
 
+class PayloadLifecycle(StrictModel):
+    initial_state: str
+    states: list[str]
+
+
+class PayloadTelemetryRefs(StrictModel):
+    produced: list[str] = Field(default_factory=list)
+
+
+class PayloadCommandRefs(StrictModel):
+    accepted: list[str] = Field(default_factory=list)
+
+
+class PayloadEventRefs(StrictModel):
+    generated: list[str] = Field(default_factory=list)
+
+
+class PayloadFaultRefs(StrictModel):
+    possible: list[str] = Field(default_factory=list)
+
+
+class PayloadContract(StrictModel):
+    id: str
+    subsystem: str
+    profile: PayloadProfile
+    lifecycle: PayloadLifecycle
+    telemetry: PayloadTelemetryRefs = Field(default_factory=PayloadTelemetryRefs)
+    commands: PayloadCommandRefs = Field(default_factory=PayloadCommandRefs)
+    events: PayloadEventRefs = Field(default_factory=PayloadEventRefs)
+    faults: PayloadFaultRefs = Field(default_factory=PayloadFaultRefs)
+    description: str | None = None
+
+
 class AllowedValues(StrictModel):
     allowed_values: list[str]
 
@@ -181,6 +215,7 @@ class MissionModel(StrictModel):
     faults: list[Fault]
     packets: list[Packet]
     policies: Policies
+    payloads: list[PayloadContract] = Field(default_factory=list)
 
     @property
     def subsystem_ids(self) -> set[str]:
@@ -205,6 +240,10 @@ class MissionModel(StrictModel):
     @property
     def packet_ids(self) -> set[str]:
         return {item.id for item in self.packets}
+
+    @property
+    def payload_ids(self) -> set[str]:
+        return {item.id for item in self.payloads}
 
     @property
     def mode_ids(self) -> set[str]:

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -24,6 +24,69 @@ def test_load_demo_mission() -> None:
     assert len(model.packets) >= 3
 
 
+def test_load_demo_payload_contract() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    assert len(model.payloads) == 1
+    payload = model.payloads[0]
+
+    assert payload.id == "demo_iod_payload"
+    assert payload.subsystem == "payload"
+    assert payload.profile == "iod"
+    assert payload.lifecycle.initial_state == "READY"
+    assert payload.lifecycle.states == ["OFF", "READY", "ACQUIRING", "FAULT"]
+    assert payload.telemetry.produced == ["payload.acquisition.active"]
+    assert payload.commands.accepted == [
+        "payload.start_acquisition",
+        "payload.stop_acquisition",
+    ]
+    assert payload.events.generated == [
+        "payload.acquisition_started",
+        "payload.acquisition_stopped",
+    ]
+    assert payload.faults.possible == []
+
+
+def test_optional_payloads_file_can_be_absent(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        if source_file.name == "payloads.yaml":
+            continue
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert model.payloads == []
+
+
+def test_invalid_payloads_top_level_key_fails(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    (mission_dir / "payloads.yaml").write_text(
+        "payload_contracts: []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissionModelError) as exc_info:
+        MissionModelLoader().load(mission_dir)
+
+    codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
+    assert "OF-STR-001" in codes
+    assert "OF-STR-002" in codes
+
+
 def test_missing_mission_directory_fails() -> None:
     with pytest.raises(MissionModelError) as exc_info:
         MissionModelLoader().load(Path("does-not-exist"))
@@ -45,7 +108,7 @@ def test_missing_required_file_fails(tmp_path: Path) -> None:
     codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
     assert "OF-SYN-002" in codes
 
-    suggestions = {    
+    suggestions = {
         diagnostic.suggestion
         for diagnostic in exc_info.value.diagnostics
         if diagnostic.code == "OF-SYN-002"


### PR DESCRIPTION
## Summary

Introduces an optional `payloads.yaml` Mission Model domain for first-class Payload / IOD Payload Contracts.

This PR keeps the feature deliberately narrow and model-first:

- adds payload contract Pydantic model types;
- loads `payloads.yaml` as an optional mission file;
- keeps missions without `payloads.yaml` valid;
- adds a synthetic demo IOD payload contract;
- adds loader tests for payload loading and optional absence.

## Scope

This PR only introduces structural model support.

Semantic reference checks for payload telemetry, commands, events, faults and lifecycle states are intentionally left to the dedicated lint issue.

## Non-goals

- Payload firmware
- Payload drivers
- Payload runtime services
- Hardware integration
- Bus/protocol implementation
- Real payload acquisition data
- Payload simulator behavior
- Ground export artifacts

## Related issue

Closes #35