### PR TITLE
lint: add payload lifecycle checks

### DIFF
--- a/examples/demo-3u/mission/commands.yaml
+++ b/examples/demo-3u/mission/commands.yaml
@@ -10,12 +10,19 @@ commands:
         description: Requested acquisition duration in seconds.
     allowed_modes:
       - NOMINAL
+    preconditions:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
     requires_ack: true
     timeout_ms: 1000
     risk: medium
     emits:
       - payload.acquisition_started
     expected_effects:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: ACQUIRING
       telemetry:
         payload.acquisition.active: true
       mode_transition:
@@ -29,12 +36,19 @@ commands:
       - PAYLOAD_ACTIVE
       - DEGRADED
       - SAFE
+    preconditions:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: ACQUIRING
     requires_ack: true
     timeout_ms: 1000
     risk: low
     emits:
       - payload.acquisition_stopped
     expected_effects:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
       telemetry:
         payload.acquisition.active: false
 

--- a/src/orbitfabric/lint/engine.py
+++ b/src/orbitfabric/lint/engine.py
@@ -6,6 +6,7 @@ from orbitfabric.lint.rules_events import check_events
 from orbitfabric.lint.rules_faults import check_faults
 from orbitfabric.lint.rules_modes import check_modes
 from orbitfabric.lint.rules_packets import check_packets
+from orbitfabric.lint.rules_payloads import check_payloads
 from orbitfabric.lint.rules_references import check_references
 from orbitfabric.lint.rules_telemetry import check_telemetry
 from orbitfabric.model.mission import MissionModel
@@ -18,6 +19,7 @@ class LintEngine:
         findings = []
         findings.extend(check_references(model))
         findings.extend(check_modes(model))
+        findings.extend(check_payloads(model))
         findings.extend(check_telemetry(model))
         findings.extend(check_commands(model))
         findings.extend(check_events(model))

--- a/src/orbitfabric/lint/rules_payloads.py
+++ b/src/orbitfabric/lint/rules_payloads.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Any
+
+from orbitfabric.lint.finding import LintFinding
+from orbitfabric.model.mission import MissionModel, PayloadContract
+
+
+def check_payloads(model: MissionModel) -> list[LintFinding]:
+    """Check Payload / IOD Payload Contract lifecycle consistency."""
+    findings: list[LintFinding] = []
+
+    payloads_by_id = {payload.id: payload for payload in model.payloads}
+
+    for payload in model.payloads:
+        findings.extend(_check_lifecycle_definition(payload))
+
+    for command in model.commands:
+        findings.extend(
+            _check_lifecycle_reference_group(
+                payloads_by_id=payloads_by_id,
+                command_id=command.id,
+                container=command.preconditions,
+                location="preconditions",
+                code_unknown_payload="OF-PAY-003",
+                code_unknown_state="OF-PAY-004",
+            )
+        )
+        findings.extend(
+            _check_lifecycle_reference_group(
+                payloads_by_id=payloads_by_id,
+                command_id=command.id,
+                container=command.expected_effects,
+                location="expected_effects",
+                code_unknown_payload="OF-PAY-005",
+                code_unknown_state="OF-PAY-006",
+            )
+        )
+
+    return findings
+
+
+def _check_lifecycle_definition(payload: PayloadContract) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    states = payload.lifecycle.states
+
+    if not states:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-PAY-001",
+                file="payloads.yaml",
+                domain="payloads",
+                object_id=payload.id,
+                message="payload lifecycle must define at least one state",
+                suggestion="Add at least one lifecycle state to lifecycle.states.",
+            )
+        )
+        return findings
+
+    if payload.lifecycle.initial_state not in states:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-PAY-002",
+                file="payloads.yaml",
+                domain="payloads",
+                object_id=payload.id,
+                message=(
+                    f"payload lifecycle initial state '{payload.lifecycle.initial_state}' "
+                    "is not declared in lifecycle.states"
+                ),
+                suggestion="Add the initial state to lifecycle.states or fix initial_state.",
+            )
+        )
+
+    return findings
+
+
+def _check_lifecycle_reference_group(
+    payloads_by_id: dict[str, PayloadContract],
+    command_id: str,
+    container: Any,
+    location: str,
+    code_unknown_payload: str,
+    code_unknown_state: str,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    reference = _extract_payload_lifecycle_reference(container)
+    if reference is None:
+        return findings
+
+    payload_id = reference.get("payload")
+    state = reference.get("state")
+
+    if not isinstance(payload_id, str) or not payload_id:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code=code_unknown_payload,
+                file="commands.yaml",
+                domain="commands",
+                object_id=command_id,
+                message=f"command {location} payload lifecycle reference must define a payload id",
+                suggestion="Set payload_lifecycle.payload to an existing payload id.",
+            )
+        )
+        return findings
+
+    payload = payloads_by_id.get(payload_id)
+    if payload is None:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code=code_unknown_payload,
+                file="commands.yaml",
+                domain="commands",
+                object_id=command_id,
+                message=(
+                    f"command {location} references unknown payload lifecycle "
+                    f"payload '{payload_id}'"
+                ),
+                suggestion="Add the payload to payloads.yaml or fix the payload reference.",
+            )
+        )
+        return findings
+
+    if not isinstance(state, str) or state not in payload.lifecycle.states:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code=code_unknown_state,
+                file="commands.yaml",
+                domain="commands",
+                object_id=command_id,
+                message=(
+                    f"command {location} references unknown lifecycle state "
+                    f"'{state}' for payload '{payload_id}'"
+                ),
+                suggestion="Use one of the lifecycle states declared in payloads.yaml.",
+            )
+        )
+
+    return findings
+
+
+def _extract_payload_lifecycle_reference(container: Any) -> dict[str, Any] | None:
+    if not isinstance(container, dict):
+        return None
+
+    reference = container.get("payload_lifecycle")
+    if reference is None:
+        return None
+
+    if isinstance(reference, dict):
+        return reference
+
+    return {}

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -50,3 +50,46 @@ def test_missing_initial_mode_is_reported() -> None:
     codes = {finding.code for finding in report.findings}
     assert "OF-MODE-001" in codes
     assert report.has_errors
+
+
+def test_payload_lifecycle_initial_state_must_exist_in_states() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].lifecycle.initial_state = "UNKNOWN"
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-002" in codes
+    assert report.has_errors
+
+
+def test_command_precondition_payload_lifecycle_state_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commands[0].preconditions = {
+        "payload_lifecycle": {
+            "payload": "demo_iod_payload",
+            "state": "UNKNOWN",
+        }
+    }
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-004" in codes
+    assert report.has_errors
+
+
+def test_command_expected_effect_payload_lifecycle_state_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commands[0].expected_effects = {
+        "payload_lifecycle": {
+            "payload": "demo_iod_payload",
+            "state": "UNKNOWN",
+        }
+    }
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-006" in codes
+    assert report.has_errors


### PR DESCRIPTION
## Summary

Adds semantic lint support for the minimal Payload / IOD Payload Contract lifecycle model.

This PR keeps the lifecycle slice deliberately narrow:

- validates that each payload lifecycle has a usable initial state;
- validates that `initial_state` exists in `lifecycle.states`;
- allows commands to reference payload lifecycle states in `preconditions`;
- allows commands to reference payload lifecycle states in `expected_effects`;
- reports invalid lifecycle payload/state references clearly;
- updates the demo mission commands with explicit payload lifecycle references.

## Example model shape

```yaml
preconditions:
  payload_lifecycle:
    payload: demo_iod_payload
    state: READY

expected_effects:
  payload_lifecycle:
    payload: demo_iod_payload
    state: ACQUIRING
```

## Non-goals

- Full payload state machine engine
- Physical payload simulation
- Timing model for warmup or acquisition
- Runtime scheduler
- Hardware state monitoring

## Related issue

Closes #36