### PR TITLE
lint: add payload contract reference checks

### DIFF
--- a/src/orbitfabric/lint/rules_payloads.py
+++ b/src/orbitfabric/lint/rules_payloads.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 from typing import Any
 
 from orbitfabric.lint.finding import LintFinding
-from orbitfabric.model.mission import MissionModel, PayloadContract
+from orbitfabric.model.mission import MissionModel, PayloadContract, Subsystem
 
 
 def check_payloads(model: MissionModel) -> list[LintFinding]:
-    """Check Payload / IOD Payload Contract lifecycle consistency."""
+    """Check Payload / IOD Payload Contract consistency."""
     findings: list[LintFinding] = []
 
     payloads_by_id = {payload.id: payload for payload in model.payloads}
+    subsystems_by_id = {subsystem.id: subsystem for subsystem in model.subsystems}
 
     for payload in model.payloads:
+        findings.extend(_check_payload_subsystem(payload, subsystems_by_id))
         findings.extend(_check_lifecycle_definition(payload))
+        findings.extend(_check_payload_references(model, payload))
 
     for command in model.commands:
         findings.extend(
@@ -22,8 +25,7 @@ def check_payloads(model: MissionModel) -> list[LintFinding]:
                 command_id=command.id,
                 container=command.preconditions,
                 location="preconditions",
-                code_unknown_payload="OF-PAY-003",
-                code_unknown_state="OF-PAY-004",
+                code="OF-PAY-009",
             )
         )
         findings.extend(
@@ -32,8 +34,50 @@ def check_payloads(model: MissionModel) -> list[LintFinding]:
                 command_id=command.id,
                 container=command.expected_effects,
                 location="expected_effects",
-                code_unknown_payload="OF-PAY-005",
-                code_unknown_state="OF-PAY-006",
+                code="OF-PAY-010",
+            )
+        )
+
+    return findings
+
+
+def _check_payload_subsystem(
+    payload: PayloadContract,
+    subsystems_by_id: dict[str, Subsystem],
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    subsystem = subsystems_by_id.get(payload.subsystem)
+
+    if subsystem is None:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-PAY-001",
+                file="payloads.yaml",
+                domain="payloads",
+                object_id=payload.id,
+                message=(
+                    f"payload subsystem '{payload.subsystem}' does not reference "
+                    "an existing subsystem"
+                ),
+                suggestion="Add the subsystem to subsystems.yaml or fix payload.subsystem.",
+            )
+        )
+        return findings
+
+    if subsystem.type != "payload":
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-PAY-002",
+                file="payloads.yaml",
+                domain="payloads",
+                object_id=payload.id,
+                message=(
+                    f"payload subsystem '{payload.subsystem}' references subsystem "
+                    f"type '{subsystem.type}', expected 'payload'"
+                ),
+                suggestion="Use a subsystem with type 'payload' or fix payload.subsystem.",
             )
         )
 
@@ -44,11 +88,24 @@ def _check_lifecycle_definition(payload: PayloadContract) -> list[LintFinding]:
     findings: list[LintFinding] = []
     states = payload.lifecycle.states
 
+    if not payload.lifecycle.initial_state:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-PAY-003",
+                file="payloads.yaml",
+                domain="payloads",
+                object_id=payload.id,
+                message="payload lifecycle must define an initial_state",
+                suggestion="Set lifecycle.initial_state to one of lifecycle.states.",
+            )
+        )
+
     if not states:
         findings.append(
             LintFinding(
                 severity="ERROR",
-                code="OF-PAY-001",
+                code="OF-PAY-004",
                 file="payloads.yaml",
                 domain="payloads",
                 object_id=payload.id,
@@ -62,7 +119,7 @@ def _check_lifecycle_definition(payload: PayloadContract) -> list[LintFinding]:
         findings.append(
             LintFinding(
                 severity="ERROR",
-                code="OF-PAY-002",
+                code="OF-PAY-004",
                 file="payloads.yaml",
                 domain="payloads",
                 object_id=payload.id,
@@ -77,13 +134,89 @@ def _check_lifecycle_definition(payload: PayloadContract) -> list[LintFinding]:
     return findings
 
 
+def _check_payload_references(
+    model: MissionModel,
+    payload: PayloadContract,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    findings.extend(
+        _check_reference_list(
+            values=payload.telemetry.produced,
+            known_ids=model.telemetry_ids,
+            payload_id=payload.id,
+            code="OF-PAY-005",
+            label="telemetry",
+            file="telemetry.yaml",
+        )
+    )
+    findings.extend(
+        _check_reference_list(
+            values=payload.commands.accepted,
+            known_ids=model.command_ids,
+            payload_id=payload.id,
+            code="OF-PAY-006",
+            label="command",
+            file="commands.yaml",
+        )
+    )
+    findings.extend(
+        _check_reference_list(
+            values=payload.events.generated,
+            known_ids=model.event_ids,
+            payload_id=payload.id,
+            code="OF-PAY-007",
+            label="event",
+            file="events.yaml",
+        )
+    )
+    findings.extend(
+        _check_reference_list(
+            values=payload.faults.possible,
+            known_ids=model.fault_ids,
+            payload_id=payload.id,
+            code="OF-PAY-008",
+            label="fault",
+            file="faults.yaml",
+        )
+    )
+
+    return findings
+
+
+def _check_reference_list(
+    values: list[str],
+    known_ids: set[str],
+    payload_id: str,
+    code: str,
+    label: str,
+    file: str,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    for value in values:
+        if value not in known_ids:
+            findings.append(
+                LintFinding(
+                    severity="ERROR",
+                    code=code,
+                    file="payloads.yaml",
+                    domain="payloads",
+                    object_id=payload_id,
+                    message=f"payload references unknown {label} '{value}'",
+                    suggestion=f"Add the {label} to {file} or fix the payload reference.",
+                )
+            )
+
+    return findings
+
+
 def _check_lifecycle_reference_group(
     payloads_by_id: dict[str, PayloadContract],
     command_id: str,
     container: Any,
     location: str,
-    code_unknown_payload: str,
-    code_unknown_state: str,
+    code: str,
 ) -> list[LintFinding]:
     findings: list[LintFinding] = []
 
@@ -98,7 +231,7 @@ def _check_lifecycle_reference_group(
         findings.append(
             LintFinding(
                 severity="ERROR",
-                code=code_unknown_payload,
+                code=code,
                 file="commands.yaml",
                 domain="commands",
                 object_id=command_id,
@@ -113,7 +246,7 @@ def _check_lifecycle_reference_group(
         findings.append(
             LintFinding(
                 severity="ERROR",
-                code=code_unknown_payload,
+                code=code,
                 file="commands.yaml",
                 domain="commands",
                 object_id=command_id,
@@ -130,7 +263,7 @@ def _check_lifecycle_reference_group(
         findings.append(
             LintFinding(
                 severity="ERROR",
-                code=code_unknown_state,
+                code=code,
                 file="commands.yaml",
                 domain="commands",
                 object_id=command_id,

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -52,6 +52,28 @@ def test_missing_initial_mode_is_reported() -> None:
     assert report.has_errors
 
 
+def test_payload_subsystem_reference_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].subsystem = "missing_subsystem"
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-001" in codes
+    assert report.has_errors
+
+
+def test_payload_subsystem_type_must_be_payload() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].subsystem = "eps"
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-002" in codes
+    assert report.has_errors
+
+
 def test_payload_lifecycle_initial_state_must_exist_in_states() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
     model.payloads[0].lifecycle.initial_state = "UNKNOWN"
@@ -59,7 +81,51 @@ def test_payload_lifecycle_initial_state_must_exist_in_states() -> None:
     report = LintEngine().run(model)
 
     codes = {finding.code for finding in report.findings}
-    assert "OF-PAY-002" in codes
+    assert "OF-PAY-004" in codes
+    assert report.has_errors
+
+
+def test_payload_telemetry_references_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].telemetry.produced.append("payload.unknown.telemetry")
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-005" in codes
+    assert report.has_errors
+
+
+def test_payload_command_references_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].commands.accepted.append("payload.unknown_command")
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-006" in codes
+    assert report.has_errors
+
+
+def test_payload_event_references_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].events.generated.append("payload.unknown_event")
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-007" in codes
+    assert report.has_errors
+
+
+def test_payload_fault_references_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads[0].faults.possible.append("payload.unknown_fault")
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-PAY-008" in codes
     assert report.has_errors
 
 
@@ -75,7 +141,7 @@ def test_command_precondition_payload_lifecycle_state_must_exist() -> None:
     report = LintEngine().run(model)
 
     codes = {finding.code for finding in report.findings}
-    assert "OF-PAY-004" in codes
+    assert "OF-PAY-009" in codes
     assert report.has_errors
 
 
@@ -91,5 +157,5 @@ def test_command_expected_effect_payload_lifecycle_state_must_exist() -> None:
     report = LintEngine().run(model)
 
     codes = {finding.code for finding in report.findings}
-    assert "OF-PAY-006" in codes
+    assert "OF-PAY-010" in codes
     assert report.has_errors


### PR DESCRIPTION
## Summary

Adds semantic lint rules for Payload / IOD Payload Contracts.

This PR extends the payload lint layer beyond lifecycle checks and validates that payload contracts reference existing canonical Mission Model objects.

## Checks added

- `OF-PAY-001` payload subsystem must reference an existing subsystem
- `OF-PAY-002` payload subsystem must have type `payload`
- `OF-PAY-003` payload lifecycle must define an `initial_state`
- `OF-PAY-004` payload lifecycle `initial_state` must exist in `states`
- `OF-PAY-005` payload telemetry references must exist
- `OF-PAY-006` payload command references must exist
- `OF-PAY-007` payload event references must exist
- `OF-PAY-008` payload fault references must exist
- `OF-PAY-009` payload command preconditions must reference known payload lifecycle states
- `OF-PAY-010` payload command expected effects must reference known payload lifecycle states

## Scope

This PR validates references only.

It does not introduce runtime enforcement, hardware checks, payload driver validation, real payload data validation or plugin-based lint rules.

## Related issue

Closes #37