### PR TITLE
docs: generate payload contract reference

### DIFF
--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -12,6 +12,7 @@ from orbitfabric.model.mission import (
     FaultRecovery,
     MissionModel,
     Packet,
+    PayloadContract,
     QualityPolicy,
     TelemetryItem,
     TelemetryLimits,
@@ -30,6 +31,11 @@ def generate_markdown_docs(model: MissionModel, output_dir: Path) -> list[Path]:
         _write(output_dir / "modes.md", _render_modes(model)),
         _write(output_dir / "packets.md", _render_packets(model)),
     ]
+
+    if model.payloads:
+        generated_files.append(
+            _write(output_dir / "payloads.md", _render_payloads(model))
+        )
 
     return generated_files
 
@@ -262,6 +268,43 @@ def _render_packet_row(packet: Packet) -> str:
     )
 
 
+def _render_payloads(model: MissionModel) -> str:
+    lines = [_header("Payload Contract Reference", model)]
+
+    lines.append("## Summary\n\n")
+    lines.append(f"- Payload contracts: `{len(model.payloads)}`\n")
+    lines.append(f"- Payload profiles: `{len({payload.profile for payload in model.payloads})}`\n\n")
+
+    lines.append("## Payload contracts\n\n")
+
+    for payload in sorted(model.payloads, key=lambda item: item.id):
+        lines.append(_render_payload_contract(model, payload))
+
+    return "".join(lines)
+
+
+def _render_payload_contract(model: MissionModel, payload: PayloadContract) -> str:
+    lines: list[str] = []
+
+    lines.append(f"### {_code(payload.id)}\n\n")
+
+    if payload.description:
+        lines.append(f"{_text(payload.description)}\n\n")
+
+    lines.append("| Field | Value |\n")
+    lines.append("|---|---|\n")
+    lines.append(f"| Subsystem | {_subsystem_heading(model, payload.subsystem)} |\n")
+    lines.append(f"| Profile | {_code(payload.profile)} |\n")
+    lines.append(f"| Initial lifecycle state | {_code(payload.lifecycle.initial_state)} |\n")
+    lines.append(f"| Lifecycle states | {_format_list(payload.lifecycle.states)} |\n")
+    lines.append(f"| Telemetry produced | {_format_list(payload.telemetry.produced)} |\n")
+    lines.append(f"| Commands accepted | {_format_list(payload.commands.accepted)} |\n")
+    lines.append(f"| Events generated | {_format_list(payload.events.generated)} |\n")
+    lines.append(f"| Faults possible | {_format_list(payload.faults.possible)} |\n\n")
+
+    return "".join(lines)
+
+
 def _telemetry_by_source(model: MissionModel) -> dict[str, list[TelemetryItem]]:
     grouped: dict[str, list[TelemetryItem]] = {}
 
@@ -346,6 +389,13 @@ def _format_expected_effects(expected_effects: dict[str, Any]) -> str:
 
     lines: list[str] = []
 
+    payload_lifecycle = expected_effects.get("payload_lifecycle")
+    if isinstance(payload_lifecycle, dict):
+        payload_id = payload_lifecycle.get("payload")
+        state = payload_lifecycle.get("state")
+        if payload_id is not None and state is not None:
+            lines.append(f"payload {_code(payload_id)} lifecycle -> {_code(state)}")
+
     telemetry_effects = expected_effects.get("telemetry", {})
     if isinstance(telemetry_effects, dict):
         for telemetry_id, value in sorted(telemetry_effects.items()):
@@ -357,7 +407,12 @@ def _format_expected_effects(expected_effects: dict[str, Any]) -> str:
         if target_mode is not None:
             lines.append(f"mode -> {_code(target_mode)}")
 
-    ignored_keys = {"telemetry", "mode_transition", "no_state_change"}
+    ignored_keys = {
+        "telemetry",
+        "mode_transition",
+        "no_state_change",
+        "payload_lifecycle",
+    }
     remaining = {
         key: value
         for key, value in expected_effects.items()

--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -271,9 +271,11 @@ def _render_packet_row(packet: Packet) -> str:
 def _render_payloads(model: MissionModel) -> str:
     lines = [_header("Payload Contract Reference", model)]
 
+    profile_count = len({payload.profile for payload in model.payloads})
+
     lines.append("## Summary\n\n")
     lines.append(f"- Payload contracts: `{len(model.payloads)}`\n")
-    lines.append(f"- Payload profiles: `{len({payload.profile for payload in model.payloads})}`\n\n")
+    lines.append(f"- Payload profiles: `{profile_count}`\n\n")
 
     lines.append("## Payload contracts\n\n")
 

--- a/tests/test_doc_generator.py
+++ b/tests/test_doc_generator.py
@@ -25,16 +25,20 @@ def test_generate_markdown_docs(tmp_path: Path) -> None:
         "faults.md",
         "modes.md",
         "packets.md",
+        "payloads.md",
     }
 
     telemetry_doc = (tmp_path / "telemetry.md").read_text(encoding="utf-8")
     commands_doc = (tmp_path / "commands.md").read_text(encoding="utf-8")
+    payloads_doc = (tmp_path / "payloads.md").read_text(encoding="utf-8")
 
     assert "Telemetry Reference" in telemetry_doc
     assert "eps.battery.voltage" in telemetry_doc
     assert "Battery Voltage" in telemetry_doc
     assert "Command Reference" in commands_doc
     assert "payload.start_acquisition" in commands_doc
+    assert "Payload Contract Reference" in payloads_doc
+    assert "demo_iod_payload" in payloads_doc
 
     faults_doc = (tmp_path / "faults.md").read_text(encoding="utf-8")
 
@@ -82,3 +86,4 @@ def test_gen_docs_cli_writes_markdown_files(tmp_path: Path) -> None:
     assert (output_dir / "faults.md").exists()
     assert (output_dir / "modes.md").exists()
     assert (output_dir / "packets.md").exists()
+    assert (output_dir / "payloads.md").exists()

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.gen.docs import generate_markdown_docs
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_generate_payload_contract_docs(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    payloads_path = tmp_path / "payloads.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "payloads.md" in generated_names
+    assert payloads_path.exists()
+
+    content = payloads_path.read_text(encoding="utf-8")
+
+    assert "# Payload Contract Reference" in content
+    assert "`demo_iod_payload`" in content
+    assert "`payload` - Demo Payload" in content
+    assert "`iod`" in content
+    assert "`READY`" in content
+    assert "`ACQUIRING`" in content
+    assert "`payload.acquisition.active`" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`payload.acquisition_started`" in content
+
+
+def test_payload_contract_docs_are_skipped_without_payloads(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.payloads = []
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+    generated_names = {path.name for path in generated_files}
+
+    assert "payloads.md" not in generated_names
+    assert not (tmp_path / "payloads.md").exists()


### PR DESCRIPTION
## Summary

Adds generated Markdown documentation for Payload / IOD Payload Contracts.

When a mission defines payload contracts, `orbitfabric gen docs` now emits:

```text
generated/docs/payloads.md
```

The generated page includes:

- payload id
- linked subsystem
- payload profile
- initial lifecycle state
- lifecycle states
- telemetry produced
- commands accepted
- events generated
- faults possible

## Behavior

- Missions with payload contracts generate `payloads.md`.
- Missions without payload contracts do not generate `payloads.md`.
- Existing generated documentation remains unchanged unless payload contracts are present.

## Non-goals

- Manual payload documentation
- Payload operations manual
- Ground dictionary export
- Runtime skeleton generation
- Real payload data documentation

## Related issue

Closes #38