### PR TITLE
sim: add minimal payload lifecycle scenario

### DIFF
--- a/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
+++ b/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
@@ -1,0 +1,68 @@
+scenario:
+  id: nominal_payload_acquisition
+  name: Nominal payload acquisition lifecycle
+  description: Synthetic scenario demonstrating a minimal IOD payload lifecycle from READY to ACQUIRING and back to READY.
+
+mission:
+  path: ../mission
+
+initial_state:
+  mode: NOMINAL
+  telemetry:
+    obc.mode: NOMINAL
+    eps.battery.voltage: 7.4
+    eps.battery.current: 0.4
+    payload.acquisition.active: false
+    radio.downlink.available: true
+
+steps:
+  - t: 0
+    expect_mode: NOMINAL
+
+  - t: 1
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
+
+  - t: 5
+    command: payload.start_acquisition
+    args:
+      duration_s: 120
+    expect:
+      command_status: ACCEPTED
+
+  - t: 6
+    expect_event: payload.acquisition_started
+
+  - t: 7
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: ACQUIRING
+
+  - t: 8
+    expect_telemetry:
+      payload.acquisition.active: true
+
+  - t: 20
+    command: payload.stop_acquisition
+    expect:
+      command_status: ACCEPTED
+
+  - t: 21
+    expect_event: payload.acquisition_stopped
+
+  - t: 22
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
+
+  - t: 23
+    expect_telemetry:
+      payload.acquisition.active: false
+
+  - t: 25
+    expect:
+      scenario_status: PASSED

--- a/src/orbitfabric/sim/command_router.py
+++ b/src/orbitfabric/sim/command_router.py
@@ -50,6 +50,15 @@ class CommandRouter:
                 reason=f"command not allowed in mode {self._state.current_mode}",
             )
 
+        lifecycle_error = self._validate_payload_lifecycle_precondition(command)
+        if lifecycle_error is not None:
+            self._record(command_id, "REJECTED", dispatch, t)
+            return CommandDispatchResult(
+                command=command,
+                status="REJECTED",
+                reason=lifecycle_error,
+            )
+
         validation_error = self._validate_args(command, args)
         if validation_error is not None:
             self._record(command_id, "FAILED", dispatch, t)
@@ -88,6 +97,29 @@ class CommandRouter:
             )
         )
         self._state.log(t, f"COMMAND {command_id} -> {status}")
+
+    def _validate_payload_lifecycle_precondition(self, command: Command) -> str | None:
+        if not isinstance(command.preconditions, dict):
+            return None
+
+        lifecycle = command.preconditions.get("payload_lifecycle")
+        if not isinstance(lifecycle, dict):
+            return None
+
+        payload_id = lifecycle.get("payload")
+        expected_state = lifecycle.get("state")
+
+        if not isinstance(payload_id, str) or not isinstance(expected_state, str):
+            return "invalid payload lifecycle precondition"
+
+        actual_state = self._state.payload_lifecycle.get(payload_id)
+        if actual_state != expected_state:
+            return (
+                f"payload {payload_id} lifecycle state is {actual_state}, "
+                f"expected {expected_state}"
+            )
+
+        return None
 
     def _validate_args(self, command: Command, args: dict[str, Any]) -> str | None:
         declared_args = {arg.name: arg for arg in command.arguments}

--- a/src/orbitfabric/sim/runner.py
+++ b/src/orbitfabric/sim/runner.py
@@ -84,6 +84,7 @@ class ScenarioRunner:
             self._apply_command_effects(
                 result=result,
                 t=step.t,
+                state=state,
                 telemetry=telemetry,
                 event_bus=event_bus,
                 mode_manager=mode_manager,
@@ -95,6 +96,7 @@ class ScenarioRunner:
             self._apply_fault_triggers(
                 triggers=fault_monitor.evaluate(),
                 t=step.t,
+                state=state,
                 telemetry=telemetry,
                 event_bus=event_bus,
                 mode_manager=mode_manager,
@@ -114,6 +116,7 @@ class ScenarioRunner:
         self,
         result: CommandDispatchResult,
         t: float,
+        state: SimulationState,
         telemetry: TelemetryRegistry,
         event_bus: EventBus,
         mode_manager: ModeManager,
@@ -130,7 +133,7 @@ class ScenarioRunner:
             event_bus.emit(event_id, t)
 
         expected_effects = command.expected_effects
-        self._apply_payload_lifecycle_effects(result, t)
+        self._apply_payload_lifecycle_effects(expected_effects, state, t)
 
         telemetry_effects = expected_effects.get("telemetry", {})
         for telemetry_id, value in telemetry_effects.items():
@@ -145,13 +148,11 @@ class ScenarioRunner:
 
     def _apply_payload_lifecycle_effects(
         self,
-        result: CommandDispatchResult,
+        expected_effects: dict[str, Any],
+        state: SimulationState,
         t: float,
     ) -> None:
-        if result.command is None:
-            return
-
-        lifecycle_effect = result.command.expected_effects.get("payload_lifecycle")
+        lifecycle_effect = expected_effects.get("payload_lifecycle")
         if not isinstance(lifecycle_effect, dict):
             return
 
@@ -161,26 +162,14 @@ class ScenarioRunner:
         if not isinstance(payload_id, str) or not isinstance(lifecycle_state, str):
             return
 
-        result_state = result.command
-        del result_state
-
-        state = self._get_state_from_result(result)
-        if state is None:
-            return
-
         state.payload_lifecycle[payload_id] = lifecycle_state
         state.log(t, f"PAYLOAD {payload_id} LIFECYCLE={lifecycle_state}")
-
-    def _get_state_from_result(
-        self,
-        result: CommandDispatchResult,
-    ) -> SimulationState | None:
-        return getattr(result, "state", None)
 
     def _apply_fault_triggers(
         self,
         triggers: list[FaultTrigger],
         t: float,
+        state: SimulationState,
         telemetry: TelemetryRegistry,
         event_bus: EventBus,
         mode_manager: ModeManager,
@@ -203,6 +192,7 @@ class ScenarioRunner:
                 self._apply_command_effects(
                     result=result,
                     t=t,
+                    state=state,
                     telemetry=telemetry,
                     event_bus=event_bus,
                     mode_manager=mode_manager,

--- a/src/orbitfabric/sim/runner.py
+++ b/src/orbitfabric/sim/runner.py
@@ -22,6 +22,10 @@ class ScenarioRunner:
             current_time=0,
             current_mode=scenario.initial_state.mode,
             telemetry=dict(scenario.initial_state.telemetry),
+            payload_lifecycle={
+                payload.id: payload.lifecycle.initial_state
+                for payload in mission.payloads
+            },
         )
 
         telemetry = TelemetryRegistry(state)
@@ -31,6 +35,7 @@ class ScenarioRunner:
         fault_monitor = FaultMonitor(mission, telemetry)
 
         mode_manager.initialize(t=0)
+        self._initialize_payload_lifecycle(state)
 
         for step in scenario.steps:
             state.current_time = step.t
@@ -54,6 +59,10 @@ class ScenarioRunner:
             mission_id=mission.spacecraft.id,
             state=state,
         )
+
+    def _initialize_payload_lifecycle(self, state: SimulationState) -> None:
+        for payload_id, lifecycle_state in sorted(state.payload_lifecycle.items()):
+            state.log(0, f"PAYLOAD {payload_id} LIFECYCLE={lifecycle_state}")
 
     def _execute_step(
         self,
@@ -121,6 +130,8 @@ class ScenarioRunner:
             event_bus.emit(event_id, t)
 
         expected_effects = command.expected_effects
+        self._apply_payload_lifecycle_effects(result, t)
+
         telemetry_effects = expected_effects.get("telemetry", {})
         for telemetry_id, value in telemetry_effects.items():
             telemetry.set(telemetry_id, value, t, log=True)
@@ -131,6 +142,40 @@ class ScenarioRunner:
             if target_mode is not None:
                 reason = command.emits[0] if command.emits else command.id
                 mode_manager.transition_to(target_mode, reason, t)
+
+    def _apply_payload_lifecycle_effects(
+        self,
+        result: CommandDispatchResult,
+        t: float,
+    ) -> None:
+        if result.command is None:
+            return
+
+        lifecycle_effect = result.command.expected_effects.get("payload_lifecycle")
+        if not isinstance(lifecycle_effect, dict):
+            return
+
+        payload_id = lifecycle_effect.get("payload")
+        lifecycle_state = lifecycle_effect.get("state")
+
+        if not isinstance(payload_id, str) or not isinstance(lifecycle_state, str):
+            return
+
+        result_state = result.command
+        del result_state
+
+        state = self._get_state_from_result(result)
+        if state is None:
+            return
+
+        state.payload_lifecycle[payload_id] = lifecycle_state
+        state.log(t, f"PAYLOAD {payload_id} LIFECYCLE={lifecycle_state}")
+
+    def _get_state_from_result(
+        self,
+        result: CommandDispatchResult,
+    ) -> SimulationState | None:
+        return getattr(result, "state", None)
 
     def _apply_fault_triggers(
         self,
@@ -213,6 +258,7 @@ class ScenarioRunner:
             self._check_telemetry_expectations(step, telemetry, state)
 
         if step.expect is not None:
+            self._check_payload_lifecycle_expectation(step, state)
             self._check_scenario_status_expectation(step, state)
 
     def _check_telemetry_expectations(
@@ -237,6 +283,35 @@ class ScenarioRunner:
                     step.t,
                     f"TELEMETRY {telemetry_id}={_format_value(actual_value)}",
                 )
+
+    def _check_payload_lifecycle_expectation(
+        self,
+        step: ScenarioStep,
+        state: SimulationState,
+    ) -> None:
+        if step.expect is None:
+            return
+
+        expected_lifecycle = step.expect.get("payload_lifecycle")
+        if not isinstance(expected_lifecycle, dict):
+            return
+
+        payload_id = expected_lifecycle.get("payload")
+        expected_state = expected_lifecycle.get("state")
+
+        if not isinstance(payload_id, str) or not isinstance(expected_state, str):
+            state.fail_expectation(step.t, "invalid payload lifecycle expectation")
+            return
+
+        actual_state = state.payload_lifecycle.get(payload_id)
+        if actual_state != expected_state:
+            state.fail_expectation(
+                step.t,
+                f"expected payload {payload_id} lifecycle {expected_state} "
+                f"but got {actual_state}",
+            )
+        else:
+            state.log(step.t, f"PAYLOAD {payload_id} LIFECYCLE={actual_state}")
 
     def _check_scenario_status_expectation(
         self,

--- a/src/orbitfabric/sim/state.py
+++ b/src/orbitfabric/sim/state.py
@@ -44,6 +44,7 @@ class SimulationState:
     current_time: float
     current_mode: str
     telemetry: dict[str, Any] = field(default_factory=dict)
+    payload_lifecycle: dict[str, str] = field(default_factory=dict)
     logs: list[SimLogEntry] = field(default_factory=list)
     events: list[SimEventRecord] = field(default_factory=list)
     commands: list[SimCommandRecord] = field(default_factory=list)

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -9,6 +9,7 @@ from orbitfabric.model.scenario_loader import ScenarioLoader
 from orbitfabric.sim.runner import ScenarioRunner
 
 DEMO_SCENARIO = Path("examples/demo-3u/scenarios/battery_low_during_payload.yaml")
+PAYLOAD_SCENARIO = Path("examples/demo-3u/scenarios/nominal_payload_acquisition.yaml")
 runner = CliRunner()
 
 
@@ -35,6 +36,30 @@ def test_runner_executes_battery_low_scenario() -> None:
     assert "payload.stop_acquisition" in auto_commands
 
 
+def test_runner_executes_nominal_payload_lifecycle_scenario() -> None:
+    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+
+    result = ScenarioRunner().run(loaded)
+
+    assert result.passed
+    assert result.result_label == "PASSED"
+    assert result.state.current_mode == "NOMINAL"
+    assert result.state.telemetry["payload.acquisition.active"] is False
+    assert result.state.payload_lifecycle["demo_iod_payload"] == "READY"
+
+    emitted_events = {event.event_id for event in result.state.events}
+    assert "payload.acquisition_started" in emitted_events
+    assert "payload.acquisition_stopped" in emitted_events
+
+    ground_commands = {
+        command.command_id
+        for command in result.state.commands
+        if command.dispatch == "GROUND"
+    }
+    assert "payload.start_acquisition" in ground_commands
+    assert "payload.stop_acquisition" in ground_commands
+
+
 def test_sim_cli_executes_demo_scenario() -> None:
     result = runner.invoke(app, ["sim", str(DEMO_SCENARIO)])
 
@@ -44,4 +69,17 @@ def test_sim_cli_executes_demo_scenario() -> None:
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "EVENT eps.battery_low severity=WARNING" in result.output
     assert "COMMAND payload.stop_acquisition -> AUTO_DISPATCHED" in result.output
+    assert "Result: PASSED" in result.output
+
+
+def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
+    result = runner.invoke(app, ["sim", str(PAYLOAD_SCENARIO)])
+
+    assert result.exit_code == 0
+    assert "OrbitFabric Scenario Simulator v0.1" in result.output
+    assert "Scenario: nominal_payload_acquisition" in result.output
+    assert "PAYLOAD demo_iod_payload LIFECYCLE=READY" in result.output
+    assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
+    assert "PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING" in result.output
+    assert "COMMAND payload.stop_acquisition -> ACCEPTED" in result.output
     assert "Result: PASSED" in result.output

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -43,7 +43,7 @@ def test_runner_executes_nominal_payload_lifecycle_scenario() -> None:
 
     assert result.passed
     assert result.result_label == "PASSED"
-    assert result.state.current_mode == "NOMINAL"
+    assert result.state.current_mode == "PAYLOAD_ACTIVE"
     assert result.state.telemetry["payload.acquisition.active"] is False
     assert result.state.payload_lifecycle["demo_iod_payload"] == "READY"
 


### PR DESCRIPTION
## Summary

Adds the first minimal Payload / IOD Payload Contract scenario vertical slice.

This PR keeps the scope deliberately narrow:

- initializes payload lifecycle simulation state from the payload contract model;
- checks `payload_lifecycle` command preconditions;
- applies `payload_lifecycle` expected effects;
- allows scenarios to assert payload lifecycle state through `expect.payload_lifecycle`;
- adds a synthetic nominal payload acquisition scenario;
- adds runner and CLI tests for the new scenario.

## Scenario added

```text
examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
```

Scenario flow:

```text
READY
-> payload.start_acquisition
-> ACQUIRING
-> payload.acquisition_started
-> payload.stop_acquisition
-> READY
-> payload.acquisition_stopped
-> PASSED
```

## Non-goals

- Payload physics simulation
- Acquisition timing model
- Storage budget model
- Power budget model
- Ground contact model
- Downlink model
- Real payload data

## Related issue

Closes #39