### PR TITLE
docs: update roadmap after Payload Contract Model

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # OrbitFabric — Roadmap
 
-Version: 0.1.0.dev0  
+Version: v0.2.2 alignment  
 Status: Development preview  
-Scope: v0.1 to v0.5 planning   
+Scope: v0.2.x to v1.0 planning
 
 ---
 
@@ -14,22 +14,24 @@ The project must not try to become, at the same time:
 
 - a flight software framework;
 - a ground segment;
-- a spacecraft simulator;
+- a spacecraft dynamics simulator;
 - a packet standard implementation;
 - a formal verification tool;
 - a hardware abstraction layer;
-- a CubeSat tutorial.
+- a CubeSat tutorial;
+- a payload runtime framework.
 
 The correct growth path is:
 
 ```text
 Mission Model
-  -> lint
-  -> scenario simulation
-  -> generated documentation
-  -> runtime skeletons
-  -> ground integration artifacts
-  -> plugins and extensibility
+        → lint
+        → scenario simulation
+        → generated documentation
+        → model hardening
+        → runtime skeletons
+        → ground integration artifacts
+        → plugins and extensibility
 ```
 
 Every milestone must reinforce the core identity:
@@ -53,34 +55,37 @@ The priority before v1.0 is:
 
 Backward compatibility matters, but it must not prevent correction of weak early model choices.
 
-The model should become more stable from v0.3 onward.
+The model should become progressively more stable before generated runtime artifacts are introduced.
 
 ---
 
 ## 3. Roadmap Overview
 
 ```text
-v0.1  Mission Contract MVP
-v0.2  Model Hardening
-v0.3  Generated Runtime Skeletons
-v0.4  Ground Integration Artifacts
-v0.5  Plugin and Extensibility Layer
-v1.0  Stable Mission Data Contract
+v0.1    Mission Contract MVP                         completed
+v0.2    Model Hardening                              active line
+v0.2.1  Payload Contract Model                       completed
+v0.2.2  Payload Contract Release Alignment           active
+v0.3    Generated Runtime Skeletons                  future
+v0.4    Ground Integration Artifacts                 future
+v0.5    Plugin and Extensibility Layer               future
+v1.0    Stable Mission Data Contract                 future
 ```
 
-The immediate target is v0.1 only.
+The immediate target is `v0.2.2`.
 
-Everything after v0.1 is directional and must remain subordinate to what is learned from the first working vertical slice.
+The next implementation priority is not runtime generation.  
+The next priority is to align documentation, release notes, roadmap and public communication after the Payload Contract Model vertical slice.
 
 ---
 
-# 4. v0.1 — Mission Contract MVP
+## 4. Completed Baseline — v0.1 Mission Contract MVP
 
-## 4.1 Objective
+### 4.1 Objective
 
 Demonstrate the complete OrbitFabric philosophy with one small, coherent, synthetic mission.
 
-v0.1 must prove that a user can:
+v0.1 proves that a user can:
 
 1. define a mission once;
 2. lint it semantically;
@@ -88,15 +93,11 @@ v0.1 must prove that a user can:
 4. execute an operational scenario;
 5. receive readable logs and JSON reports.
 
-The v0.1 goal is not breadth.
+The v0.1 goal was coherence, not breadth.
 
-The v0.1 goal is coherence.
+### 4.2 Capabilities
 
----
-
-## 4.2 Required Capabilities
-
-v0.1 includes the following implemented capabilities:
+The v0.1 baseline includes:
 
 ```text
 Mission Model YAML
@@ -115,212 +116,9 @@ Simulation plain-text log generation
 Synthetic demo mission demo-3u
 ```
 
----
+### 4.3 Non-Goals
 
-## 4.3 Required CLI Commands
-
-v0.1 currently supports:
-
-```bash
-orbitfabric lint examples/demo-3u/mission/
-
-orbitfabric lint examples/demo-3u/mission/ \
-  --json generated/reports/lint_report.json
-
-orbitfabric gen docs examples/demo-3u/mission/
-
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
-
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
-  --json generated/reports/battery_low_during_payload_report.json \
-  --log generated/logs/battery_low_during_payload.log
-```
-
-`inspect` is not required for v0.1.
-
----
-
-## 4.4 Required Repository Artifacts
-
-```text
-README.md
-LICENSE
-pyproject.toml
-mkdocs.yml
-.github/workflows/ci.yml
-
-docs/PROJECT_CHARTER.md
-docs/CLEAN_ROOM_POLICY.md
-docs/ARCHITECTURE.md
-docs/ROADMAP.md
-docs/reference/mission-model-v0.1.md
-docs/adr/ADR-0001-mission-model-first.md
-docs/adr/ADR-0002-python-toolchain-first.md
-docs/adr/ADR-0003-yaml-multifile-mission-model.md
-docs/adr/ADR-0004-no-flight-runtime-in-v0.1.md
-docs/adr/ADR-0005-lint-as-core-feature.md
-
-examples/demo-3u/mission/*.yaml
-examples/demo-3u/scenarios/battery_low_during_payload.yaml
-
-src/orbitfabric/...
-tests/...
-```
-
----
-
-## 4.5 Required Demo Mission
-
-The canonical demo mission is:
-
-```text
-demo-3u
-```
-
-It must include:
-
-```text
-subsystems:
-  obc
-  eps
-  payload
-  radio
-
-modes:
-  BOOT
-  NOMINAL
-  PAYLOAD_ACTIVE
-  DEGRADED
-  SAFE
-  MAINTENANCE
-
-scenario:
-  battery_low_during_payload
-```
-
-The scenario narrative:
-
-```text
-payload starts acquisition
-battery voltage drops below warning threshold
-fault monitor detects battery warning
-warning event is emitted
-mode transitions to DEGRADED
-payload stop command is auto-dispatched
-scenario passes
-```
-
----
-
-## 4.6 Required Generated Artifacts
-
-v0.1 now generates:
-
-```text
-generated/
-├── docs/
-│   ├── telemetry.md
-│   ├── commands.md
-│   ├── events.md
-│   ├── faults.md
-│   ├── modes.md
-│   └── packets.md
-├── reports/
-│   ├── lint_report.json
-│   └── battery_low_during_payload_report.json
-└── logs/
-    └── battery_low_during_payload.log
-```
-
-Generated docs must be derived from the validated Mission Model.
-
-Generated docs must not be manually edited.
-
----
-
-## 4.7 v0.1 Lint Rule Minimum
-
-The first lint implementation must include at least:
-
-```text
-OF-ID-001 duplicate IDs are not allowed within a domain
-OF-ID-002 IDs must follow canonical format
-OF-REF-001 telemetry source must reference an existing subsystem
-OF-REF-002 command target must reference an existing subsystem
-OF-REF-003 event source must reference an existing subsystem
-OF-REF-004 fault source must reference an existing subsystem
-OF-REF-005 fault condition telemetry must reference known telemetry
-OF-REF-006 command emitted events must reference existing events
-OF-REF-007 fault emitted events must reference existing events
-OF-REF-008 command allowed modes must reference existing modes
-OF-REF-009 recovery mode transitions must reference existing modes
-OF-REF-010 packet telemetry entries must reference existing telemetry
-OF-TLM-001 high-criticality telemetry must define operational limits
-OF-CMD-005 command should define timeout_ms
-OF-CMD-007 risky commands must not be allowed in SAFE mode unless justified
-OF-EVT-002 event should define downlink priority
-OF-FLT-003 fault must emit at least one event
-OF-MODE-001 exactly one initial mode must be defined
-OF-PKT-002 packet must not be empty
-OF-SCN-005 scenario timeline must be monotonic
-```
-
-The complete rule catalog may be documented in v0.1, but the implementation can start with this minimum set.
-
----
-
-## 4.8 v0.1 Tests
-
-Minimum tests:
-
-```text
-load valid demo mission
-fail on missing YAML file
-fail on invalid top-level key
-fail on duplicate telemetry ID
-fail on unknown telemetry source
-fail on command emitted unknown event
-fail on fault references unknown telemetry
-fail on command allowed in unknown mode
-fail on packet references unknown telemetry
-warn on high-criticality telemetry without limits
-warn on command without timeout
-run battery_low_during_payload scenario successfully
-generate Markdown docs without crashing
-produce lint JSON report
-produce scenario JSON report
-```
-
----
-
-## 4.9 v0.1 Done Criteria
-
-v0.1 is functionally close when:
-
-```text
-README explains the project clearly                       done
-clean-room policy exists                                  done
-architecture exists                                       done
-roadmap exists                                            done
-mission model reference exists                            done
-ADRs 0001-0005 exist                                      done
-demo-3u mission exists                                    done
-lint command works                                        done
-lint JSON report works                                    done
-gen docs command works                                    done
-sim command executes the demo scenario                    done
-sim JSON report works                                     done
-sim log output works                                      done
-pytest passes                                             done
-ruff passes                                               done
-no private mission data is present                        required ongoing
-```
-
----
-
-## 4.10 Explicit v0.1 Non-Goals
-
-v0.1 must not include:
+v0.1 intentionally did not include:
 
 ```text
 C++ runtime generation
@@ -343,82 +141,177 @@ message broker
 real spacecraft data
 ```
 
-These are not delayed bugs.
-
-They are intentionally out of scope.
-
----
-
-# 5. v0.2 — Model Hardening
-
-## 5.1 Objective
-
-Make the Mission Model more robust after the first working vertical slice.
-
-v0.2 should improve correctness, diagnostics, test coverage and user experience without expanding into runtime or ground integration too early.
+These are not missing features.  
+They are intentionally outside the first vertical slice.
 
 ---
 
-## 5.2 Candidate Features
+## 5. Completed Slice — v0.2.1 Payload Contract Model
+
+### 5.1 Objective
+
+Introduce a first narrow vertical slice for Payload / IOD Payload Contracts.
+
+The goal is to let OrbitFabric describe mission-specific or IOD payload behavior as part of the Mission Data Contract without turning OrbitFabric into a payload firmware, driver or runtime framework.
+
+### 5.2 Completed Capabilities
+
+v0.2.1 introduced:
 
 ```text
-mission manifest file
-schema versioning improvements
-better unknown-field handling
-better diagnostics with file/line context if practical
-scenario validation command
-more complete command preconditions
-more robust expected_effects model
-better packet size estimation
-rule documentation pages
-lint severity profiles
-warnings-as-errors flag
-improved generated docs
-more invalid mission fixtures
-more scenario examples
+Payload Contract Model ADR
+optional payloads.yaml domain
+PayloadContract model
+minimal payload lifecycle model
+payload profile model
+payload semantic lint rules
+payload reference checks
+generated payload contract documentation
+payload-aware scenario behavior
+invalid payload contract fixtures
+negative tests for mutated fixtures
 ```
 
----
-
-## 5.3 Possible New CLI Commands
-
-```bash
-orbitfabric validate scenario examples/demo-3u/scenarios/battery_low_during_payload.yaml
-orbitfabric inspect examples/demo-3u/mission/
-orbitfabric lint examples/demo-3u/mission/ --warnings-as-errors
-```
-
----
-
-## 5.4 v0.2 Non-Goals
-
-Still out of scope:
+The current payload lifecycle model is intentionally minimal:
 
 ```text
-flight runtime
-hardware support
-CCSDS/PUS/CFDP
-Yamcs/OpenC3 export
-Basilisk integration
+OFF
+READY
+ACQUIRING
+FAULT
 ```
 
-v0.2 should harden the contract before adding external integrations.
+The first demo payload vertical slice demonstrates:
+
+```text
+READY → ACQUIRING → READY
+```
+
+### 5.3 Payload Contract Boundary
+
+A payload contract may describe:
+
+```text
+payload identity
+payload profile
+linked subsystem
+telemetry references
+command references
+event references
+fault references
+lifecycle states
+command preconditions
+expected effects
+scenario-level behavior
+generated documentation
+```
+
+A payload contract must not describe:
+
+```text
+payload firmware
+payload drivers
+hardware buses
+onboard runtime services
+payload data processing pipelines
+physical instrument simulation
+thermal, optical or scientific simulation
+ground segment implementation
+```
+
+The Payload Contract Model strengthens OrbitFabric as a Mission Data Contract Layer.
+
+It does not expand OrbitFabric into a payload runtime.
 
 ---
 
-# 6. v0.3 — Generated Runtime Skeletons
+## 6. Active Milestone — v0.2.2 Payload Contract Release Alignment
 
-## 6.1 Objective
+### 6.1 Objective
 
-Start deriving onboard-oriented artifacts from the Mission Model.
+Capitalise on the completed Payload Contract Model vertical slice.
 
-This is not flight software.
+v0.2.2 is a release-alignment milestone.  
+It must make the repository, public documentation, roadmap, changelog, release notes and public communication consistent with the current state of the project.
 
+### 6.2 Required Work
+
+v0.2.2 should include:
+
+```text
+README alignment
+public documentation alignment
+ROADMAP alignment
+CHANGELOG update
+release/version decision
+release notes preparation
+Payload Contract Model communication draft
+```
+
+### 6.3 Required Boundary
+
+v0.2.2 must not introduce new core model features.
+
+The milestone must not include:
+
+```text
+new payload lifecycle states
+new payload scenario semantics
+second payload example
+runtime skeleton generation
+C++ generator work
+ground integration export
+plugin API
+payload runtime behavior
+physical payload simulation
+```
+
+The purpose of v0.2.2 is alignment, not expansion.
+
+---
+
+## 7. Possible Follow-Up — v0.2.x Additional Model Hardening
+
+After v0.2.2, a small additional v0.2.x milestone may be considered if the model still needs hardening before v0.3.
+
+Possible candidates:
+
+```text
+second clean-room payload example
+improved payload rule documentation
+more invalid payload fixtures
+clearer payload command precondition checks
+improved diagnostics
+expanded scenario validation
+schema/versioning cleanup
+```
+
+A second payload example may be valuable, but only if it proves generality without expanding the core too aggressively.
+
+Candidate examples:
+
+```text
+imaging payload
+radiation monitor
+AIS or IoT receiver
+generic science payload
+technology demonstration payload
+```
+
+Any second example must remain synthetic and clean-room.
+
+---
+
+## 8. Future Milestone — v0.3 Generated Runtime Skeletons
+
+### 8.1 Objective
+
+Start deriving onboard-oriented artifacts from the Mission Data Contract.
+
+This is not flight software.  
 This is generated skeleton code that demonstrates how the Mission Data Contract can support future onboard runtime integration.
 
----
-
-## 6.2 Candidate Features
+### 8.2 Candidate Features
 
 ```text
 C++17 generated headers
@@ -434,9 +327,7 @@ generated telemetry registry skeleton
 host-buildable CMake example
 ```
 
----
-
-## 6.3 Required Boundary
+### 8.3 Required Boundary
 
 v0.3 generated code must be described as:
 
@@ -452,36 +343,10 @@ It must not be described as:
 flight-ready runtime
 qualified software
 complete OBC framework
-replacement for cFS/F Prime
+replacement for cFS or F Prime
 ```
 
----
-
-## 6.4 Candidate CLI Commands
-
-```bash
-orbitfabric gen cpp examples/demo-3u/mission/
-```
-
-Possible output:
-
-```text
-generated/cpp/
-├── include/
-│   └── orbitfabric_demo3u/
-│       ├── telemetry_ids.hpp
-│       ├── command_ids.hpp
-│       ├── event_ids.hpp
-│       ├── mode_ids.hpp
-│       └── adapters.hpp
-├── src/
-│   └── command_dispatch.cpp
-└── CMakeLists.txt
-```
-
----
-
-## 6.5 v0.3 Non-Goals
+### 8.4 v0.3 Non-Goals
 
 Still out of scope:
 
@@ -493,21 +358,23 @@ flight qualification
 complete scheduler
 complete storage subsystem
 complete radio stack
+payload firmware
+payload driver generation
 ```
+
+v0.3 must only start after the Mission Data Contract model is sufficiently stable.
 
 ---
 
-# 7. v0.4 — Ground Integration Artifacts
+## 9. Future Milestone — v0.4 Ground Integration Artifacts
 
-## 7.1 Objective
+### 9.1 Objective
 
 Generate useful artifacts for ground integration without becoming a ground segment.
 
 OrbitFabric should help external tools consume the Mission Data Contract.
 
----
-
-## 7.2 Candidate Features
+### 9.2 Candidate Features
 
 ```text
 JSON mission database export
@@ -518,28 +385,11 @@ command dictionary export
 Yamcs-like export prototype
 OpenC3-like export prototype
 XTCE exploration/prototype
-WebSocket or UDP debug bridge prototype
 ```
 
----
+### 9.3 Required Boundary
 
-## 7.3 Candidate CLI Commands
-
-```bash
-orbitfabric gen mission-db examples/demo-3u/mission/
-orbitfabric gen decoder examples/demo-3u/mission/
-orbitfabric gen yamcs examples/demo-3u/mission/
-orbitfabric gen openc3 examples/demo-3u/mission/
-```
-
-The exact commands must be decided only after v0.1 and v0.2 clarify the internal model.
-
----
-
-## 7.4 Required Boundary
-
-OrbitFabric may export to ground tools.
-
+OrbitFabric may export artifacts for ground tools.  
 OrbitFabric must not become a ground tool.
 
 No v0.4 feature should implement:
@@ -556,17 +406,15 @@ live spacecraft operations stack
 
 ---
 
-# 8. v0.5 — Plugin and Extensibility Layer
+## 10. Future Milestone — v0.5 Plugin and Extensibility Layer
 
-## 8.1 Objective
+### 10.1 Objective
 
-Turn OrbitFabric from a useful tool into a framework.
+Turn OrbitFabric from a useful tool into an extensible framework.
 
 v0.5 should introduce controlled extension points.
 
----
-
-## 8.2 Candidate Features
+### 10.2 Candidate Features
 
 ```text
 custom lint rule plugins
@@ -581,43 +429,26 @@ rule documentation generator
 semantic versioning policy
 ```
 
----
-
-## 8.3 Candidate Plugin Types
-
-```text
-lint-rule plugin
-documentation generator plugin
-runtime generator plugin
-ground export plugin
-model extension plugin
-scenario step plugin
-```
-
----
-
-## 8.4 Required Boundary
+### 10.3 Required Boundary
 
 Plugins must extend OrbitFabric without breaking the core contract.
 
-A plugin may consume or extend the Mission Model.
-
+A plugin may consume or extend the Mission Model.  
 A plugin must not silently redefine core semantics.
 
 ---
 
-# 9. v1.0 — Stable Mission Data Contract
+## 11. Future Milestone — v1.0 Stable Mission Data Contract
 
-## 9.1 Objective
+### 11.1 Objective
 
-v1.0 should be the first version where the Mission Data Contract is considered stable enough for external users to build around.
+v1.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
 
----
-
-## 9.2 Possible v1.0 Requirements
+### 11.2 Possible v1.0 Requirements
 
 ```text
 stable Mission Model schema
+stable Payload Contract Model schema
 stable CLI commands
 stable lint rule code policy
 stable generated documentation format
@@ -631,9 +462,7 @@ CI-tested release artifacts
 clear contribution process
 ```
 
----
-
-## 9.3 v1.0 Should Not Require
+### 11.3 v1.0 Should Not Require
 
 ```text
 flight qualification
@@ -641,15 +470,17 @@ complete CCSDS/PUS stack
 complete Yamcs/OpenC3 compatibility
 complete cFS/F Prime bridge
 real spacecraft deployment
+payload firmware support
+payload hardware support
 ```
 
 v1.0 should mean stable Mission Data Contract framework, not complete space software ecosystem.
 
 ---
 
-## 10. Backlog Parking Lot
+## 12. Backlog Parking Lot
 
-These ideas are valid but must not distract from v0.1.
+These ideas are valid but must not distract from the active milestone.
 
 ```text
 XTCE export
@@ -664,7 +495,6 @@ F Prime topology generator
 cFS table/app generator
 web dashboard
 visual mission model editor
-Obsidian/MkDocs publishing workflow
 SARIF lint export
 VS Code extension
 JSON Schema publication
@@ -681,21 +511,22 @@ ADCS abstract mode examples
 thermal abstract mode examples
 security policy model
 command authorization model
+second payload example
+payload lifecycle expansion
 ```
 
-Parking lot items are not rejected.
-
+Parking lot items are not rejected.  
 They are explicitly deferred.
 
 ---
 
-## 11. Priority Rules
+## 13. Priority Rules
 
 When deciding what to implement next, use these rules.
 
-### Rule 1 — Protect v0.1
+### Rule 1 — Protect the Core Identity
 
-If a feature does not help complete v0.1, defer it.
+If a feature weakens the Mission Data Contract identity, defer it.
 
 ### Rule 2 — Model Before Generator
 
@@ -719,73 +550,52 @@ If an example resembles a private mission, remove or generalize it.
 
 ### Rule 7 — Small Working Slice Beats Broad Incomplete Scope
 
-A working `demo-3u` vertical slice is more valuable than ten half-implemented integrations.
+A working vertical slice is more valuable than multiple half-implemented integrations.
+
+### Rule 8 — Payload Contracts Are Contracts
+
+Payload contracts describe expected mission-data behavior.
+
+They must not become payload firmware, payload drivers, hardware simulation or scientific processing pipelines.
 
 ---
 
-## 12. Immediate Work Plan After This Roadmap
+## 14. Immediate Work Plan
 
-After the foundation documents are complete, the next work package is:
-
-```text
-examples/demo-3u/
-├── mission/
-│   ├── spacecraft.yaml
-│   ├── subsystems.yaml
-│   ├── modes.yaml
-│   ├── telemetry.yaml
-│   ├── commands.yaml
-│   ├── events.yaml
-│   ├── faults.yaml
-│   ├── packets.yaml
-│   └── policies.yaml
-└── scenarios/
-    └── battery_low_during_payload.yaml
-```
-
-Then:
+The immediate work package is:
 
 ```text
-src/orbitfabric/model/
-src/orbitfabric/lint/
-src/orbitfabric/sim/
-src/orbitfabric/gen/
-src/orbitfabric/cli.py
+v0.2.2 — Payload Contract Release Alignment
 ```
 
-The first implementation should follow this order:
+Required sequence:
 
 ```text
-1. repository skeleton
-2. demo-3u YAML files
-3. model loader
-4. lint engine minimum rules
-5. CLI lint command
-6. scenario loader
-7. simulator minimum runtime
-8. CLI sim command
-9. docs generator
-10. CLI gen docs command
-11. tests and CI
+1. README alignment
+2. public documentation alignment
+3. ROADMAP alignment
+4. CHANGELOG update
+5. release/version alignment
+6. public communication draft
 ```
 
-Do not implement the simulator before the demo model exists.
+Do not start v0.3 until v0.2.2 is complete.
 
-Do not implement generators before the loader is stable.
+Do not add runtime skeletons before the model and documentation are coherent.
 
-Do not implement C++ before v0.1 is complete.
+Do not add a second payload example until the current Payload Contract Model has been clearly documented and communicated.
 
 ---
 
-## 13. Final Roadmap Statement
+## 15. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
 > defining, validating, simulating and documenting a Mission Data Contract for a small spacecraft.
 
-Only after that should it grow into runtime generation, ground integration and plugin extensibility.
+The Payload Contract Model strengthens this mission by making mission-specific and IOD payload behavior explicit, lintable, documentable and scenario-aware.
 
-The v0.1 milestone is deliberately narrow.
+Only after the model is clear and stable should OrbitFabric grow into runtime skeleton generation, ground integration artifacts and plugin extensibility.
 
+The narrowness of the roadmap is intentional.  
 That narrowness is a strength, not a limitation.
-


### PR DESCRIPTION
## Summary

Updates the roadmap after the completed `v0.2.1 — Payload Contract Model` milestone.

## Changes

- Marks `v0.2.1 — Payload Contract Model` as completed.
- Introduces `v0.2.2 — Payload Contract Release Alignment` as the active milestone.
- Keeps `v0.3 — Generated Runtime Skeletons` as a future milestone.
- Clarifies that runtime skeleton generation must not start before the model and documentation are coherent.
- Preserves the OrbitFabric principles: Model Before Generator, Lint Before Runtime, Docs from Model.

## Scope

Documentation-only change.

Closes #50