### PR TITLE
docs: update changelog for Payload Contract Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,59 @@
 
 All notable changes to OrbitFabric will be documented in this file.
 
-This project follows a lightweight pre-1.0 changelog style while the Mission Model and CLI stabilize.
+This project follows a lightweight pre-1.0 changelog style while the Mission Model, Payload Contract Model and CLI stabilize.
 
 ---
 
 ## [Unreleased]
+
+### Changed
+
+- Public documentation, roadmap and release alignment work for the Payload Contract Model is ongoing under `v0.2.2 — Payload Contract Release Alignment`.
+
+---
+
+## [v0.2.1] — Payload Contract Model
+
+### Added
+
+- Added the Payload / IOD Payload Contract Model as an optional mission model domain.
+- Added optional `mission/payloads.yaml` loading.
+- Added the `PayloadContract` model.
+- Added payload profile support.
+- Added minimal payload lifecycle support.
+- Added payload contract semantic linting.
+- Added payload lint rules `OF-PAY-001` through `OF-PAY-010`.
+- Added payload reference checks for linked subsystems, telemetry, commands, events and faults.
+- Added generated payload contract documentation.
+- Added generated `payloads.md` documentation output.
+- Added minimal payload-aware scenario behavior.
+- Added nominal payload lifecycle simulation for `READY → ACQUIRING → READY`.
+- Added invalid payload contract fixtures.
+- Added negative tests for mutated payload contract fixtures.
+- Added ADR-0006 for the Payload Contract Model.
+
+### Changed
+
+- Extended the synthetic `demo-3u` mission with a clean-room IOD payload contract.
+- Extended the demo scenario to include payload lifecycle behavior during `battery_low_during_payload`.
+- Reinforced OrbitFabric's positioning as a Mission Data Contract Layer.
+
+### Boundaries
+
+The Payload Contract Model intentionally does not introduce:
+
+- payload firmware;
+- payload drivers;
+- payload runtime execution;
+- physical payload simulation;
+- hardware bus integration;
+- payload data processing pipelines;
+- ground segment implementation.
+
+---
+
+## [Initial development preview]
 
 ### Added
 
@@ -38,9 +86,18 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 ### Current Verified Baseline
 
 ```text
-ruff check .  -> passing
-pytest        -> 34 tests passing
-lint          -> passing
-gen docs      -> passing
-sim           -> passing
+ruff check .
+-> passing
+
+pytest
+-> passing
+
+lint
+-> passing
+
+gen docs
+-> passing
+
+sim
+-> passing
 ```


### PR DESCRIPTION
## Summary

Updates the changelog with the completed `v0.2.1 — Payload Contract Model` milestone.

## Changes

- Adds a dedicated `v0.2.1` changelog entry.
- Mentions optional `payloads.yaml`.
- Mentions `PayloadContract`.
- Mentions payload lifecycle support.
- Mentions lint rules `OF-PAY-001` through `OF-PAY-010`.
- Mentions generated `payloads.md`.
- Mentions minimal payload scenario behavior.
- Mentions invalid payload contract fixtures and tests.
- Keeps release tagging and version bump out of scope.

## Scope

Documentation-only change.

Closes #51