### PR TITLE
release: align version and release notes

### DIFF
--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,88 @@
+# OrbitFabric v0.2.2 — Payload Contract Release Alignment
+
+Status: development preview  
+Release type: model and documentation alignment  
+Primary focus: Payload / IOD Payload Contract Model
+
+## Summary
+
+OrbitFabric v0.2.2 consolidates the Payload / IOD Payload Contract Model introduced during the v0.2.x development line.
+
+This release aligns the repository, public documentation, roadmap, changelog and package version around the new Payload Contract Model.
+
+The main result is that OrbitFabric can now describe optional mission-specific and IOD payload contracts as part of the Mission Data Contract.
+
+## Highlights
+
+- Optional `mission/payloads.yaml` model domain.
+- `PayloadContract` model.
+- Payload profile support.
+- Minimal payload lifecycle model.
+- Payload semantic lint rules.
+- Payload reference checks.
+- Generated payload contract documentation.
+- Generated `payloads.md`.
+- Payload-aware scenario behavior.
+- Minimal lifecycle simulation: `READY → ACQUIRING → READY`.
+- Invalid payload contract fixtures and negative tests.
+- Public Payload Contract Model documentation.
+- Roadmap and changelog alignment.
+
+## What Payload Contracts Describe
+
+Payload contracts may describe:
+
+- payload identity;
+- payload profile;
+- linked subsystem;
+- telemetry references;
+- command references;
+- event references;
+- fault references;
+- lifecycle states;
+- command preconditions;
+- expected effects;
+- scenario-level behavior;
+- generated documentation.
+
+## What Payload Contracts Do Not Describe
+
+Payload contracts do not describe:
+
+- payload firmware;
+- payload drivers;
+- hardware buses;
+- onboard runtime services;
+- payload runtime execution;
+- physical instrument simulation;
+- payload data processing pipelines;
+- ground segment implementation.
+
+## Positioning
+
+OrbitFabric remains a Mission Data Contract framework.
+
+This release does not turn OrbitFabric into:
+
+- a flight software framework;
+- a payload runtime;
+- a payload driver framework;
+- a physical simulator;
+- a ground segment;
+- a CCSDS/PUS/CFDP implementation.
+
+## Compatibility
+
+OrbitFabric is still pre-1.0.
+
+The Mission Model and Payload Contract Model may evolve before v1.0.
+
+## Verification
+
+Expected verification commands:
+
+```text
+ruff check .
+pytest
+mkdocs build --strict
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.2.0.dev0"
+version = "0.2.2"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.2"


### PR DESCRIPTION
## Summary

Aligns package version and release notes after the Payload Contract Model documentation work.

## Changes

- Bumps package version to `0.2.2`.
- Updates `orbitfabric.__version__` to `0.2.2`.
- Adds release notes for `v0.2.2 — Payload Contract Release Alignment`.
- Records the decision to tag the aligned public baseline as `v0.2.2`.

## Scope

Release/documentation alignment only.

No model changes.
No generator work.
No runtime skeletons.

Closes #52