### PR TITLE
docs: introduce Mission Data Chain roadmap

### DIFF
--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,8 +1,8 @@
 # OrbitFabric — Project Charter
 
-Version: 0.1-draft  
+Version: 0.2-draft  
 Status: Draft  
-Scope: MVP foundation  
+Scope: Mission Data Contract foundation and Mission Data Chain direction  
 
 ---
 
@@ -10,9 +10,9 @@ Scope: MVP foundation
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets and operational scenarios once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions and operational scenarios once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
 
-OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial or another ground segment tool.
+OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool or a payload runtime framework.
 
 It is the contract layer between mission design, onboard software, simulation, testing, documentation and ground integration.
 
@@ -37,7 +37,12 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - operational modes;
 - mode transitions;
 - packets;
-- persistence and downlink policies;
+- payload contracts;
+- data products;
+- persistence, storage and retention policies;
+- downlink priorities and contact assumptions;
+- commandability constraints;
+- autonomy and recovery expectations;
 - operational scenarios;
 - validation and linting rules.
 
@@ -59,11 +64,13 @@ The same information is commonly duplicated and reinterpreted across multiple pl
 - simulation setups;
 - operational procedures;
 - fault handling logic;
-- payload-specific integration notes.
+- payload-specific integration notes;
+- storage and downlink planning notes;
+- contact and pass assumptions.
 
 This creates drift.
 
-A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice.
+A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize.
 
 OrbitFabric addresses this by making the mission data model explicit, validated, executable and reusable.
 
@@ -78,7 +85,8 @@ The initial target users are:
 - aerospace students building mission software prototypes;
 - embedded engineers entering the small spacecraft domain;
 - small space startups and technical teams needing disciplined mission-data organization;
-- research labs needing repeatable mission simulations and test scenarios.
+- research labs needing repeatable mission simulations and test scenarios;
+- space software architects who need a coherent contract between payload behavior, onboard data handling and ground-facing artifacts.
 
 The target is not purely educational.
 
@@ -122,7 +130,26 @@ The first valuable artifact is the contract.
 
 Code generation, runtime execution and integration bridges are secondary and must not be designed before the model has sufficient clarity.
 
-### 6.3 Linting as Engineering Judgment
+### 6.3 Mission Data Chain Before Runtime
+
+OrbitFabric must make the mission data chain explicit before generating runtime skeletons.
+
+The project must be able to reason about:
+
+```text
+payload behavior
+        -> data products
+        -> onboard storage and retention
+        -> downlink queue intent
+        -> contact window assumptions
+        -> commandability constraints
+        -> autonomy and recovery expectations
+        -> end-to-end scenario evidence
+```
+
+Only after these concepts are sufficiently clear should OrbitFabric derive runtime skeletons or ground integration artifacts from them.
+
+### 6.4 Linting as Engineering Judgment
 
 OrbitFabric linting must not be limited to YAML syntax validation.
 
@@ -135,11 +162,14 @@ Examples:
 - a fault emitting an unknown event is an error;
 - a packet referencing unknown telemetry is an error;
 - a command without timeout is at least a warning;
-- an event without downlink priority is at least a warning.
+- an event without downlink priority is at least a warning;
+- a payload data product without storage intent is at least a warning;
+- a high-priority data product without downlink policy is at least a warning;
+- a contact profile referenced by downlink policy but missing from the model is an error.
 
 The lint system is a core feature, not a utility.
 
-### 6.4 Scenario-First Testing
+### 6.5 Scenario-First Testing
 
 Operational scenarios must be first-class artifacts.
 
@@ -149,7 +179,9 @@ The simulator must be able to answer a practical engineering question:
 
 > Given this mission model and this scenario, does the system behave as expected?
 
-### 6.5 Ground by Construction
+As the model matures, scenarios should be able to provide evidence not only for mode transitions and command behavior, but also for payload data production, storage intent, downlink assumptions, contact windows and recovery expectations.
+
+### 6.6 Ground by Construction
 
 OrbitFabric must not become a full ground segment.
 
@@ -159,25 +191,27 @@ However, it must generate artifacts useful for ground integration:
 - JSON mission database exports;
 - packet descriptions;
 - decoder skeletons;
+- data product dictionaries;
+- downlink policy descriptions;
 - future Yamcs/OpenC3/XTCE exports.
 
-### 6.6 Clean-Room Development
+### 6.7 Clean-Room Development
 
 OrbitFabric must be developed from scratch using public knowledge, synthetic examples and generic engineering concepts.
 
 It must not contain proprietary mission details, real non-public architectures, private protocols, real bus maps, real pinouts, real logs, real payload data or any information under NDA.
 
-### 6.7 Small Core, Extensible Edges
+### 6.8 Small Core, Extensible Edges
 
 The core must stay small.
 
 Extensibility should come through plugins, generators, custom lint rules and adapters, not through a bloated core.
 
-### 6.8 Practical Before Perfect
+### 6.9 Practical Before Perfect
 
 OrbitFabric must favor useful, testable, well-documented behavior over broad but shallow standard compliance.
 
-CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations are future extensions, not v0.1 requirements.
+CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations are future extensions, not early-version requirements.
 
 ---
 
@@ -215,9 +249,68 @@ orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 
 ---
 
-## 8. MVP v0.1 Non-Goals
+## 8. Payload Contract Direction
 
-v0.1 must not include:
+The Payload / IOD Payload Contract Model makes mission-specific payload behavior explicit without turning OrbitFabric into a payload runtime framework.
+
+A payload contract may describe:
+
+- payload identity;
+- payload profile;
+- linked subsystem;
+- lifecycle states;
+- telemetry references;
+- command references;
+- event references;
+- fault references;
+- command preconditions;
+- expected effects;
+- scenario-level behavior;
+- generated documentation.
+
+A payload contract must not describe:
+
+- payload firmware;
+- payload drivers;
+- hardware buses;
+- physical payload simulation;
+- scientific data processing pipelines;
+- real payload acquisition implementation.
+
+Payload contracts are part of the Mission Data Contract.
+
+They are the foundation for later data product, storage and downlink modeling.
+
+---
+
+## 9. Mission Data Chain Direction
+
+After the Payload Contract Model, OrbitFabric should evolve toward explicit Mission Data Chain modeling.
+
+The chain is:
+
+```text
+Payload or subsystem activity
+        -> generated telemetry and data products
+        -> onboard storage and retention intent
+        -> downlink queue and priority intent
+        -> contact window assumptions
+        -> commandability and autonomy constraints
+        -> end-to-end scenario evidence
+        -> future runtime and ground artifacts
+```
+
+This direction is essential for small spacecraft and CubeSat missions because the value of mission data depends on the full path from onboard generation to ground consumption.
+
+OrbitFabric must model the contract of that path.
+
+It must not implement the physical, flight or operational stack behind that path.
+
+---
+
+## 10. Early Non-Goals
+
+Early OrbitFabric versions must not include:
 
 - real spacecraft hardware support;
 - real SPI/I2C/UART drivers;
@@ -233,19 +326,23 @@ v0.1 must not include:
 - CANopen integration;
 - cFS integration;
 - F Prime integration;
-- Yamcs integration;
-- OpenC3 integration;
-- Basilisk integration;
+- Yamcs integration as a live service;
+- OpenC3 integration as a live service;
+- Basilisk integration as a dynamics simulator;
 - formal verification;
 - advanced security;
 - real mission operations procedures;
-- proprietary mission examples.
+- proprietary mission examples;
+- payload firmware support;
+- payload driver support;
+- physical payload simulation;
+- live ground operations.
 
-These items may become future work only after the Mission Model, lint engine and scenario runner prove valuable.
+These items may become future integration targets, generated artifacts or external consumers only after the Mission Model, lint engine, scenario runner and mission data chain contracts prove valuable.
 
 ---
 
-## 9. Demo Mission
+## 11. Demo Mission
 
 The initial demo mission is `demo-3u`.
 
@@ -286,11 +383,15 @@ The expected scenario narrative is:
 [00:40] SCENARIO PASSED
 ```
 
+Future demo slices may extend this clean-room mission with synthetic data products, storage policies, downlink assumptions and contact windows.
+
+Those additions must remain generic and must not encode private mission details.
+
 ---
 
-## 10. Initial Technical Direction
+## 12. Initial Technical Direction
 
-The recommended technical baseline for v0.1 is:
+The recommended technical baseline is:
 
 - Python 3.11 or newer;
 - YAML for the Mission Model;
@@ -303,11 +404,11 @@ The recommended technical baseline for v0.1 is:
 - GitHub Actions for CI;
 - Apache-2.0 license.
 
-The future onboard runtime may use C++17, but C++ generation is explicitly out of scope for v0.1.
+The future onboard runtime may use C++17, but C++ generation must wait until the Mission Data Contract and Mission Data Chain models are sufficiently clear.
 
 ---
 
-## 11. Repository Philosophy
+## 13. Repository Philosophy
 
 OrbitFabric should use a monorepo at the beginning.
 
@@ -339,9 +440,9 @@ Splitting into multiple repositories too early would add complexity without arch
 
 ---
 
-## 12. Success Criteria for v0.1
+## 14. Success Criteria for the Early Public Preview
 
-OrbitFabric v0.1 is successful if a user can:
+OrbitFabric is successful in the early public preview if a user can:
 
 1. inspect the `demo-3u` Mission Model;
 2. run mission linting;
@@ -350,13 +451,15 @@ OrbitFabric v0.1 is successful if a user can:
 5. see events, faults, mode transitions and auto-dispatched commands in the log;
 6. generate Markdown documentation from the same Mission Model;
 7. understand the project positioning from the README in less than one minute;
-8. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals.
+8. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
+9. understand how payload contracts fit into the Mission Data Contract;
+10. understand why data products, storage, downlink and contact assumptions belong in the roadmap before runtime skeletons.
 
-A minimal but strong v0.1 is better than a broad, fragile and unfinished v0.1.
+A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 
 ---
 
-## 13. Clean-Room Policy Summary
+## 15. Clean-Room Policy Summary
 
 OrbitFabric must not use or encode non-public mission information.
 
@@ -384,15 +487,17 @@ Allowed content includes:
 - invented telemetry;
 - invented commands;
 - invented scenarios;
+- invented data products;
+- invented contact windows;
 - clean-room code written from scratch.
 
 If a design choice risks being too close to a private mission, it must be generalized or removed.
 
 ---
 
-## 14. Governance Principles
+## 16. Governance Principles
 
-Until the project reaches a usable v0.1, technical decisions should optimize for clarity, minimalism and architectural coherence.
+Technical decisions should optimize for clarity, minimalism and architectural coherence.
 
 The project should prefer:
 
@@ -402,7 +507,8 @@ The project should prefer:
 - deterministic simulation over realism;
 - semantic lint rules over superficial validation;
 - generated documentation over manually duplicated references;
-- clean interfaces over premature integrations.
+- clean interfaces over premature integrations;
+- mission data chain modeling before runtime skeleton generation.
 
 The project should reject:
 
@@ -411,43 +517,24 @@ The project should reject:
 - hardware-specific shortcuts;
 - hidden behavior not represented in the Mission Model;
 - undocumented assumptions;
-- private mission-derived examples.
+- private mission-derived examples;
+- runtime generation from an immature model;
+- ground integration exports before the contract they export is clear.
 
 ---
 
-## 15. Immediate Next Artifacts
+## 17. Final Position
 
-After this Project Charter, the next required artifacts are:
-
-```text
-docs/CLEAN_ROOM_POLICY.md
-docs/ROADMAP.md
-docs/ARCHITECTURE.md
-docs/adr/ADR-0001-mission-model-first.md
-docs/adr/ADR-0002-python-toolchain-first.md
-docs/adr/ADR-0003-yaml-multifile-mission-model.md
-docs/adr/ADR-0004-no-flight-runtime-in-v0.1.md
-docs/adr/ADR-0005-lint-as-core-feature.md
-docs/reference/mission-model-v0.1.md
-```
-
-The next highest-priority artifact is:
-
-```text
-docs/adr/ADR-0001-mission-model-first.md
-```
-
----
-
-## 16. Final Position
-
-OrbitFabric must begin as a disciplined Mission Data Contract framework.
+OrbitFabric must remain a disciplined Mission Data Contract framework.
 
 The project should not try to look large. It should try to be coherent.
 
-The first version must prove one thing convincingly:
+The first versions must prove one thing convincingly:
 
 > A small spacecraft mission can be described once, validated semantically, simulated operationally, tested through scenarios and documented automatically from a single source of truth.
 
-That is the core of OrbitFabric.
+The next versions must extend that proof to the mission data chain:
 
+> Payload behavior, data products, onboard storage intent, downlink priorities, contact assumptions, commandability constraints and recovery expectations can be modeled before real onboard or ground software is implemented.
+
+That is the core of OrbitFabric.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric — Roadmap
 
-Version: v0.2.2 alignment  
+Version: v0.2.3 planning  
 Status: Development preview  
 Scope: v0.2.x to v1.0 planning
 
@@ -25,18 +25,21 @@ The correct growth path is:
 
 ```text
 Mission Model
-        → lint
-        → scenario simulation
-        → generated documentation
-        → model hardening
-        → runtime skeletons
-        → ground integration artifacts
-        → plugins and extensibility
+        -> lint
+        -> scenario simulation
+        -> generated documentation
+        -> payload contracts
+        -> mission data chain contracts
+        -> runtime skeletons
+        -> ground integration artifacts
+        -> plugins and extensibility
 ```
 
 Every milestone must reinforce the core identity:
 
 > OrbitFabric is a Mission Data Contract framework.
+
+The next major architectural objective is to model the mission data chain from payload behavior to onboard storage, downlink assumptions, contact windows, commandability, recovery behavior and ground-facing artifacts.
 
 ---
 
@@ -62,20 +65,26 @@ The model should become progressively more stable before generated runtime artif
 ## 3. Roadmap Overview
 
 ```text
-v0.1    Mission Contract MVP                         completed
-v0.2    Model Hardening                              active line
-v0.2.1  Payload Contract Model                       completed
-v0.2.2  Payload Contract Release Alignment           active
-v0.3    Generated Runtime Skeletons                  future
-v0.4    Ground Integration Artifacts                 future
-v0.5    Plugin and Extensibility Layer               future
-v1.0    Stable Mission Data Contract                 future
+v0.1    Mission Contract MVP                                  completed
+v0.2    Model Hardening                                       completed line
+v0.2.1  Payload Contract Model                                completed
+v0.2.2  Payload Contract Release Alignment                    completed
+v0.2.3  Mission Data Chain Roadmap Alignment                  immediate
+v0.3    Data Product and Storage Contracts                    future
+v0.4    Contact Windows and Downlink Flow Contracts           future
+v0.5    Commandability and Autonomy Contracts                 future
+v0.6    End-to-End Mission Data Flow Evidence                 future
+v0.7    Generated Runtime Skeletons                           future
+v0.8    Ground Integration Artifacts                          future
+v0.9    Plugin and Extensibility Layer                        future
+v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target is `v0.2.2`.
+The immediate target is `v0.2.3`.
 
-The next implementation priority is not runtime generation.  
-The next priority is to align documentation, release notes, roadmap and public communication after the Payload Contract Model vertical slice.
+The next implementation priority is not runtime generation.
+
+The next priority is to formalize the Mission Data Chain roadmap after the Payload Contract Model vertical slice.
 
 ---
 
@@ -141,7 +150,7 @@ message broker
 real spacecraft data
 ```
 
-These are not missing features.  
+These are not missing features.
 They are intentionally outside the first vertical slice.
 
 ---
@@ -184,7 +193,7 @@ FAULT
 The first demo payload vertical slice demonstrates:
 
 ```text
-READY → ACQUIRING → READY
+READY -> ACQUIRING -> READY
 ```
 
 ### 5.3 Payload Contract Boundary
@@ -225,34 +234,33 @@ It does not expand OrbitFabric into a payload runtime.
 
 ---
 
-## 6. Active Milestone — v0.2.2 Payload Contract Release Alignment
+## 6. Completed Alignment — v0.2.2 Payload Contract Release Alignment
 
 ### 6.1 Objective
 
 Capitalise on the completed Payload Contract Model vertical slice.
 
-v0.2.2 is a release-alignment milestone.  
-It must make the repository, public documentation, roadmap, changelog, release notes and public communication consistent with the current state of the project.
+v0.2.2 is a release-alignment milestone.
+It makes the repository, public documentation, roadmap, changelog, release notes and public communication consistent with the Payload Contract Model.
 
-### 6.2 Required Work
+### 6.2 Completed Work
 
-v0.2.2 should include:
+v0.2.2 aligned:
 
 ```text
-README alignment
-public documentation alignment
-ROADMAP alignment
-CHANGELOG update
-release/version decision
-release notes preparation
-Payload Contract Model communication draft
+README
+public documentation
+ROADMAP
+CHANGELOG
+release/version story
+Payload Contract Model communication
 ```
 
-### 6.3 Required Boundary
+### 6.3 Boundary
 
-v0.2.2 must not introduce new core model features.
+v0.2.2 did not introduce new core model features.
 
-The milestone must not include:
+It did not include:
 
 ```text
 new payload lifecycle states
@@ -266,52 +274,257 @@ payload runtime behavior
 physical payload simulation
 ```
 
-The purpose of v0.2.2 is alignment, not expansion.
+The purpose of v0.2.2 was alignment, not expansion.
 
 ---
 
-## 7. Possible Follow-Up — v0.2.x Additional Model Hardening
+## 7. Immediate Milestone — v0.2.3 Mission Data Chain Roadmap Alignment
 
-After v0.2.2, a small additional v0.2.x milestone may be considered if the model still needs hardening before v0.3.
+### 7.1 Objective
 
-Possible candidates:
+Formalize the next architectural direction after the Payload Contract Model.
 
-```text
-second clean-room payload example
-improved payload rule documentation
-more invalid payload fixtures
-clearer payload command precondition checks
-improved diagnostics
-expanded scenario validation
-schema/versioning cleanup
-```
+OrbitFabric should not jump directly from payload contracts to generated runtime skeletons.
 
-A second payload example may be valuable, but only if it proves generality without expanding the core too aggressively.
-
-Candidate examples:
+The model must first express the mission data chain:
 
 ```text
-imaging payload
-radiation monitor
-AIS or IoT receiver
-generic science payload
-technology demonstration payload
+Payload behavior
+        -> data products
+        -> onboard storage and retention
+        -> downlink queue intent
+        -> contact window assumptions
+        -> commandability constraints
+        -> autonomy and recovery expectations
+        -> end-to-end scenario evidence
+        -> future runtime and ground artifacts
 ```
 
-Any second example must remain synthetic and clean-room.
+### 7.2 Required Work
+
+v0.2.3 should include:
+
+```text
+ROADMAP update
+Project Charter alignment
+ADR for Mission Data Chain before runtime generation
+public documentation navigation update
+issue backlog alignment if needed
+```
+
+### 7.3 Required Boundary
+
+v0.2.3 must remain documentation-first and architecture-first.
+
+It must not introduce:
+
+```text
+data_products.yaml
+contacts.yaml
+storage simulator behavior
+downlink simulator behavior
+new scenario semantics
+runtime skeleton generation
+ground export
+plugin API
+```
+
+The milestone exists to make the next implementation sequence explicit before adding new model domains.
 
 ---
 
-## 8. Future Milestone — v0.3 Generated Runtime Skeletons
+## 8. Future Milestone — v0.3 Data Product and Storage Contracts
 
 ### 8.1 Objective
 
-Start deriving onboard-oriented artifacts from the Mission Data Contract.
+Introduce data products as first-class mission data artifacts.
 
-This is not flight software.  
-This is generated skeleton code that demonstrates how the Mission Data Contract can support future onboard runtime integration.
+A telemetry item describes state or measurement.
+A packet describes transport grouping.
+A data product describes an object produced by the mission or payload.
+
+Examples:
+
+```text
+image frame
+radiation histogram
+science sample batch
+AIS capture window
+IoT receiver burst
+diagnostic dump
+compressed payload product
+```
 
 ### 8.2 Candidate Features
+
+```text
+optional data_products.yaml domain
+DataProductContract model
+data product producer reference
+optional payload reference
+data product type
+estimated size
+priority
+storage class
+retention policy
+overflow policy
+downlink intent
+generated data product documentation
+data product lint rules
+invalid data product fixtures
+```
+
+### 8.3 Candidate Lint Rules
+
+```text
+ERROR: data product references unknown producer.
+ERROR: data product references unknown payload.
+ERROR: data product has no estimated size.
+WARNING: high-priority data product has no downlink policy.
+WARNING: retained data product has no overflow policy.
+```
+
+### 8.4 Boundary
+
+v0.3 must not implement real storage, file systems, compression, payload processing pipelines or downlink runtime behavior.
+
+It must only describe the contract.
+
+---
+
+## 9. Future Milestone — v0.4 Contact Windows and Downlink Flow Contracts
+
+### 9.1 Objective
+
+Model ground contact and downlink assumptions without becoming a ground segment or an orbital dynamics simulator.
+
+OrbitFabric should let a mission designer ask:
+
+> Given the declared data products, priorities, storage policies and contact assumptions, is the data flow coherent?
+
+### 9.2 Candidate Features
+
+```text
+contact window model
+contact profile model
+link profile model
+estimated downlink budget
+abstract downlink queue policy
+data product downlink eligibility
+scenario contact events
+generated downlink documentation
+downlink consistency lint rules
+```
+
+### 9.3 Candidate Lint Rules
+
+```text
+WARNING: produced data volume may exceed nominal contact budget.
+ERROR: downlink policy references unknown contact profile.
+WARNING: critical event has no immediate downlink class.
+WARNING: high-priority product is retained but never scheduled for downlink.
+```
+
+### 9.4 Boundary
+
+v0.4 must not implement orbit propagation, antenna pointing, RF budgets, live ground links, Yamcs/OpenC3 services or real spacecraft operations.
+
+Contact windows are contract assumptions, not physical simulation.
+
+---
+
+## 10. Future Milestone — v0.5 Commandability and Autonomy Contracts
+
+### 10.1 Objective
+
+Make command use and autonomous behavior explicit in the Mission Data Contract.
+
+Commands should not only exist.
+
+The model should express when they can be used, who or what may dispatch them, what they require and what evidence they should produce.
+
+### 10.2 Candidate Features
+
+```text
+command source model: ground, onboard, autonomous
+requires_contact flag
+allowed modes refinement
+abstract operator confirmation hint
+expected events
+expected telemetry effects
+timeout expectations
+recovery command references
+command inhibition rules
+autonomy rule documentation
+```
+
+### 10.3 Candidate Lint Rules
+
+```text
+ERROR: autonomous command has no expected effect.
+WARNING: ground-only command is used in autonomous recovery scenario.
+ERROR: command requires contact but scenario dispatches it outside contact.
+WARNING: risky command lacks operator confirmation hint.
+```
+
+### 10.4 Boundary
+
+v0.5 must not implement real command authentication, authorization, encryption, live uplink, operator consoles or flight-ready autonomy.
+
+It defines commandability and autonomy contracts only.
+
+---
+
+## 11. Future Milestone — v0.6 End-to-End Mission Data Flow Evidence
+
+### 11.1 Objective
+
+Combine payload contracts, data products, storage intent, downlink assumptions, contact windows, commandability and recovery expectations into end-to-end scenario evidence.
+
+The user should be able to inspect a data chain such as:
+
+```text
+payload acquisition
+        -> data product generated
+        -> stored onboard
+        -> queued for downlink
+        -> contact window available
+        -> product downlinked, partially downlinked, retained or dropped
+        -> ground-facing artifact prepared
+        -> scenario evidence generated
+```
+
+### 11.2 Candidate Features
+
+```text
+mission data flow graph
+scenario assertions on data product state
+scenario assertions on storage state
+scenario assertions on downlink state
+generated mission data flow documentation
+JSON data-flow evidence report
+scenario coverage for data products
+end-to-end demo scenario
+```
+
+### 11.3 Boundary
+
+v0.6 must remain deterministic and contract-level.
+
+It must not become real onboard storage software, a ground segment, a live simulator or an operations console.
+
+---
+
+## 12. Future Milestone — v0.7 Generated Runtime Skeletons
+
+### 12.1 Objective
+
+Start deriving onboard-oriented artifacts from the Mission Data Contract after the mission data chain model is sufficiently clear.
+
+This is not flight software.
+This is generated skeleton code that demonstrates how the Mission Data Contract can support future onboard runtime integration.
+
+### 12.2 Candidate Features
 
 ```text
 C++17 generated headers
@@ -320,16 +533,21 @@ generated command IDs
 generated event IDs
 generated mode IDs
 generated packet IDs
+generated payload IDs
+generated data product IDs
+generated storage policy enums
+generated downlink policy enums
 generated command argument structs
 generated adapter interfaces
 generated command dispatch skeleton
 generated telemetry registry skeleton
+generated data product registry skeleton
 host-buildable CMake example
 ```
 
-### 8.3 Required Boundary
+### 12.3 Required Boundary
 
-v0.3 generated code must be described as:
+v0.7 generated code must be described as:
 
 ```text
 runtime skeleton
@@ -346,35 +564,17 @@ complete OBC framework
 replacement for cFS or F Prime
 ```
 
-### 8.4 v0.3 Non-Goals
-
-Still out of scope:
-
-```text
-real hardware support
-RTOS-specific runtime
-Linux service integration
-flight qualification
-complete scheduler
-complete storage subsystem
-complete radio stack
-payload firmware
-payload driver generation
-```
-
-v0.3 must only start after the Mission Data Contract model is sufficiently stable.
-
 ---
 
-## 9. Future Milestone — v0.4 Ground Integration Artifacts
+## 13. Future Milestone — v0.8 Ground Integration Artifacts
 
-### 9.1 Objective
+### 13.1 Objective
 
 Generate useful artifacts for ground integration without becoming a ground segment.
 
 OrbitFabric should help external tools consume the Mission Data Contract.
 
-### 9.2 Candidate Features
+### 13.2 Candidate Features
 
 ```text
 JSON mission database export
@@ -382,17 +582,19 @@ packet dictionary export
 simple decoder skeletons
 telemetry dictionary export
 command dictionary export
+data product dictionary export
+downlink policy export
 Yamcs-like export prototype
 OpenC3-like export prototype
 XTCE exploration/prototype
 ```
 
-### 9.3 Required Boundary
+### 13.3 Required Boundary
 
-OrbitFabric may export artifacts for ground tools.  
+OrbitFabric may export artifacts for ground tools.
 OrbitFabric must not become a ground tool.
 
-No v0.4 feature should implement:
+No v0.8 feature should implement:
 
 ```text
 complete mission control UI
@@ -406,19 +608,22 @@ live spacecraft operations stack
 
 ---
 
-## 10. Future Milestone — v0.5 Plugin and Extensibility Layer
+## 14. Future Milestone — v0.9 Plugin and Extensibility Layer
 
-### 10.1 Objective
+### 14.1 Objective
 
 Turn OrbitFabric from a useful tool into an extensible framework.
 
-v0.5 should introduce controlled extension points.
+v0.9 should introduce controlled extension points after the core mission data chain has matured.
 
-### 10.2 Candidate Features
+### 14.2 Candidate Features
 
 ```text
 custom lint rule plugins
 custom generator plugins
+custom data product validators
+custom ground exporters
+custom scenario step plugins
 mission model extension mechanism
 adapter SDK
 plugin discovery
@@ -429,26 +634,29 @@ rule documentation generator
 semantic versioning policy
 ```
 
-### 10.3 Required Boundary
+### 14.3 Required Boundary
 
 Plugins must extend OrbitFabric without breaking the core contract.
 
-A plugin may consume or extend the Mission Model.  
+A plugin may consume or extend the Mission Model.
 A plugin must not silently redefine core semantics.
 
 ---
 
-## 11. Future Milestone — v1.0 Stable Mission Data Contract
+## 15. Future Milestone — v1.0 Stable Mission Data Contract
 
-### 11.1 Objective
+### 15.1 Objective
 
 v1.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
 
-### 11.2 Possible v1.0 Requirements
+### 15.2 Possible v1.0 Requirements
 
 ```text
 stable Mission Model schema
 stable Payload Contract Model schema
+stable Data Product Contract schema
+stable Contact/Downlink Contract schema
+stable Commandability Contract schema
 stable CLI commands
 stable lint rule code policy
 stable generated documentation format
@@ -462,7 +670,7 @@ CI-tested release artifacts
 clear contribution process
 ```
 
-### 11.3 v1.0 Should Not Require
+### 15.3 v1.0 Should Not Require
 
 ```text
 flight qualification
@@ -478,7 +686,7 @@ v1.0 should mean stable Mission Data Contract framework, not complete space soft
 
 ---
 
-## 12. Backlog Parking Lot
+## 16. Backlog Parking Lot
 
 These ideas are valid but must not distract from the active milestone.
 
@@ -515,12 +723,12 @@ second payload example
 payload lifecycle expansion
 ```
 
-Parking lot items are not rejected.  
+Parking lot items are not rejected.
 They are explicitly deferred.
 
 ---
 
-## 13. Priority Rules
+## 17. Priority Rules
 
 When deciding what to implement next, use these rules.
 
@@ -532,62 +740,71 @@ If a feature weakens the Mission Data Contract identity, defer it.
 
 If the model cannot express a concept cleanly, do not generate code for it.
 
-### Rule 3 — Lint Before Runtime
+### Rule 3 — Chain Before Runtime
+
+If the mission data chain is not explicit, do not generate runtime skeletons from it.
+
+### Rule 4 — Lint Before Runtime
 
 If a behavior can be inconsistent, create a lint rule before creating downstream generators.
 
-### Rule 4 — Docs from Model
+### Rule 5 — Docs from Model
 
 If information exists in the model, generated docs should expose it.
 
-### Rule 5 — No Hidden Semantics
+### Rule 6 — No Hidden Semantics
 
 If behavior matters, it must not live only in Python code.
 
-### Rule 6 — No Private Examples
+### Rule 7 — No Private Examples
 
 If an example resembles a private mission, remove or generalize it.
 
-### Rule 7 — Small Working Slice Beats Broad Incomplete Scope
+### Rule 8 — Small Working Slice Beats Broad Incomplete Scope
 
 A working vertical slice is more valuable than multiple half-implemented integrations.
 
-### Rule 8 — Payload Contracts Are Contracts
+### Rule 9 — Payload Contracts Are Contracts
 
 Payload contracts describe expected mission-data behavior.
 
 They must not become payload firmware, payload drivers, hardware simulation or scientific processing pipelines.
 
+### Rule 10 — Ground Assumptions Are Contracts
+
+Contact windows, downlink budgets and ground-facing artifacts are model assumptions and derived outputs.
+
+They must not become a live ground segment inside OrbitFabric.
+
 ---
 
-## 14. Immediate Work Plan
+## 18. Immediate Work Plan
 
 The immediate work package is:
 
 ```text
-v0.2.2 — Payload Contract Release Alignment
+v0.2.3 — Mission Data Chain Roadmap Alignment
 ```
 
 Required sequence:
 
 ```text
-1. README alignment
-2. public documentation alignment
-3. ROADMAP alignment
-4. CHANGELOG update
-5. release/version alignment
-6. public communication draft
+1. ROADMAP alignment
+2. Project Charter alignment
+3. Mission Data Chain ADR
+4. public documentation navigation update
+5. issue backlog alignment if needed
 ```
 
-Do not start v0.3 until v0.2.2 is complete.
+Do not start v0.3 implementation until v0.2.3 is complete.
 
-Do not add runtime skeletons before the model and documentation are coherent.
+Do not add runtime skeletons before the mission data chain model is coherent.
 
-Do not add a second payload example until the current Payload Contract Model has been clearly documented and communicated.
+Do not add ground exports before contact, downlink and data product contracts exist.
 
 ---
 
-## 15. Final Roadmap Statement
+## 19. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
@@ -595,7 +812,9 @@ OrbitFabric must first become excellent at one thing:
 
 The Payload Contract Model strengthens this mission by making mission-specific and IOD payload behavior explicit, lintable, documentable and scenario-aware.
 
+The Mission Data Chain roadmap extends that foundation by making payload data products, storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations and end-to-end scenario evidence explicit before runtime or ground artifacts are generated.
+
 Only after the model is clear and stable should OrbitFabric grow into runtime skeleton generation, ground integration artifacts and plugin extensibility.
 
-The narrowness of the roadmap is intentional.  
+The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/adr/ADR-0007-mission-data-chain-before-runtime.md
+++ b/docs/adr/ADR-0007-mission-data-chain-before-runtime.md
@@ -1,0 +1,240 @@
+# ADR-0007 — Mission Data Chain Before Runtime Generation
+
+Status: Proposed  
+Date: 2026-05-01
+
+---
+
+## Context
+
+OrbitFabric is a model-first Mission Data Contract framework for small spacecraft.
+
+The project already demonstrates a coherent early vertical slice:
+
+```text
+Mission Model
+        -> structural validation
+        -> semantic lint
+        -> generated documentation
+        -> scenario validation
+        -> deterministic scenario execution
+        -> JSON reports and logs
+```
+
+The Payload / IOD Payload Contract Model extends this foundation by making mission-specific payload behavior explicit, lintable, documentable and scenario-aware.
+
+The next obvious technical temptation is generated runtime skeletons.
+
+That would be premature.
+
+A small spacecraft mission data contract is not only a set of telemetry, commands, events, faults, modes and packets.
+
+For the onboard-to-ground chain to be architecturally meaningful, the model must also express how mission data is produced, preserved, prioritized, made available for downlink and consumed by future ground-facing artifacts.
+
+Without that layer, generated runtime skeletons would be derived from an incomplete contract.
+
+---
+
+## Decision
+
+OrbitFabric will introduce Mission Data Chain modeling before generated runtime skeletons.
+
+The roadmap will therefore place these model-first milestones before runtime generation:
+
+```text
+Data Product and Storage Contracts
+Contact Windows and Downlink Flow Contracts
+Commandability and Autonomy Contracts
+End-to-End Mission Data Flow Evidence
+```
+
+Generated runtime skeletons will be deferred until after these concepts are clear enough to be represented in the Mission Data Contract.
+
+The intended chain is:
+
+```text
+Payload or subsystem activity
+        -> generated telemetry and data products
+        -> onboard storage and retention intent
+        -> downlink queue and priority intent
+        -> contact window assumptions
+        -> commandability and autonomy constraints
+        -> end-to-end scenario evidence
+        -> future runtime and ground artifacts
+```
+
+This decision reinforces the existing OrbitFabric principles:
+
+```text
+model before generator
+lint before runtime
+docs from model
+no hidden semantics
+small working slice before broad scope
+```
+
+---
+
+## Rationale
+
+Generated code is only useful if the model behind it is strong.
+
+If OrbitFabric generated runtime skeletons before modeling data products, storage intent, contact assumptions and downlink priorities, the generated artifacts would reflect an incomplete view of the mission.
+
+For CubeSat and small spacecraft missions, the value of a payload is not limited to command acceptance or telemetry generation.
+
+The relevant engineering questions are broader:
+
+- What data products are produced?
+- Which payload or subsystem produces them?
+- How large are they expected to be?
+- How long should they be retained onboard?
+- What happens when storage is full?
+- Which products are prioritized for downlink?
+- What contact assumptions are used?
+- Which commands require ground contact?
+- Which commands may be dispatched autonomously?
+- What recovery behavior is expected after faults?
+- Which scenarios prove the expected end-to-end behavior?
+
+These are Mission Data Contract questions.
+
+They are not flight runtime implementation details.
+
+---
+
+## Scope
+
+Mission Data Chain modeling may introduce contract-level descriptions for:
+
+```text
+data products
+product producers
+estimated product size
+product priority
+storage class
+retention policy
+overflow policy
+downlink intent
+downlink queue assumptions
+contact windows
+contact profiles
+link profiles
+command source constraints
+requires-contact constraints
+expected command effects
+timeout expectations
+recovery command references
+autonomy expectations
+scenario evidence for data flow
+```
+
+These concepts must remain declarative, synthetic and clean-room.
+
+---
+
+## Non-Goals
+
+This decision does not authorize OrbitFabric to implement:
+
+```text
+real onboard storage software
+file systems
+compression engines
+payload processing pipelines
+RF link simulation
+orbit propagation
+antenna pointing
+live downlink services
+live command uplink services
+operator consoles
+Yamcs or OpenC3 as embedded services
+flight-ready autonomy
+real command authentication or authorization
+qualified flight runtime
+```
+
+Those are outside the core scope.
+
+They may become future integration targets, generated artifacts or plugin outputs only after the contract is clear.
+
+---
+
+## Consequences
+
+The roadmap changes from:
+
+```text
+Payload Contracts
+        -> Generated Runtime Skeletons
+        -> Ground Integration Artifacts
+```
+
+to:
+
+```text
+Payload Contracts
+        -> Mission Data Chain Contracts
+        -> End-to-End Mission Data Flow Evidence
+        -> Generated Runtime Skeletons
+        -> Ground Integration Artifacts
+```
+
+This delays runtime skeleton generation, but it makes it more valuable.
+
+The generated runtime artifacts will eventually be able to reflect payloads, data products, storage policies, downlink priorities and commandability constraints, not only IDs and basic command/telemetry structures.
+
+The ground integration artifacts will also be stronger, because they will be derived from a richer contract that already includes data products and downlink assumptions.
+
+---
+
+## Expected Roadmap Impact
+
+The roadmap should include these milestones before runtime generation:
+
+```text
+v0.3 Data Product and Storage Contracts
+v0.4 Contact Windows and Downlink Flow Contracts
+v0.5 Commandability and Autonomy Contracts
+v0.6 End-to-End Mission Data Flow Evidence
+```
+
+Generated runtime skeletons should move later:
+
+```text
+v0.7 Generated Runtime Skeletons
+```
+
+Ground integration artifacts should follow after the model contains enough ground-facing semantics:
+
+```text
+v0.8 Ground Integration Artifacts
+```
+
+Plugin and extensibility work should remain after the core model has matured:
+
+```text
+v0.9 Plugin and Extensibility Layer
+```
+
+---
+
+## Acceptance Criteria for This Decision
+
+This ADR is satisfied when:
+
+- the roadmap explicitly places Mission Data Chain modeling before runtime skeleton generation;
+- the Project Charter explains Mission Data Chain as part of OrbitFabric's direction;
+- generated runtime skeletons are no longer the immediate next implementation milestone;
+- future data product, storage, downlink, contact, commandability and autonomy concepts are described as contracts, not runtime implementations;
+- non-goals remain explicit.
+
+---
+
+## Final Position
+
+OrbitFabric must not generate code from an immature mission contract.
+
+It must first model the mission data chain.
+
+That is the architectural step that turns OrbitFabric from a useful mission-model tool into a credible Mission Data Fabric.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - ADR-0004 No Flight Runtime in v0.1: adr/ADR-0004-no-flight-runtime-in-v0.1.md
       - ADR-0005 Lint as Core Feature: adr/ADR-0005-lint-as-core-feature.md
       - ADR-0006 Payload Contract Model: adr/ADR-0006-payload-contract-model.md
+      - ADR-0007 Mission Data Chain Before Runtime: adr/ADR-0007-mission-data-chain-before-runtime.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

This PR updates the OrbitFabric roadmap after the completed Payload Contract alignment work.

It formalizes the next architectural direction: Mission Data Chain modeling before generated runtime skeletons.

## Changes

- marks `v0.2.2 — Payload Contract Release Alignment` as completed in the roadmap;
- introduces `v0.2.3 — Mission Data Chain Roadmap Alignment`;
- moves generated runtime skeletons later in the roadmap;
- adds future milestones for:
  - Data Product and Storage Contracts;
  - Contact Windows and Downlink Flow Contracts;
  - Commandability and Autonomy Contracts;
  - End-to-End Mission Data Flow Evidence;
- aligns the Project Charter with Mission Data Chain terminology;
- adds `ADR-0007 — Mission Data Chain Before Runtime Generation`;
- exposes the new ADR in `mkdocs.yml`.

## Boundary

This PR is documentation-only.

It intentionally does not add:

- new model files;
- new schema fields;
- new simulator behavior;
- runtime skeleton generation;
- ground export logic;
- plugin APIs.

## Rationale

OrbitFabric should not generate runtime skeletons from an immature mission contract.

After Payload Contracts, the next coherent step is to model the mission data chain:

```text
Payload behavior
        -> data products
        -> onboard storage and retention
        -> downlink queue intent
        -> contact window assumptions
        -> commandability constraints
        -> autonomy and recovery expectations
        -> end-to-end scenario evidence
```

Only after that should runtime and ground artifacts be derived.

## Validation

Documentation-only change. Recommended local check:

```bash
mkdocs build --strict
```
