### PR TITLE
docs: define Data Product Contract scope

### DIFF
--- a/docs/adr/ADR-0008-data-product-and-storage-contracts.md
+++ b/docs/adr/ADR-0008-data-product-and-storage-contracts.md
@@ -1,0 +1,264 @@
+# ADR-0008 — Data Product and Storage Contracts
+
+Status: Proposed  
+Date: 2026-05-01
+
+---
+
+## Context
+
+OrbitFabric is a model-first Mission Data Contract framework for small spacecraft.
+
+The Payload / IOD Payload Contract Model introduced a first-class way to describe mission-specific payload behavior as a declarative contract.
+
+That model can describe payload telemetry, commands, events, faults, lifecycle states, preconditions and expected effects.
+
+However, a payload does not only expose telemetry or accept commands.
+
+In many small spacecraft and IOD missions, a payload produces mission data objects that must be preserved, prioritized and eventually delivered to the ground.
+
+Examples include:
+
+```text
+image frames
+radiation histograms
+science sample batches
+AIS capture windows
+IoT receiver bursts
+diagnostic dumps
+compressed payload products
+```
+
+These objects are not the same as telemetry fields.
+
+They are also not the same as packets.
+
+OrbitFabric needs a contract-level way to describe them before runtime skeletons, downlink models or ground integration artifacts are generated.
+
+---
+
+## Decision
+
+OrbitFabric will introduce Data Product and Storage Contracts as the next model-first slice after Payload Contracts.
+
+A data product is a declared mission-data object produced by a payload or subsystem.
+
+A data product contract may describe:
+
+```text
+data product identity
+producer reference
+producer type
+optional payload reference
+product type
+estimated size
+priority
+storage class
+retention intent
+overflow policy
+downlink intent
+```
+
+Storage and downlink fields represent declared intent.
+
+They do not represent real storage implementation, file-system behavior, compression, contact-window simulation or downlink runtime behavior.
+
+The first implementation slice should remain narrow and should be introduced as an optional model domain.
+
+A candidate file name is:
+
+```text
+mission/data_products.yaml
+```
+
+---
+
+## Terminology
+
+OrbitFabric must keep these concepts distinct.
+
+```text
+Telemetry
+    A state, measurement or status value exposed by the Mission Model.
+
+Packet
+    A declared grouping or transport-oriented representation of mission data.
+
+Data Product
+    A mission or payload output object that may require storage, retention,
+    prioritization and eventual downlink.
+```
+
+This distinction is essential.
+
+A payload may produce telemetry such as `payload.acquisition.active` while also producing a data product such as `payload.radiation_histogram`.
+
+The telemetry describes operational state.
+
+The data product describes a mission output object.
+
+---
+
+## Candidate Minimal Shape
+
+The first data product slice may use a shape similar to:
+
+```yaml
+data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: science
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+```
+
+This is a candidate shape, not a frozen schema.
+
+The implementation may refine field names if that improves clarity or validation.
+
+---
+
+## Initial Scope
+
+The first vertical slice should include:
+
+```text
+optional data_products.yaml loading
+typed DataProductContract model
+producer reference validation
+optional payload reference validation
+estimated size validation
+priority validation
+storage intent fields
+downlink intent fields
+semantic lint rules
+generated data product documentation
+invalid fixtures and tests
+one synthetic demo data product
+```
+
+The slice should prove this relationship:
+
+```text
+Payload Contract
+        -> Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+```
+
+---
+
+## Non-Goals
+
+This decision must not introduce:
+
+```text
+real onboard storage runtime
+file-system abstraction
+compression engine
+payload data processing pipeline
+contact window model
+RF link model
+downlink runtime
+ground segment export
+runtime skeleton generation
+real payload data
+private mission-specific data products
+```
+
+These are not missing pieces of the first data product slice.
+
+They are intentionally outside the scope of this ADR.
+
+Contact windows and downlink flow contracts belong to a later milestone.
+
+Runtime skeletons and ground integration artifacts must remain deferred until the contract is mature.
+
+---
+
+## Linting Direction
+
+Data Product and Storage Contracts must be lintable from the beginning.
+
+Candidate lint rules include:
+
+```text
+ERROR: data product id is duplicated.
+ERROR: data product references an unknown producer.
+ERROR: data product references an unknown payload contract.
+ERROR: data product estimated size must be positive.
+WARNING: retained data product has no retention policy.
+WARNING: retained data product has no overflow policy.
+WARNING: high-priority data product has no downlink intent.
+```
+
+Exact rule IDs and severities should be defined during implementation.
+
+The principle is fixed:
+
+> If a data product can become operationally ambiguous, the ambiguity must be visible before runtime or ground artifacts are generated.
+
+---
+
+## Documentation Direction
+
+Generated documentation should expose data products from the validated Mission Model.
+
+A candidate generated file is:
+
+```text
+generated/docs/data_products.md
+```
+
+The generated page should make clear that storage and downlink fields are contract intent, not executable runtime behavior.
+
+---
+
+## Consequences
+
+This decision extends OrbitFabric from payload behavior modeling toward mission data chain modeling.
+
+It makes the first post-payload step explicit:
+
+```text
+payload behavior
+        -> data product produced
+        -> storage intent declared
+        -> downlink intent declared
+```
+
+This strengthens future milestones.
+
+Runtime skeletons will eventually be able to include data product identifiers and storage/downlink policy enumerations.
+
+Ground artifacts will eventually be able to export not only telemetry and command dictionaries, but also data product dictionaries and downlink policy information.
+
+---
+
+## Acceptance Criteria for This Decision
+
+This ADR is satisfied when:
+
+- the scope of Data Product and Storage Contracts is documented;
+- data products are clearly distinguished from telemetry and packets;
+- storage and downlink fields are described as intent, not implementation;
+- non-goals are explicit;
+- the public documentation exposes the proposed contract scope;
+- implementation can proceed through small follow-up issues.
+
+---
+
+## Final Position
+
+OrbitFabric should not jump from payload contracts directly to runtime generation.
+
+The next correct step is to model the mission data objects produced by payloads and subsystems, together with their storage and downlink intent.
+
+That is the first concrete layer of the Mission Data Chain.

--- a/docs/reference/data-product-contract-model.md
+++ b/docs/reference/data-product-contract-model.md
@@ -1,0 +1,199 @@
+# Data Product Contract Model
+
+Status: Proposed for OrbitFabric v0.3  
+Scope: Data Product and Storage Contract definition
+
+## Purpose
+
+The Data Product Contract Model extends OrbitFabric with a proposed model domain for mission data objects produced by payloads or subsystems.
+
+A data product contract describes what mission data object is expected to be produced, who produces it, how large it is expected to be, how important it is, how it should be retained and how it should be prepared for future downlink planning.
+
+The model is contract-level only.
+
+It does not implement onboard storage, payload processing, compression, contact windows, downlink execution or ground export.
+
+## Why Data Products Are Separate
+
+OrbitFabric must keep telemetry, packets and data products distinct.
+
+```text
+Telemetry
+    A state, measurement or status value exposed by the Mission Model.
+
+Packet
+    A declared grouping or transport-oriented representation of mission data.
+
+Data Product
+    A mission or payload output object that may require storage, retention,
+    prioritization and eventual downlink.
+```
+
+For example, a payload may expose telemetry indicating that acquisition is active while also producing a histogram, image, sample batch or diagnostic dump.
+
+The telemetry describes operational state.
+
+The data product describes the mission output object.
+
+## What a Data Product Contract May Describe
+
+A data product contract may describe:
+
+- data product identity;
+- producer reference;
+- producer type;
+- optional payload reference;
+- product type;
+- estimated size;
+- priority;
+- storage class;
+- retention intent;
+- overflow policy;
+- downlink intent.
+
+These fields make the first part of the Mission Data Chain explicit:
+
+```text
+Payload or subsystem activity
+        -> data product produced
+        -> storage intent declared
+        -> downlink intent declared
+```
+
+## What a Data Product Contract Does Not Describe
+
+A data product contract does not describe:
+
+- real onboard storage software;
+- file-system implementation;
+- compression engines;
+- payload data processing pipelines;
+- physical payload simulation;
+- contact window modeling;
+- RF link modeling;
+- downlink runtime;
+- ground segment implementation;
+- runtime skeleton generation.
+
+Those are intentionally outside the proposed v0.3 scope.
+
+## Candidate YAML Shape
+
+The first implementation slice may introduce an optional file:
+
+```text
+mission/data_products.yaml
+```
+
+A candidate shape is:
+
+```yaml
+data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: science
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+```
+
+This is a proposed shape for the v0.3 design direction.
+
+It is not yet a stable schema.
+
+## Relationship with Payload Contracts
+
+Payload Contracts describe expected payload behavior.
+
+Data Product Contracts describe mission data objects produced by that behavior.
+
+The relationship is:
+
+```text
+Payload Contract
+        -> produced telemetry
+        -> accepted commands
+        -> generated events
+        -> possible faults
+        -> lifecycle behavior
+        -> Data Product Contracts
+```
+
+A data product may reference a payload contract as its producer.
+
+The reference must remain declarative.
+
+It must not imply payload runtime execution or data processing.
+
+## Storage Intent
+
+Storage fields describe policy intent.
+
+Examples include:
+
+- storage class;
+- retention duration;
+- overflow policy.
+
+They do not implement storage.
+
+They make it possible to validate that a produced mission object has a declared preservation strategy before later milestones introduce contact windows, downlink flow or runtime skeletons.
+
+## Downlink Intent
+
+Downlink fields describe future delivery intent.
+
+Examples include:
+
+- next available contact;
+- priority-based downlink;
+- deferred downlink;
+- manual or operator-selected downlink.
+
+The first data product slice should not implement contact windows or downlink simulation.
+
+Those belong to later Mission Data Chain milestones.
+
+## Linting Direction
+
+Data Product Contracts should be linted semantically.
+
+Candidate findings include:
+
+```text
+ERROR: data product id is duplicated.
+ERROR: data product references an unknown producer.
+ERROR: data product references an unknown payload contract.
+ERROR: estimated size must be positive.
+WARNING: retained data product has no retention policy.
+WARNING: retained data product has no overflow policy.
+WARNING: high-priority data product has no downlink intent.
+```
+
+Exact rule IDs and severities should be defined during implementation.
+
+## Generated Documentation Direction
+
+When data products are present, OrbitFabric should be able to generate data product documentation from the validated Mission Model.
+
+Candidate output:
+
+```text
+generated/docs/data_products.md
+```
+
+The generated page should expose data product identity, producer, type, estimated size, priority, storage intent and downlink intent.
+
+## Current Status
+
+This page defines proposed v0.3 scope only.
+
+It does not document an implemented schema yet.
+
+Implementation should proceed through small follow-up issues covering model loading, lint rules, invalid fixtures, generated documentation and one synthetic demo data product.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - JSON Reports v0.1: reference/json-reports-v0.1.md
       - Lint Rules v0.1: reference/lint-rules-v0.1.md
       - Payload Contract Model: reference/payload-contract-model.md
+      - Data Product Contract Model: reference/data-product-contract-model.md
 
   - ADR:
       - ADR-0001 Mission Model First: adr/ADR-0001-mission-model-first.md
@@ -34,6 +35,7 @@ nav:
       - ADR-0005 Lint as Core Feature: adr/ADR-0005-lint-as-core-feature.md
       - ADR-0006 Payload Contract Model: adr/ADR-0006-payload-contract-model.md
       - ADR-0007 Mission Data Chain Before Runtime: adr/ADR-0007-mission-data-chain-before-runtime.md
+      - ADR-0008 Data Product and Storage Contracts: adr/ADR-0008-data-product-and-storage-contracts.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

This PR defines the scope of `v0.3 — Data Product and Storage Contracts` before implementation.

It introduces the proposed Data Product Contract Model as the first concrete layer of the Mission Data Chain after Payload Contracts.

## Changes

- adds `ADR-0008 — Data Product and Storage Contracts`;
- adds a reference page for the proposed Data Product Contract Model;
- exposes the new ADR and reference page in `mkdocs.yml`.

## Scope

The PR documents the contract-level concepts for:

- data product identity;
- producer reference;
- producer type;
- optional payload reference;
- product type;
- estimated size;
- priority;
- storage class;
- retention intent;
- overflow policy;
- downlink intent.

## Boundary

This PR is documentation-only.

It intentionally does not add:

- `data_products.yaml` loading;
- model classes;
- schema fields;
- lint rules;
- invalid fixtures;
- generated data product docs;
- demo mission changes;
- simulator behavior;
- runtime skeletons;
- ground export logic.

## Rationale

OrbitFabric should model data products as mission-data contract objects before implementing runtime or ground artifacts.

The distinction is explicit:

```text
Telemetry      = state / measurement / status
Packet         = transport-oriented grouping
Data Product   = mission or payload output object requiring storage, retention, priority and future downlink intent
```

## Related issue

Closes #61

## Validation

Documentation-only change. Recommended local check:

```bash
mkdocs build --strict
```
