### PR TITLE
model: add optional data products domain

### DIFF
--- a/src/orbitfabric/model/loader.py
+++ b/src/orbitfabric/model/loader.py
@@ -24,6 +24,7 @@ REQUIRED_FILES: dict[str, tuple[str, ...]] = {
 
 OPTIONAL_FILES: dict[str, tuple[str, ...]] = {
     "payloads.yaml": ("payloads",),
+    "data_products.yaml": ("data_products",),
 }
 
 
@@ -254,6 +255,13 @@ class MissionModelLoader:
                 domain="payloads",
                 file="payloads.yaml",
                 values=[item.id for item in model.payloads],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="data_products",
+                file="data_products.yaml",
+                values=[item.id for item in model.data_products],
             )
         )
         diagnostics.extend(

--- a/src/orbitfabric/model/mission.py
+++ b/src/orbitfabric/model/mission.py
@@ -26,6 +26,25 @@ TelemetryType = Literal[
 
 PacketType = Literal["json", "binary_compact", "ccsds_like"]
 PayloadProfile = Literal["iod", "mission_specific"]
+DataProductProducerType = Literal["payload", "subsystem"]
+DataProductType = Literal[
+    "histogram",
+    "image",
+    "sample_batch",
+    "capture_window",
+    "diagnostic_dump",
+    "compressed_product",
+    "generic",
+]
+StorageClass = Literal["science", "diagnostic", "housekeeping", "engineering"]
+OverflowPolicy = Literal["drop_oldest", "drop_newest", "reject_new", "overwrite", "none"]
+DownlinkIntentPolicy = Literal[
+    "none",
+    "next_available_contact",
+    "priority_based",
+    "deferred",
+    "manual",
+]
 
 
 class StrictModel(BaseModel):
@@ -192,6 +211,29 @@ class PayloadContract(StrictModel):
     description: str | None = None
 
 
+class DataProductStorageIntent(StrictModel):
+    storage_class: StorageClass = Field(alias="class")
+    retention: str | None = None
+    overflow_policy: OverflowPolicy | None = None
+
+
+class DataProductDownlinkIntent(StrictModel):
+    policy: DownlinkIntentPolicy | None = None
+
+
+class DataProductContract(StrictModel):
+    id: str
+    producer: str
+    producer_type: DataProductProducerType
+    type: DataProductType
+    estimated_size_bytes: int = Field(gt=0)
+    priority: DownlinkPriority
+    payload: str | None = None
+    storage: DataProductStorageIntent | None = None
+    downlink: DataProductDownlinkIntent | None = None
+    description: str | None = None
+
+
 class AllowedValues(StrictModel):
     allowed_values: list[str]
 
@@ -216,6 +258,7 @@ class MissionModel(StrictModel):
     packets: list[Packet]
     policies: Policies
     payloads: list[PayloadContract] = Field(default_factory=list)
+    data_products: list[DataProductContract] = Field(default_factory=list)
 
     @property
     def subsystem_ids(self) -> set[str]:
@@ -244,6 +287,10 @@ class MissionModel(StrictModel):
     @property
     def payload_ids(self) -> set[str]:
         return {item.id for item in self.payloads}
+
+    @property
+    def data_product_ids(self) -> set[str]:
+        return {item.id for item in self.data_products}
 
     @property
     def mode_ids(self) -> set[str]:

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -9,6 +9,35 @@ from orbitfabric.model.loader import MissionModelLoader
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
 
+VALID_DATA_PRODUCTS_YAML = """data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: science
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+    description: Synthetic payload data product used to validate data product contracts.
+"""
+
+
+def copy_demo_mission(tmp_path: Path) -> Path:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    return mission_dir
+
 
 def test_load_demo_mission() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
@@ -65,14 +94,7 @@ def test_optional_payloads_file_can_be_absent(tmp_path: Path) -> None:
 
 
 def test_invalid_payloads_top_level_key_fails(tmp_path: Path) -> None:
-    mission_dir = tmp_path / "mission"
-    mission_dir.mkdir()
-
-    for source_file in DEMO_MISSION.glob("*.yaml"):
-        (mission_dir / source_file.name).write_text(
-            source_file.read_text(encoding="utf-8"),
-            encoding="utf-8",
-        )
+    mission_dir = copy_demo_mission(tmp_path)
 
     (mission_dir / "payloads.yaml").write_text(
         "payload_contracts: []\n",
@@ -85,6 +107,89 @@ def test_invalid_payloads_top_level_key_fails(tmp_path: Path) -> None:
     codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
     assert "OF-STR-001" in codes
     assert "OF-STR-002" in codes
+
+
+def test_optional_data_products_file_can_be_absent() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    assert model.data_products == []
+
+
+def test_load_valid_data_product_contract(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "data_products.yaml").write_text(
+        VALID_DATA_PRODUCTS_YAML,
+        encoding="utf-8",
+    )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert len(model.data_products) == 1
+    data_product = model.data_products[0]
+
+    assert data_product.id == "payload.radiation_histogram"
+    assert data_product.producer == "demo_iod_payload"
+    assert data_product.producer_type == "payload"
+    assert data_product.type == "histogram"
+    assert data_product.estimated_size_bytes == 4096
+    assert data_product.priority == "high"
+    assert data_product.storage is not None
+    assert data_product.storage.storage_class == "science"
+    assert data_product.storage.retention == "7d"
+    assert data_product.storage.overflow_policy == "drop_oldest"
+    assert data_product.downlink is not None
+    assert data_product.downlink.policy == "next_available_contact"
+    assert data_product.description is not None
+    assert model.data_product_ids == {"payload.radiation_histogram"}
+
+
+def test_invalid_data_products_top_level_key_fails(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "data_products.yaml").write_text(
+        "products: []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissionModelError) as exc_info:
+        MissionModelLoader().load(mission_dir)
+
+    codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
+    assert "OF-STR-001" in codes
+    assert "OF-STR-002" in codes
+
+
+def test_duplicate_data_product_id_fails(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "data_products.yaml").write_text(
+        """data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissionModelError) as exc_info:
+        MissionModelLoader().load(mission_dir)
+
+    diagnostics = exc_info.value.diagnostics
+
+    assert any(
+        diagnostic.code == "OF-ID-001"
+        and diagnostic.file == "data_products.yaml"
+        and diagnostic.domain == "data_products"
+        and diagnostic.object_id == "payload.radiation_histogram"
+        for diagnostic in diagnostics
+    )
 
 
 def test_missing_mission_directory_fails() -> None:


### PR DESCRIPTION
## Summary

This PR introduces the first implementation slice for `v0.3 — Data Product and Storage Contracts`.

It adds an optional `data_products.yaml` Mission Model domain and the typed model structures needed to parse data product contracts.

## Changes

- adds `DataProductContract` and related intent models;
- adds literal types for producer type, product type, storage class, overflow policy and downlink intent policy;
- adds `MissionModel.data_products` with an empty default;
- adds `MissionModel.data_product_ids`;
- teaches `MissionModelLoader` to load optional `data_products.yaml`;
- adds duplicate ID checks for the `data_products` domain;
- adds loader tests for:
  - absent optional `data_products.yaml`;
  - valid data product contract loading;
  - invalid top-level key;
  - duplicate data product IDs.

## Boundary

This PR intentionally keeps the slice structural and model-level.

It does not add:

- semantic producer reference linting;
- semantic payload reference linting;
- data product lint rule catalog entries;
- invalid data product fixture suite;
- generated `data_products.md` documentation;
- demo mission `data_products.yaml`;
- scenario behavior;
- storage execution;
- downlink execution;
- contact windows;
- runtime skeletons;
- ground export logic.

Semantic reference checks and operational warnings remain in the follow-up lint issue #63.

## Candidate YAML shape

```yaml
data_products:
  - id: payload.radiation_histogram
    producer: demo_iod_payload
    producer_type: payload
    type: histogram
    estimated_size_bytes: 4096
    priority: high
    storage:
      class: science
      retention: 7d
      overflow_policy: drop_oldest
    downlink:
      policy: next_available_contact
```

## Related issue

Progresses #62.

## Validation

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
