### PR TITLE
lint: add semantic rules for data products

### DIFF
--- a/src/orbitfabric/lint/engine.py
+++ b/src/orbitfabric/lint/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from orbitfabric.lint.finding import LintReport
 from orbitfabric.lint.rules_commands import check_commands
+from orbitfabric.lint.rules_data_products import check_data_products
 from orbitfabric.lint.rules_events import check_events
 from orbitfabric.lint.rules_faults import check_faults
 from orbitfabric.lint.rules_modes import check_modes
@@ -20,6 +21,7 @@ class LintEngine:
         findings.extend(check_references(model))
         findings.extend(check_modes(model))
         findings.extend(check_payloads(model))
+        findings.extend(check_data_products(model))
         findings.extend(check_telemetry(model))
         findings.extend(check_commands(model))
         findings.extend(check_events(model))

--- a/src/orbitfabric/lint/rules_data_products.py
+++ b/src/orbitfabric/lint/rules_data_products.py
@@ -103,7 +103,10 @@ def _check_storage_intent(data_product: DataProductContract) -> list[LintFinding
                 domain="data_products",
                 object_id=data_product.id,
                 message="data product storage intent should define retention",
-                suggestion="Set storage.retention or remove storage intent if the product is not retained.",
+                suggestion=(
+                    "Set storage.retention or remove storage intent if the product "
+                    "is not retained."
+                ),
             )
         )
 

--- a/src/orbitfabric/lint/rules_data_products.py
+++ b/src/orbitfabric/lint/rules_data_products.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from orbitfabric.lint.finding import LintFinding
+from orbitfabric.model.mission import DataProductContract, MissionModel
+
+
+def check_data_products(model: MissionModel) -> list[LintFinding]:
+    """Check Data Product and Storage Contract consistency."""
+    findings: list[LintFinding] = []
+
+    for data_product in model.data_products:
+        findings.extend(_check_producer_reference(model, data_product))
+        findings.extend(_check_payload_reference(model, data_product))
+        findings.extend(_check_storage_intent(data_product))
+        findings.extend(_check_downlink_intent(data_product))
+
+    return findings
+
+
+def _check_producer_reference(
+    model: MissionModel,
+    data_product: DataProductContract,
+) -> list[LintFinding]:
+    if data_product.producer_type == "payload":
+        if data_product.producer in model.payload_ids:
+            return []
+
+        return [
+            LintFinding(
+                severity="ERROR",
+                code="OF-DP-002",
+                file="data_products.yaml",
+                domain="data_products",
+                object_id=data_product.id,
+                message=(
+                    f"data product producer '{data_product.producer}' does not reference "
+                    "an existing payload contract"
+                ),
+                suggestion="Add the payload to payloads.yaml or fix data_product.producer.",
+            )
+        ]
+
+    if data_product.producer_type == "subsystem":
+        if data_product.producer in model.subsystem_ids:
+            return []
+
+        return [
+            LintFinding(
+                severity="ERROR",
+                code="OF-DP-002",
+                file="data_products.yaml",
+                domain="data_products",
+                object_id=data_product.id,
+                message=(
+                    f"data product producer '{data_product.producer}' does not reference "
+                    "an existing subsystem"
+                ),
+                suggestion="Add the subsystem to subsystems.yaml or fix data_product.producer.",
+            )
+        ]
+
+    return []
+
+
+def _check_payload_reference(
+    model: MissionModel,
+    data_product: DataProductContract,
+) -> list[LintFinding]:
+    if data_product.payload is None:
+        return []
+
+    if data_product.payload in model.payload_ids:
+        return []
+
+    return [
+        LintFinding(
+            severity="ERROR",
+            code="OF-DP-003",
+            file="data_products.yaml",
+            domain="data_products",
+            object_id=data_product.id,
+            message=(
+                f"data product payload reference '{data_product.payload}' does not reference "
+                "an existing payload contract"
+            ),
+            suggestion="Add the payload to payloads.yaml or fix data_product.payload.",
+        )
+    ]
+
+
+def _check_storage_intent(data_product: DataProductContract) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if data_product.storage is None:
+        return findings
+
+    if data_product.storage.retention is None:
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-DP-006",
+                file="data_products.yaml",
+                domain="data_products",
+                object_id=data_product.id,
+                message="data product storage intent should define retention",
+                suggestion="Set storage.retention or remove storage intent if the product is not retained.",
+            )
+        )
+
+    if data_product.storage.overflow_policy is None:
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-DP-007",
+                file="data_products.yaml",
+                domain="data_products",
+                object_id=data_product.id,
+                message="data product storage intent should define overflow_policy",
+                suggestion="Set storage.overflow_policy for retained data products.",
+            )
+        )
+
+    return findings
+
+
+def _check_downlink_intent(data_product: DataProductContract) -> list[LintFinding]:
+    if data_product.priority not in {"high", "critical"}:
+        return []
+
+    if data_product.downlink is not None and data_product.downlink.policy not in {None, "none"}:
+        return []
+
+    return [
+        LintFinding(
+            severity="WARNING",
+            code="OF-DP-008",
+            file="data_products.yaml",
+            domain="data_products",
+            object_id=data_product.id,
+            message="high-priority data product should define downlink intent",
+            suggestion="Set downlink.policy for high or critical data products.",
+        )
+    ]

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -4,8 +4,32 @@ from pathlib import Path
 
 from orbitfabric.lint.engine import LintEngine
 from orbitfabric.model.loader import MissionModelLoader
+from orbitfabric.model.mission import (
+    DataProductContract,
+    DataProductDownlinkIntent,
+    DataProductStorageIntent,
+)
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def make_valid_data_product() -> DataProductContract:
+    return DataProductContract(
+        id="payload.radiation_histogram",
+        producer="demo_iod_payload",
+        producer_type="payload",
+        type="histogram",
+        estimated_size_bytes=4096,
+        priority="high",
+        storage=DataProductStorageIntent(
+            **{
+                "class": "science",
+                "retention": "7d",
+                "overflow_policy": "drop_oldest",
+            }
+        ),
+        downlink=DataProductDownlinkIntent(policy="next_available_contact"),
+    )
 
 
 def test_demo_mission_has_no_semantic_lint_findings() -> None:
@@ -159,3 +183,82 @@ def test_command_expected_effect_payload_lifecycle_state_must_exist() -> None:
     codes = {finding.code for finding in report.findings}
     assert "OF-PAY-010" in codes
     assert report.has_errors
+
+
+def test_valid_data_product_contract_has_no_lint_findings() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.data_products.append(make_valid_data_product())
+
+    report = LintEngine().run(model)
+
+    data_product_codes = {
+        finding.code for finding in report.findings if finding.domain == "data_products"
+    }
+    assert data_product_codes == set()
+
+
+def test_data_product_payload_producer_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    data_product = make_valid_data_product()
+    data_product.producer = "missing_payload"
+    model.data_products.append(data_product)
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-DP-002" in codes
+    assert report.has_errors
+
+
+def test_data_product_subsystem_producer_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    data_product = make_valid_data_product()
+    data_product.producer = "missing_subsystem"
+    data_product.producer_type = "subsystem"
+    model.data_products.append(data_product)
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-DP-002" in codes
+    assert report.has_errors
+
+
+def test_data_product_optional_payload_reference_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    data_product = make_valid_data_product()
+    data_product.payload = "missing_payload"
+    model.data_products.append(data_product)
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-DP-003" in codes
+    assert report.has_errors
+
+
+def test_data_product_storage_intent_should_define_retention_and_overflow_policy() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    data_product = make_valid_data_product()
+    data_product.storage = DataProductStorageIntent(**{"class": "science"})
+    model.data_products.append(data_product)
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-DP-006" in codes
+    assert "OF-DP-007" in codes
+    assert report.warning_count >= 2
+
+
+def test_high_priority_data_product_should_define_downlink_intent() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    data_product = make_valid_data_product()
+    data_product.downlink = None
+    model.data_products.append(data_product)
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-DP-008" in codes
+    assert report.warning_count >= 1


### PR DESCRIPTION
## Summary

This PR adds semantic lint rules for the new Data Product and Storage Contract domain introduced in #68.

It keeps the implementation contract-level and does not add generated documentation, demo mission updates, storage execution or downlink behavior.

## Changes

- adds `src/orbitfabric/lint/rules_data_products.py`;
- wires data product linting into `LintEngine`;
- validates data product producer references:
  - payload producers must reference existing payload contracts;
  - subsystem producers must reference existing subsystems;
- validates optional payload references;
- warns when storage intent is incomplete:
  - missing `retention`;
  - missing `overflow_policy`;
- warns when high/critical priority data products have no useful downlink intent;
- adds tests for valid and invalid data product lint cases.

## Rule coverage

Implemented rule IDs:

```text
OF-DP-002  producer reference must be known
OF-DP-003  optional payload reference must be known
OF-DP-006  storage intent should define retention
OF-DP-007  storage intent should define overflow_policy
OF-DP-008  high-priority data product should define downlink intent
```

The following are intentionally handled structurally by the model/loader rather than duplicated in lint:

```text
estimated_size_bytes > 0
known literal values for priority, storage class, overflow policy and downlink policy
unique data product IDs
```

## Boundary

This PR does not add:

- invalid fixture suite for data products;
- generated `data_products.md` documentation;
- demo mission `data_products.yaml`;
- scenario behavior;
- storage runtime;
- downlink runtime;
- contact windows;
- runtime skeletons;
- ground export logic.

## Related issue

Closes #63

## Validation

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
