### PR TITLE
docs: generate data product documentation

### DIFF
--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -6,6 +6,9 @@ from typing import Any
 from orbitfabric.model.mission import (
     Command,
     CommandArgument,
+    DataProductContract,
+    DataProductDownlinkIntent,
+    DataProductStorageIntent,
     Event,
     Fault,
     FaultCondition,
@@ -35,6 +38,11 @@ def generate_markdown_docs(model: MissionModel, output_dir: Path) -> list[Path]:
     if model.payloads:
         generated_files.append(
             _write(output_dir / "payloads.md", _render_payloads(model))
+        )
+
+    if model.data_products:
+        generated_files.append(
+            _write(output_dir / "data_products.md", _render_data_products(model))
         )
 
     return generated_files
@@ -305,6 +313,78 @@ def _render_payload_contract(model: MissionModel, payload: PayloadContract) -> s
     lines.append(f"| Faults possible | {_format_list(payload.faults.possible)} |\n\n")
 
     return "".join(lines)
+
+
+def _render_data_products(model: MissionModel) -> str:
+    lines = [_header("Data Product Contract Reference", model)]
+
+    producer_count = len({data_product.producer for data_product in model.data_products})
+
+    lines.append("## Summary\n\n")
+    lines.append(f"- Data products: `{len(model.data_products)}`\n")
+    lines.append(f"- Producers: `{producer_count}`\n\n")
+    lines.append(
+        "Storage and downlink fields describe contract intent only. "
+        "They do not imply onboard storage execution, contact modeling or "
+        "downlink runtime behavior.\n\n"
+    )
+
+    lines.append("## Data products\n\n")
+    lines.append(
+        "| ID | Producer | Product Type | Estimated Size | Priority | "
+        "Storage Intent | Downlink Intent | Description |\n"
+    )
+    lines.append("|---|---|---|---:|---|---|---|---|\n")
+
+    for data_product in sorted(model.data_products, key=lambda item: item.id):
+        lines.append(_render_data_product_row(model, data_product))
+
+    return "".join(lines)
+
+
+def _render_data_product_row(
+    model: MissionModel,
+    data_product: DataProductContract,
+) -> str:
+    return (
+        f"| {_code(data_product.id)} "
+        f"| {_producer_heading(model, data_product)} "
+        f"| {_code(data_product.type)} "
+        f"| {data_product.estimated_size_bytes} "
+        f"| {_code(data_product.priority)} "
+        f"| {_format_storage_intent(data_product.storage)} "
+        f"| {_format_downlink_intent(data_product.downlink)} "
+        f"| {_text(data_product.description or '-')} |\n"
+    )
+
+
+def _producer_heading(model: MissionModel, data_product: DataProductContract) -> str:
+    if data_product.producer_type == "subsystem":
+        return _subsystem_heading(model, data_product.producer)
+
+    return f"{_code(data_product.producer)} ({_code(data_product.producer_type)})"
+
+
+def _format_storage_intent(storage: DataProductStorageIntent | None) -> str:
+    if storage is None:
+        return "-"
+
+    lines = [f"class {_code(storage.storage_class)}"]
+
+    if storage.retention is not None:
+        lines.append(f"retention {_code(storage.retention)}")
+
+    if storage.overflow_policy is not None:
+        lines.append(f"overflow {_code(storage.overflow_policy)}")
+
+    return _line_break_join(lines)
+
+
+def _format_downlink_intent(downlink: DataProductDownlinkIntent | None) -> str:
+    if downlink is None or downlink.policy is None:
+        return "-"
+
+    return f"policy {_code(downlink.policy)}"
 
 
 def _telemetry_by_source(model: MissionModel) -> dict[str, list[TelemetryItem]]:

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -4,8 +4,33 @@ from pathlib import Path
 
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.model.loader import MissionModelLoader
+from orbitfabric.model.mission import (
+    DataProductContract,
+    DataProductDownlinkIntent,
+    DataProductStorageIntent,
+)
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def make_valid_data_product() -> DataProductContract:
+    return DataProductContract(
+        id="payload.radiation_histogram",
+        producer="demo_iod_payload",
+        producer_type="payload",
+        type="histogram",
+        estimated_size_bytes=4096,
+        priority="high",
+        storage=DataProductStorageIntent(
+            **{
+                "class": "science",
+                "retention": "7d",
+                "overflow_policy": "drop_oldest",
+            }
+        ),
+        downlink=DataProductDownlinkIntent(policy="next_available_contact"),
+        description="Synthetic payload histogram data product.",
+    )
 
 
 def test_generate_payload_contract_docs(tmp_path: Path) -> None:
@@ -41,3 +66,43 @@ def test_payload_contract_docs_are_skipped_without_payloads(tmp_path: Path) -> N
 
     assert "payloads.md" not in generated_names
     assert not (tmp_path / "payloads.md").exists()
+
+
+def test_generate_data_product_contract_docs(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.data_products.append(make_valid_data_product())
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    data_products_path = tmp_path / "data_products.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "data_products.md" in generated_names
+    assert data_products_path.exists()
+
+    content = data_products_path.read_text(encoding="utf-8")
+
+    assert "# Data Product Contract Reference" in content
+    assert "Storage and downlink fields describe contract intent only." in content
+    assert "`payload.radiation_histogram`" in content
+    assert "`demo_iod_payload` (`payload`)" in content
+    assert "`histogram`" in content
+    assert "4096" in content
+    assert "`high`" in content
+    assert "class `science`" in content
+    assert "retention `7d`" in content
+    assert "overflow `drop_oldest`" in content
+    assert "policy `next_available_contact`" in content
+    assert "Synthetic payload histogram data product." in content
+
+
+def test_data_product_contract_docs_are_skipped_without_data_products(
+    tmp_path: Path,
+) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+    generated_names = {path.name for path in generated_files}
+
+    assert "data_products.md" not in generated_names
+    assert not (tmp_path / "data_products.md").exists()


### PR DESCRIPTION
## Summary

This PR adds generated Markdown documentation for Data Product Contracts.

It extends the existing docs generator with an optional `data_products.md` page when the Mission Model contains data products.

## Changes

- generates `data_products.md` only when `model.data_products` is non-empty;
- adds a Data Product Contract Reference page with:
  - data product id;
  - producer;
  - product type;
  - estimated size;
  - priority;
  - storage intent;
  - downlink intent;
  - description;
- makes the page explicitly state that storage and downlink fields are contract intent only;
- adds tests for:
  - generating data product docs when data products are present;
  - skipping `data_products.md` when data products are absent.

## Boundary

This PR does not add:

- new model fields;
- new lint rules;
- demo mission `data_products.yaml`;
- scenario behavior;
- storage runtime;
- downlink runtime;
- contact windows;
- runtime skeletons;
- ground export logic.

## Related issue

Closes #64

## Validation

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
