### PR TITLE
demo: add synthetic data product contract

### DIFF
--- a/examples/demo-3u/mission/data_products.yaml
+++ b/examples/demo-3u/mission/data_products.yaml
@@ -1,0 +1,14 @@
+data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: science
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+    description: Synthetic payload histogram data product used to demonstrate Data Product Contracts.

--- a/tests/test_doc_generator.py
+++ b/tests/test_doc_generator.py
@@ -26,11 +26,13 @@ def test_generate_markdown_docs(tmp_path: Path) -> None:
         "modes.md",
         "packets.md",
         "payloads.md",
+        "data_products.md",
     }
 
     telemetry_doc = (tmp_path / "telemetry.md").read_text(encoding="utf-8")
     commands_doc = (tmp_path / "commands.md").read_text(encoding="utf-8")
     payloads_doc = (tmp_path / "payloads.md").read_text(encoding="utf-8")
+    data_products_doc = (tmp_path / "data_products.md").read_text(encoding="utf-8")
 
     assert "Telemetry Reference" in telemetry_doc
     assert "eps.battery.voltage" in telemetry_doc
@@ -39,6 +41,8 @@ def test_generate_markdown_docs(tmp_path: Path) -> None:
     assert "payload.start_acquisition" in commands_doc
     assert "Payload Contract Reference" in payloads_doc
     assert "demo_iod_payload" in payloads_doc
+    assert "Data Product Contract Reference" in data_products_doc
+    assert "payload.radiation_histogram" in data_products_doc
 
     faults_doc = (tmp_path / "faults.md").read_text(encoding="utf-8")
 
@@ -87,3 +91,4 @@ def test_gen_docs_cli_writes_markdown_files(tmp_path: Path) -> None:
     assert (output_dir / "modes.md").exists()
     assert (output_dir / "packets.md").exists()
     assert (output_dir / "payloads.md").exists()
+    assert (output_dir / "data_products.md").exists()

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -15,20 +15,20 @@ DEMO_MISSION = Path("examples/demo-3u/mission")
 
 def make_valid_data_product() -> DataProductContract:
     return DataProductContract(
-        id="payload.radiation_histogram",
+        id="payload.synthetic_histogram",
         producer="demo_iod_payload",
         producer_type="payload",
         type="histogram",
-        estimated_size_bytes=4096,
-        priority="high",
+        estimated_size_bytes=2048,
+        priority="medium",
         storage=DataProductStorageIntent(
             **{
                 "class": "science",
-                "retention": "7d",
+                "retention": "3d",
                 "overflow_policy": "drop_oldest",
             }
         ),
-        downlink=DataProductDownlinkIntent(policy="next_available_contact"),
+        downlink=DataProductDownlinkIntent(policy="priority_based"),
         description="Synthetic payload histogram data product.",
     )
 
@@ -68,9 +68,8 @@ def test_payload_contract_docs_are_skipped_without_payloads(tmp_path: Path) -> N
     assert not (tmp_path / "payloads.md").exists()
 
 
-def test_generate_data_product_contract_docs(tmp_path: Path) -> None:
+def test_generate_demo_data_product_contract_docs(tmp_path: Path) -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
-    model.data_products.append(make_valid_data_product())
 
     generated_files = generate_markdown_docs(model, tmp_path)
 
@@ -93,13 +92,35 @@ def test_generate_data_product_contract_docs(tmp_path: Path) -> None:
     assert "retention `7d`" in content
     assert "overflow `drop_oldest`" in content
     assert "policy `next_available_contact`" in content
-    assert "Synthetic payload histogram data product." in content
+    assert "Synthetic payload histogram data product used to demonstrate" in content
+
+
+def test_generate_data_product_contract_docs_from_model_object(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.data_products = [make_valid_data_product()]
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    data_products_path = tmp_path / "data_products.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "data_products.md" in generated_names
+    assert data_products_path.exists()
+
+    content = data_products_path.read_text(encoding="utf-8")
+
+    assert "`payload.synthetic_histogram`" in content
+    assert "2048" in content
+    assert "`medium`" in content
+    assert "retention `3d`" in content
+    assert "policy `priority_based`" in content
 
 
 def test_data_product_contract_docs_are_skipped_without_data_products(
     tmp_path: Path,
 ) -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
+    model.data_products = []
 
     generated_files = generate_markdown_docs(model, tmp_path)
     generated_names = {path.name for path in generated_files}

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -10,18 +10,18 @@ from orbitfabric.model.loader import MissionModelLoader
 DEMO_MISSION = Path("examples/demo-3u/mission")
 
 VALID_DATA_PRODUCTS_YAML = """data_products:
-  - id: payload.radiation_histogram
+  - id: payload.synthetic_histogram
     producer: demo_iod_payload
     producer_type: payload
     type: histogram
-    estimated_size_bytes: 4096
-    priority: high
+    estimated_size_bytes: 2048
+    priority: medium
     storage:
       class: science
-      retention: 7d
+      retention: 3d
       overflow_policy: drop_oldest
     downlink:
-      policy: next_available_contact
+      policy: priority_based
     description: Synthetic payload data product used to validate data product contracts.
 """
 
@@ -109,20 +109,8 @@ def test_invalid_payloads_top_level_key_fails(tmp_path: Path) -> None:
     assert "OF-STR-002" in codes
 
 
-def test_optional_data_products_file_can_be_absent() -> None:
+def test_load_demo_data_product_contract() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
-
-    assert model.data_products == []
-
-
-def test_load_valid_data_product_contract(tmp_path: Path) -> None:
-    mission_dir = copy_demo_mission(tmp_path)
-    (mission_dir / "data_products.yaml").write_text(
-        VALID_DATA_PRODUCTS_YAML,
-        encoding="utf-8",
-    )
-
-    model = MissionModelLoader().load(mission_dir)
 
     assert len(model.data_products) == 1
     data_product = model.data_products[0]
@@ -141,6 +129,51 @@ def test_load_valid_data_product_contract(tmp_path: Path) -> None:
     assert data_product.downlink.policy == "next_available_contact"
     assert data_product.description is not None
     assert model.data_product_ids == {"payload.radiation_histogram"}
+
+
+def test_optional_data_products_file_can_be_absent(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        if source_file.name == "data_products.yaml":
+            continue
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert model.data_products == []
+
+
+def test_load_valid_data_product_contract(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "data_products.yaml").write_text(
+        VALID_DATA_PRODUCTS_YAML,
+        encoding="utf-8",
+    )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert len(model.data_products) == 1
+    data_product = model.data_products[0]
+
+    assert data_product.id == "payload.synthetic_histogram"
+    assert data_product.producer == "demo_iod_payload"
+    assert data_product.producer_type == "payload"
+    assert data_product.type == "histogram"
+    assert data_product.estimated_size_bytes == 2048
+    assert data_product.priority == "medium"
+    assert data_product.storage is not None
+    assert data_product.storage.storage_class == "science"
+    assert data_product.storage.retention == "3d"
+    assert data_product.storage.overflow_policy == "drop_oldest"
+    assert data_product.downlink is not None
+    assert data_product.downlink.policy == "priority_based"
+    assert data_product.description is not None
+    assert model.data_product_ids == {"payload.synthetic_histogram"}
 
 
 def test_invalid_data_products_top_level_key_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR updates the synthetic `demo-3u` mission with one Data Product Contract.

It completes the first v0.3 Data Product and Storage Contract tranche by showing the relationship:

```text
Payload Contract -> Data Product Contract -> Storage Intent -> Downlink Intent
```

## Changes

- adds `examples/demo-3u/mission/data_products.yaml`;
- defines one synthetic payload data product:
  - `payload.radiation_histogram`;
  - producer: `demo_iod_payload`;
  - type: `histogram`;
  - estimated size: `4096` bytes;
  - priority: `high`;
  - storage class: `science`;
  - retention: `7d`;
  - overflow policy: `drop_oldest`;
  - downlink policy: `next_available_contact`;
- updates loader tests to assert the demo data product is loaded;
- keeps optional `data_products.yaml` absence covered with a copied mission fixture;
- updates docs generator tests to assert demo data product docs are generated.

## Boundary

This PR does not add:

- new model fields;
- new lint rules;
- new generated documentation logic;
- scenario behavior;
- storage runtime;
- downlink runtime;
- contact windows;
- runtime skeletons;
- ground export logic.

## Related issue

Closes #66

## Validation

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
