### PR TITLE
release: align v0.3.0 Data Product Contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OrbitFabric will be documented in this file.
 
-This project follows a lightweight pre-1.0 changelog style while the Mission Model, Payload Contract Model and CLI stabilize.
+This project follows a lightweight pre-1.0 changelog style while the Mission Model, Payload Contract Model, Data Product Contract Model and CLI stabilize.
 
 ---
 
@@ -10,7 +10,70 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ### Changed
 
-- Public documentation, roadmap and release alignment work for the Payload Contract Model is ongoing under `v0.2.2 — Payload Contract Release Alignment`.
+- Next development focus: `v0.4 — Contact Windows and Downlink Flow Contracts`.
+
+---
+
+## [v0.3.0] — Data Product and Storage Contracts
+
+### Added
+
+- Added the Data Product Contract Model as an optional mission model domain.
+- Added optional `mission/data_products.yaml` loading.
+- Added the `DataProductContract` model.
+- Added data product producer type support.
+- Added data product type support.
+- Added estimated data product size support.
+- Added data product priority support.
+- Added storage intent fields.
+- Added storage class support.
+- Added retention intent support.
+- Added overflow policy support.
+- Added downlink intent fields.
+- Added downlink policy support.
+- Added semantic lint rules for Data Product Contracts.
+- Added data product producer reference checks.
+- Added optional payload reference checks.
+- Added storage intent warnings for missing retention and overflow policy.
+- Added downlink intent warnings for high-priority data products.
+- Added generated data product documentation.
+- Added generated `data_products.md` documentation output.
+- Added invalid data product fixtures and tests.
+- Added one synthetic data product to the `demo-3u` mission.
+- Added ADR-0008 for Data Product and Storage Contracts.
+
+### Changed
+
+- Extended the synthetic `demo-3u` mission with a clean-room payload data product.
+- Extended generated mission documentation to include Data Product Contract references when data products are present.
+- Reinforced the Mission Data Chain direction introduced by ADR-0007.
+- Moved OrbitFabric one step further from payload behavior modeling toward explicit mission data chain modeling.
+
+### Boundaries
+
+The Data Product and Storage Contract slice intentionally does not introduce:
+
+- real onboard storage runtime;
+- file-system abstraction;
+- compression engines;
+- payload data processing pipelines;
+- contact window modeling;
+- RF link modeling;
+- downlink runtime;
+- ground segment export;
+- runtime skeleton generation;
+- real payload data.
+
+---
+
+## [v0.2.2] — Payload Contract Release Alignment
+
+### Changed
+
+- Aligned README, public documentation, roadmap, changelog, release notes and package version around the Payload Contract Model.
+- Documented `v0.2.2` as the Payload Contract Release Alignment baseline.
+- Added release notes for `v0.2.2`.
+- Prepared public communication material for the Payload Contract Model.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets and operational scenarios once.  
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products and operational scenarios once.  
 Validate them, document them, and execute deterministic mission scenarios from the same source of truth.
 
 </div>
@@ -40,21 +40,28 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is currently in the `v0.2.x` development line.
+OrbitFabric is currently at `v0.3.0 — Data Product and Storage Contracts`.
 
-The current repository includes the `v0.2.1 — Payload Contract Model` vertical slice, which extends the Mission Data Contract with an optional Payload / IOD Payload Contract domain.
+The current repository includes:
+
+- the `v0.2.1 — Payload Contract Model` vertical slice;
+- the `v0.2.3 — Mission Data Chain Roadmap Alignment` direction;
+- the `v0.3.0 — Data Product and Storage Contracts` vertical slice.
 
 The current vertical slice is functional:
 
 - Mission Model YAML loading;
 - optional `payloads.yaml` loading;
+- optional `data_products.yaml` loading;
 - structural validation;
 - semantic linting;
 - engineering lint rules;
 - payload contract lint rules;
+- data product contract lint rules;
 - JSON lint report generation;
 - generated Markdown documentation;
 - generated payload contract documentation;
+- generated data product contract documentation;
 - scenario YAML loading;
 - scenario reference validation;
 - deterministic scenario execution;
@@ -89,7 +96,8 @@ It models:
 - packets;
 - scenarios;
 - persistence and downlink policies;
-- optional Payload / IOD Payload Contracts.
+- optional Payload / IOD Payload Contracts;
+- optional Data Product and Storage Contracts.
 
 A payload contract describes mission-specific or IOD payload behavior as a declarative contract. It may reference:
 
@@ -102,7 +110,19 @@ A payload contract describes mission-specific or IOD payload behavior as a decla
 - expected effects;
 - generated payload documentation.
 
-Payload contracts are part of the Mission Data Contract. They do not describe payload firmware, payload drivers, hardware buses, onboard services or physical payload simulation.
+A data product contract describes a mission-data object produced by a payload or subsystem. It may define:
+
+- producer reference;
+- product type;
+- estimated size;
+- priority;
+- storage intent;
+- retention intent;
+- overflow policy;
+- downlink intent;
+- generated data product documentation.
+
+Payload and Data Product Contracts are part of the Mission Data Contract. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution or real downlink runtime behavior.
 
 From that model, OrbitFabric currently provides:
 
@@ -123,6 +143,12 @@ Optional Payload Contract Model
         -> payload lifecycle validation
         -> payload documentation generation
         -> payload-aware scenario behavior
+
+Optional Data Product Contract Model
+        -> producer reference validation
+        -> storage intent validation
+        -> downlink intent validation
+        -> data product documentation generation
 ```
 
 ---
@@ -139,11 +165,13 @@ OrbitFabric is not:
 - a CCSDS/PUS/CFDP implementation;
 - a hardware abstraction layer;
 - a CubeSat tutorial;
-- a ground segment.
+- a ground segment;
 - a payload firmware framework;
 - a payload driver framework;
 - a payload physical simulator;
 - a payload data processing pipeline;
+- an onboard storage runtime;
+- a downlink runtime.
 
 Those may become future integration targets or generated artifacts, but they are not part of the current development preview.
 
@@ -165,12 +193,13 @@ examples/demo-3u/
 │   ├── faults.yaml
 │   ├── packets.yaml
 │   ├── policies.yaml
-│   └── payloads.yaml
+│   ├── payloads.yaml
+│   └── data_products.yaml
 └── scenarios/
     └── battery_low_during_payload.yaml
 ```
 
-The demo also includes a synthetic IOD payload contract:
+The demo includes a synthetic IOD payload contract:
 
 ```text
 demo_iod_payload
@@ -179,7 +208,25 @@ demo_iod_payload
         lifecycle: READY -> ACQUIRING -> READY
 ```
 
-This payload contract groups payload-specific telemetry, commands, events and lifecycle behavior without introducing payload firmware or hardware integration.
+The demo also includes one synthetic payload data product:
+
+```text
+payload.radiation_histogram
+        producer: demo_iod_payload
+        type: histogram
+        estimated size: 4096 bytes
+        storage: science, retention 7d, drop_oldest
+        downlink: next_available_contact
+```
+
+This demonstrates the relationship:
+
+```text
+Payload Contract
+        -> Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+```
 
 The demo contains:
 
@@ -228,7 +275,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.2.0.dev0
+orbitfabric 0.3.0
 ```
 
 ---
@@ -280,7 +327,8 @@ generated/docs/
 ├── faults.md
 ├── modes.md
 ├── packets.md
-└── payloads.md
+├── payloads.md
+└── data_products.md
 ```
 
 These files are generated from the validated Mission Model. Do not edit them manually.
@@ -364,7 +412,8 @@ generated/
 │   ├── faults.md
 │   ├── modes.md
 │   ├── packets.md
-│   └── payloads.md
+│   ├── payloads.md
+│   └── data_products.md
 ├── reports/
 │   ├── lint_report.json
 │   └── battery_low_during_payload_report.json
@@ -379,6 +428,7 @@ The source of truth remains:
 ```text
 examples/demo-3u/mission/*.yaml
 examples/demo-3u/mission/payloads.yaml
+examples/demo-3u/mission/data_products.yaml
 examples/demo-3u/scenarios/*.yaml
 ```
 
@@ -427,6 +477,8 @@ Useful entry points:
 - `docs/ROADMAP.md`
 - `docs/DEVELOPMENT.md`
 - `docs/reference/mission-model-v0.1.md`
+- `docs/reference/payload-contract-model.md`
+- `docs/reference/data-product-contract-model.md`
 - `docs/adr/`
 
 Build the documentation site locally:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,14 +1,14 @@
 # OrbitFabric — Roadmap
 
-Version: v0.2.3 planning  
+Version: v0.3.0  
 Status: Development preview  
-Scope: v0.2.x to v1.0 planning
+Scope: v0.3 to v1.0 planning
 
 ---
 
 ## 1. Roadmap Principle
 
-OrbitFabric must grow through coherent vertical slices, not through feature accumulation.
+OrbitFabric grows through coherent vertical slices, not through feature accumulation.
 
 The project must not try to become, at the same time:
 
@@ -29,7 +29,10 @@ Mission Model
         -> scenario simulation
         -> generated documentation
         -> payload contracts
-        -> mission data chain contracts
+        -> data product and storage contracts
+        -> contact and downlink contracts
+        -> commandability and autonomy contracts
+        -> end-to-end mission data flow evidence
         -> runtime skeletons
         -> ground integration artifacts
         -> plugins and extensibility
@@ -39,7 +42,7 @@ Every milestone must reinforce the core identity:
 
 > OrbitFabric is a Mission Data Contract framework.
 
-The next major architectural objective is to model the mission data chain from payload behavior to onboard storage, downlink assumptions, contact windows, commandability, recovery behavior and ground-facing artifacts.
+The current architectural objective is to model the mission data chain from payload behavior to data products, onboard storage intent, downlink assumptions, contact windows, commandability, recovery behavior and ground-facing artifacts.
 
 ---
 
@@ -69,9 +72,9 @@ v0.1    Mission Contract MVP                                  completed
 v0.2    Model Hardening                                       completed line
 v0.2.1  Payload Contract Model                                completed
 v0.2.2  Payload Contract Release Alignment                    completed
-v0.2.3  Mission Data Chain Roadmap Alignment                  immediate
-v0.3    Data Product and Storage Contracts                    future
-v0.4    Contact Windows and Downlink Flow Contracts           future
+v0.2.3  Mission Data Chain Roadmap Alignment                  completed
+v0.3.0  Data Product and Storage Contracts                    completed
+v0.4    Contact Windows and Downlink Flow Contracts           next
 v0.5    Commandability and Autonomy Contracts                 future
 v0.6    End-to-End Mission Data Flow Evidence                 future
 v0.7    Generated Runtime Skeletons                           future
@@ -80,11 +83,9 @@ v0.9    Plugin and Extensibility Layer                        future
 v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target is `v0.2.3`.
+The immediate target is `v0.4 — Contact Windows and Downlink Flow Contracts`.
 
-The next implementation priority is not runtime generation.
-
-The next priority is to formalize the Mission Data Chain roadmap after the Payload Contract Model vertical slice.
+Runtime skeleton generation remains deferred until the Mission Data Chain is coherent enough to generate useful artifacts from it.
 
 ---
 
@@ -94,15 +95,13 @@ The next priority is to formalize the Mission Data Chain roadmap after the Paylo
 
 Demonstrate the complete OrbitFabric philosophy with one small, coherent, synthetic mission.
 
-v0.1 proves that a user can:
+v0.1 proved that a user can:
 
 1. define a mission once;
 2. lint it semantically;
 3. generate documentation;
 4. execute an operational scenario;
 5. receive readable logs and JSON reports.
-
-The v0.1 goal was coherence, not breadth.
 
 ### 4.2 Capabilities
 
@@ -181,41 +180,17 @@ invalid payload contract fixtures
 negative tests for mutated fixtures
 ```
 
-The current payload lifecycle model is intentionally minimal:
-
-```text
-OFF
-READY
-ACQUIRING
-FAULT
-```
-
 The first demo payload vertical slice demonstrates:
 
 ```text
 READY -> ACQUIRING -> READY
 ```
 
-### 5.3 Payload Contract Boundary
+### 5.3 Boundary
 
-A payload contract may describe:
+Payload contracts may describe expected mission-data behavior.
 
-```text
-payload identity
-payload profile
-linked subsystem
-telemetry references
-command references
-event references
-fault references
-lifecycle states
-command preconditions
-expected effects
-scenario-level behavior
-generated documentation
-```
-
-A payload contract must not describe:
+They must not describe:
 
 ```text
 payload firmware
@@ -228,10 +203,6 @@ thermal, optical or scientific simulation
 ground segment implementation
 ```
 
-The Payload Contract Model strengthens OrbitFabric as a Mission Data Contract Layer.
-
-It does not expand OrbitFabric into a payload runtime.
-
 ---
 
 ## 6. Completed Alignment — v0.2.2 Payload Contract Release Alignment
@@ -240,8 +211,7 @@ It does not expand OrbitFabric into a payload runtime.
 
 Capitalise on the completed Payload Contract Model vertical slice.
 
-v0.2.2 is a release-alignment milestone.
-It makes the repository, public documentation, roadmap, changelog, release notes and public communication consistent with the Payload Contract Model.
+v0.2.2 made the repository, public documentation, roadmap, changelog, release notes and public communication consistent with the Payload Contract Model.
 
 ### 6.2 Completed Work
 
@@ -258,9 +228,9 @@ Payload Contract Model communication
 
 ### 6.3 Boundary
 
-v0.2.2 did not introduce new core model features.
+v0.2.2 was alignment work, not model expansion.
 
-It did not include:
+It did not introduce:
 
 ```text
 new payload lifecycle states
@@ -274,11 +244,9 @@ payload runtime behavior
 physical payload simulation
 ```
 
-The purpose of v0.2.2 was alignment, not expansion.
-
 ---
 
-## 7. Immediate Milestone — v0.2.3 Mission Data Chain Roadmap Alignment
+## 7. Completed Alignment — v0.2.3 Mission Data Chain Roadmap Alignment
 
 ### 7.1 Objective
 
@@ -300,23 +268,23 @@ Payload behavior
         -> future runtime and ground artifacts
 ```
 
-### 7.2 Required Work
+### 7.2 Completed Work
 
-v0.2.3 should include:
+v0.2.3 introduced:
 
 ```text
 ROADMAP update
 Project Charter alignment
-ADR for Mission Data Chain before runtime generation
+ADR-0007 Mission Data Chain Before Runtime Generation
 public documentation navigation update
-issue backlog alignment if needed
+issue backlog alignment
 ```
 
-### 7.3 Required Boundary
+### 7.3 Boundary
 
-v0.2.3 must remain documentation-first and architecture-first.
+v0.2.3 remained documentation-first and architecture-first.
 
-It must not introduce:
+It did not introduce:
 
 ```text
 data_products.yaml
@@ -329,11 +297,9 @@ ground export
 plugin API
 ```
 
-The milestone exists to make the next implementation sequence explicit before adding new model domains.
-
 ---
 
-## 8. Future Milestone — v0.3 Data Product and Storage Contracts
+## 8. Completed Slice — v0.3.0 Data Product and Storage Contracts
 
 ### 8.1 Objective
 
@@ -355,9 +321,12 @@ diagnostic dump
 compressed payload product
 ```
 
-### 8.2 Candidate Features
+### 8.2 Completed Capabilities
+
+v0.3.0 introduced:
 
 ```text
+Data Product and Storage Contract ADR
 optional data_products.yaml domain
 DataProductContract model
 data product producer reference
@@ -366,33 +335,47 @@ data product type
 estimated size
 priority
 storage class
-retention policy
+retention intent
 overflow policy
 downlink intent
+data product semantic lint rules
 generated data product documentation
-data product lint rules
 invalid data product fixtures
+synthetic demo mission data product
 ```
 
-### 8.3 Candidate Lint Rules
+### 8.3 Implemented Lint Direction
+
+The first data product lint slice covers:
 
 ```text
-ERROR: data product references unknown producer.
-ERROR: data product references unknown payload.
-ERROR: data product has no estimated size.
-WARNING: high-priority data product has no downlink policy.
-WARNING: retained data product has no overflow policy.
+producer reference must be known
+optional payload reference must be known
+storage intent should define retention
+storage intent should define overflow_policy
+high-priority data product should define downlink intent
+```
+
+Structural validation covers:
+
+```text
+unique data product IDs
+positive estimated size
+known priority values
+known storage class values
+known overflow policy values
+known downlink policy values
 ```
 
 ### 8.4 Boundary
 
-v0.3 must not implement real storage, file systems, compression, payload processing pipelines or downlink runtime behavior.
+v0.3.0 does not implement real storage, file systems, compression, payload processing pipelines, contact windows or downlink runtime behavior.
 
-It must only describe the contract.
+It describes contract intent only.
 
 ---
 
-## 9. Future Milestone — v0.4 Contact Windows and Downlink Flow Contracts
+## 9. Next Milestone — v0.4 Contact Windows and Downlink Flow Contracts
 
 ### 9.1 Objective
 
@@ -458,16 +441,7 @@ command inhibition rules
 autonomy rule documentation
 ```
 
-### 10.3 Candidate Lint Rules
-
-```text
-ERROR: autonomous command has no expected effect.
-WARNING: ground-only command is used in autonomous recovery scenario.
-ERROR: command requires contact but scenario dispatches it outside contact.
-WARNING: risky command lacks operator confirmation hint.
-```
-
-### 10.4 Boundary
+### 10.3 Boundary
 
 v0.5 must not implement real command authentication, authorization, encryption, live uplink, operator consoles or flight-ready autonomy.
 
@@ -783,20 +757,19 @@ They must not become a live ground segment inside OrbitFabric.
 The immediate work package is:
 
 ```text
-v0.2.3 — Mission Data Chain Roadmap Alignment
+v0.4 — Contact Windows and Downlink Flow Contracts
 ```
 
 Required sequence:
 
 ```text
-1. ROADMAP alignment
-2. Project Charter alignment
-3. Mission Data Chain ADR
-4. public documentation navigation update
-5. issue backlog alignment if needed
+1. define contact/downlink contract scope
+2. add ADR for Contact Windows and Downlink Flow Contracts
+3. introduce optional contact/link model domain
+4. add semantic lint rules for contact/downlink references
+5. generate contact/downlink documentation
+6. update the synthetic demo mission with one clean contact/downlink slice
 ```
-
-Do not start v0.3 implementation until v0.2.3 is complete.
 
 Do not add runtime skeletons before the mission data chain model is coherent.
 
@@ -812,7 +785,9 @@ OrbitFabric must first become excellent at one thing:
 
 The Payload Contract Model strengthens this mission by making mission-specific and IOD payload behavior explicit, lintable, documentable and scenario-aware.
 
-The Mission Data Chain roadmap extends that foundation by making payload data products, storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations and end-to-end scenario evidence explicit before runtime or ground artifacts are generated.
+The Data Product and Storage Contract Model strengthens the mission data chain by making payload and subsystem data products, storage intent and downlink intent explicit.
+
+The next roadmap step is to model contact windows and downlink flow assumptions before runtime or ground artifacts are generated.
 
 Only after the model is clear and stable should OrbitFabric grow into runtime skeleton generation, ground integration artifacts and plugin extensibility.
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,131 @@
+# OrbitFabric v0.3.0 — Data Product and Storage Contracts
+
+Status: development preview  
+Release type: model and documentation release  
+Primary focus: Data Product and Storage Contracts
+
+## Summary
+
+OrbitFabric v0.3.0 introduces the first Data Product and Storage Contract slice.
+
+This release extends the Mission Data Contract beyond payload behavior and into the first concrete layer of the Mission Data Chain:
+
+```text
+Payload Contract
+        -> Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+```
+
+The main result is that OrbitFabric can now describe optional mission data products produced by payloads or subsystems, validate them structurally and semantically, generate documentation for them and demonstrate them in the synthetic `demo-3u` mission.
+
+## Highlights
+
+- Optional `mission/data_products.yaml` model domain.
+- `DataProductContract` model.
+- Data product producer references.
+- Data product type support.
+- Estimated data product size.
+- Data product priority.
+- Storage intent.
+- Storage class.
+- Retention intent.
+- Overflow policy.
+- Downlink intent.
+- Downlink policy.
+- Semantic lint rules for data products.
+- Generated `data_products.md` documentation.
+- Invalid data product fixtures and tests.
+- Synthetic demo mission data product.
+- ADR-0008 for Data Product and Storage Contracts.
+
+## What Data Product Contracts Describe
+
+Data Product Contracts may describe:
+
+- data product identity;
+- producer reference;
+- producer type;
+- optional payload reference;
+- product type;
+- estimated size;
+- priority;
+- storage class;
+- retention intent;
+- overflow policy;
+- downlink intent.
+
+## What Data Product Contracts Do Not Describe
+
+Data Product Contracts do not describe:
+
+- real onboard storage runtime;
+- file-system implementation;
+- compression engines;
+- payload data processing pipelines;
+- physical payload simulation;
+- contact window modeling;
+- RF link modeling;
+- downlink runtime;
+- ground segment implementation;
+- runtime skeleton generation.
+
+## Demo Mission Addition
+
+The synthetic `demo-3u` mission now includes one clean-room data product:
+
+```yaml
+data_products:
+  - id: payload.radiation_histogram
+    producer: demo_iod_payload
+    producer_type: payload
+    type: histogram
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: science
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+```
+
+This demonstrates the relationship between a payload contract, a produced mission-data object, storage intent and downlink intent.
+
+## Positioning
+
+OrbitFabric remains a Mission Data Contract framework.
+
+This release does not turn OrbitFabric into:
+
+- a flight software framework;
+- an onboard storage runtime;
+- a payload processing pipeline;
+- a physical simulator;
+- a ground segment;
+- a CCSDS/PUS/CFDP implementation;
+- a runtime code generator.
+
+## Compatibility
+
+OrbitFabric is still pre-1.0.
+
+The Mission Model, Payload Contract Model and Data Product Contract Model may evolve before v1.0.
+
+## Verification
+
+Expected verification commands:
+
+```text
+ruff check .
+pytest
+mkdocs build --strict
+```
+
+The demo mission should also pass:
+
+```text
+orbitfabric lint examples/demo-3u/mission/
+orbitfabric gen docs examples/demo-3u/mission/
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.2.2"
+version = "0.3.0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary

This PR aligns the repository after completion of the first `v0.3.0 — Data Product and Storage Contracts` tranche.

It updates the version, changelog, roadmap, README and release notes around the new Data Product Contract Model.

## Changes

- bumps package version from `0.2.2` to `0.3.0`;
- updates `orbitfabric.__version__` to `0.3.0`;
- adds `docs/releases/v0.3.0.md`;
- updates `CHANGELOG.md` with the v0.3.0 Data Product and Storage Contracts entry;
- updates `README.md` for:
  - `v0.3.0` current status;
  - optional `data_products.yaml`;
  - Data Product Contract Model positioning;
  - generated `data_products.md` output;
  - demo mission tree;
  - expected CLI version;
- updates `docs/ROADMAP.md` to mark:
  - `v0.2.3` as completed;
  - `v0.3.0` as completed;
  - `v0.4 — Contact Windows and Downlink Flow Contracts` as the next work package.

## Boundary

This PR is release/documentation alignment.

It intentionally does not add:

- new model fields;
- new lint rules;
- new simulator behavior;
- storage runtime;
- downlink runtime;
- contact windows;
- runtime skeletons;
- ground export logic.

## Validation

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric --version
orbitfabric lint examples/demo-3u/mission/
orbitfabric gen docs examples/demo-3u/mission/
orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
```
