### PR TITLE
docs: polish v0.3 public documentation

### DIFF
--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -39,7 +39,9 @@ examples/demo-3u/
 │   ├── events.yaml
 │   ├── faults.yaml
 │   ├── packets.yaml
-│   └── policies.yaml
+│   ├── policies.yaml
+│   ├── payloads.yaml
+│   └── data_products.yaml
 └── scenarios/
     └── battery_low_during_payload.yaml
 ```
@@ -141,6 +143,38 @@ Defines synthetic packet groupings for generated documentation and future integr
 
 Defines allowed policy values used by the model.
 
+### `payloads.yaml`
+
+Defines the synthetic IOD payload contract:
+
+```text
+demo_iod_payload
+```
+
+The contract describes payload lifecycle, telemetry references, accepted commands and generated events without introducing payload firmware, drivers or physical simulation.
+
+### `data_products.yaml`
+
+Defines one synthetic data product:
+
+```text
+payload.radiation_histogram
+```
+
+It is produced by `demo_iod_payload` and declares:
+
+```text
+type: histogram
+estimated size: 4096 bytes
+priority: high
+storage class: science
+retention: 7d
+overflow policy: drop_oldest
+downlink policy: next_available_contact
+```
+
+This is contract intent only. It does not implement storage or downlink execution.
+
 ---
 
 ## 4. Scenario: battery low during payload operation
@@ -186,6 +220,10 @@ payload.start_acquisition
 → SCENARIO PASSED
 ```
 
+The data product contract is not executed by this scenario yet.
+
+It documents the expected mission-data object produced by the payload and prepares the model for future contact/downlink contracts.
+
 ---
 
 ## 6. Run the scenario
@@ -219,13 +257,39 @@ generated/logs/battery_low_during_payload.log
 
 ---
 
-## 8. What the simulator checks
+## 8. Generate mission documentation
+
+```bash
+orbitfabric gen docs examples/demo-3u/mission/
+```
+
+Generated files:
+
+```text
+generated/docs/
+├── telemetry.md
+├── commands.md
+├── events.md
+├── faults.md
+├── modes.md
+├── packets.md
+├── payloads.md
+└── data_products.md
+```
+
+The generated data product documentation exposes storage and downlink intent as contract data, not runtime behavior.
+
+---
+
+## 9. What the simulator checks
 
 During execution, OrbitFabric checks that:
 
 - commands exist in the Mission Model;
 - commands are allowed in the current mode;
 - expected command effects are applied;
+- payload lifecycle preconditions are respected;
+- payload lifecycle expected effects are applied;
 - events are emitted;
 - telemetry injections update simulation state;
 - fault conditions are evaluated;
@@ -235,12 +299,13 @@ During execution, OrbitFabric checks that:
 
 ---
 
-## 9. Expected final state
+## 10. Expected final state
 
 At the end of the scenario:
 
 ```text
 mode = DEGRADED
+payload lifecycle = READY
 payload.acquisition.active = false
 scenario_status = PASSED
 ```
@@ -252,11 +317,12 @@ EPS warning fault
   -> transition to DEGRADED
   -> auto-dispatch payload.stop_acquisition
   -> payload acquisition inactive
+  -> payload lifecycle READY
 ```
 
 ---
 
-## 10. Clean-room boundary
+## 11. Clean-room boundary
 
 This demo is deliberately synthetic.
 
@@ -269,6 +335,8 @@ It must not include:
 - real thresholds from private missions;
 - real operational procedures;
 - real telemetry logs;
-- real anomaly sequences.
+- real anomaly sequences;
+- real payload data;
+- real storage or downlink policies.
 
 The demo exists to prove OrbitFabric's architecture, not to approximate a real spacecraft.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,6 +15,8 @@ Mission Model YAML
   -> scenario validation
   -> scenario loading
   -> deterministic scenario execution
+  -> Payload Contract documentation
+  -> Data Product Contract documentation
   -> JSON reports
   -> simulation log
 ```
@@ -80,7 +82,7 @@ orbitfabric --help
 Expected version for the current development preview:
 
 ```text
-orbitfabric 0.2.0.dev0
+orbitfabric 0.3.0
 ```
 
 ---
@@ -167,7 +169,9 @@ generated/docs/
 ├── events.md
 ├── faults.md
 ├── modes.md
-└── packets.md
+├── packets.md
+├── payloads.md
+└── data_products.md
 ```
 
 Generated mission documentation is derived from the validated Mission Model.
@@ -210,9 +214,12 @@ generated/logs/battery_low_during_payload.log
 The current demo proves that OrbitFabric can:
 
 - load a multi-file YAML Mission Model;
-- validate its structure;
+- load optional `payloads.yaml` and `data_products.yaml` domains;
+- validate Mission Model structure;
 - run semantic lint rules;
+- validate payload and data product references;
 - generate Markdown documentation;
+- generate payload and data product documentation;
 - inspect a Mission Model summary;
 - validate a scenario without executing it;
 - load a scenario;
@@ -231,9 +238,12 @@ The current demo does not prove:
 - flight readiness;
 - real-time behavior;
 - hardware integration;
+- real onboard storage execution;
+- real downlink execution;
+- contact window modeling;
 - CCSDS, PUS or CFDP compliance;
 - compatibility with cFS, F Prime, Yamcs or OpenC3;
 - orbital, attitude, power or thermal dynamics;
 - qualification for operational spacecraft use.
 
-Those are intentionally outside the current v0.2.0 development preview scope.
+Those are intentionally outside the current v0.3.0 development preview scope.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,30 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets and scenarios in a single Mission Data Contract.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products and scenarios in a single Mission Data Contract.
 
 From that contract, OrbitFabric validates consistency, generates documentation and executes host-side operational scenarios.
+
+## Current development preview
+
+OrbitFabric is currently at:
+
+```text
+v0.3.0 — Data Product and Storage Contracts
+```
+
+The current public preview includes:
+
+- Mission Model YAML loading;
+- structural validation;
+- semantic linting;
+- generated Markdown documentation;
+- deterministic scenario execution;
+- optional Payload / IOD Payload Contracts;
+- optional Data Product and Storage Contracts;
+- generated payload documentation;
+- generated data product documentation;
+- a clean-room synthetic `demo-3u` mission.
 
 ## Core Idea
 
@@ -13,5 +34,12 @@ Mission Model
   -> lint
   -> documentation
   -> scenario simulation
+  -> payload contracts
+  -> data product and storage contracts
+  -> future contact/downlink contracts
   -> future runtime and ground artifacts
 ```
+
+OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
+
+It is the contract layer between mission design, onboard software, simulation, testing, documentation and future ground integration artifacts.

--- a/docs/reference/lint-rules-v0.1.md
+++ b/docs/reference/lint-rules-v0.1.md
@@ -1,6 +1,12 @@
-# Diagnostics and Lint Rules v0.1
+# Diagnostics and Lint Rules
 
-This page documents the diagnostics and lint rules currently implemented by OrbitFabric v0.1.0 development preview.
+This page documents the diagnostics and lint rules currently implemented by OrbitFabric.
+
+Current documented baseline:
+
+```text
+v0.3.0 — Data Product and Storage Contracts
+```
 
 OrbitFabric diagnostics are intentionally actionable. A diagnostic should tell the user:
 
@@ -62,16 +68,6 @@ OrbitFabric diagnostics expose a common diagnostic shape across Mission Model lo
 
 The `suggestion` field is intentionally optional, but it should be provided whenever OrbitFabric can recommend a clear and safe corrective action.
 
-Examples:
-
-```text
-ERROR OF-SYN-002 telemetry.yaml required Mission Model file is missing Suggestion: Add the required Mission Model file 'telemetry.yaml'.
-
-ERROR OF-SCN-001 scenario.yaml battery_low_during_payload scenario command references unknown command 'payload.unknown_command' Suggestion: Use a command defined in commands.yaml.
-```
-
-Loader diagnostics and lint findings are implemented by different internal types, but they should remain aligned at the user-facing level.
-
 ---
 
 ## Rule families
@@ -88,6 +84,8 @@ Loader diagnostics and lint findings are implemented by different internal types
 | `OF-FLT-*` | Fault engineering lint rules. |
 | `OF-MODE-*` | Mode and mode-transition diagnostics. |
 | `OF-PKT-*` | Packet engineering lint rules. |
+| `OF-PAY-*` | Payload Contract lint rules. |
+| `OF-DP-*` | Data Product Contract lint rules. |
 | `OF-SCN-*` | Scenario loading and scenario reference diagnostics. |
 
 ---
@@ -118,6 +116,13 @@ packets.yaml
 policies.yaml
 ```
 
+Current optional Mission Model files:
+
+```text
+payloads.yaml
+data_products.yaml
+```
+
 ---
 
 ## `OF-STR-*` — Structural diagnostics
@@ -129,12 +134,6 @@ These diagnostics are produced during Mission Model structural validation.
 | `OF-STR-001` | `ERROR` | top-level key | A required top-level key is missing from a Mission Model YAML file. | Add the expected top-level key. |
 | `OF-STR-002` | `ERROR` | top-level key | An unexpected top-level key was found in a Mission Model YAML file. | Remove or rename the unexpected key. |
 | `OF-STR-003` | `ERROR` | typed model validation | Pydantic model validation failed. | Fix the field type, required field or invalid value. |
-
-Example:
-
-```text
-ERROR OF-STR-001 telemetry.yaml telemetry missing required top-level key 'telemetry'
-```
 
 ---
 
@@ -154,6 +153,8 @@ commands
 events
 faults
 packets
+payloads
+data_products
 ```
 
 ---
@@ -174,12 +175,6 @@ These rules check that Mission Model objects reference existing objects.
 | `OF-REF-008` | `ERROR` | commands | Command allowed mode does not reference an existing mode. | Add the mode or fix `allowed_modes`. |
 | `OF-REF-009` | `ERROR` | faults | Fault recovery references an unknown target mode. | Add the mode or fix `recovery.mode_transition`. |
 | `OF-REF-010` | `ERROR` | packets | Packet references unknown telemetry. | Add the telemetry item or fix packet `telemetry`. |
-
-Example:
-
-```text
-ERROR OF-REF-005 faults.yaml eps.battery_low_fault fault condition references unknown telemetry 'eps.battery.vbat'
-```
 
 ---
 
@@ -214,14 +209,6 @@ float64
 | `OF-CMD-006` | `WARNING` | commands | Command should define expected effects. | Add `expected_effects` or explicitly justify no expected effects. |
 | `OF-CMD-007` | `ERROR` | commands | A medium, high or critical-risk command is allowed in `SAFE` mode. | Remove `SAFE` from `allowed_modes` or lower the command risk. |
 
-Risk levels treated as risky by `OF-CMD-007`:
-
-```text
-medium
-high
-critical
-```
-
 ---
 
 ## `OF-EVT-*` — Event rules
@@ -240,8 +227,6 @@ critical
 | `OF-FLT-003` | `ERROR` | faults | Fault must emit at least one event. | Add at least one event ID to the fault `emits` list. |
 | `OF-FLT-005` | `ERROR` | faults | Fault recovery references an unknown command. | Add the command or fix `recovery.auto_commands`. |
 
-Note: `OF-FLT-005` is currently emitted by cross-reference validation because it checks a fault recovery reference.
-
 ---
 
 ## `OF-MODE-*` — Mode rules
@@ -259,6 +244,45 @@ Note: `OF-FLT-005` is currently emitted by cross-reference validation because it
 |---|---|---|---|---|
 | `OF-PKT-002` | `ERROR` | packets | Packet must not be empty. | Add at least one telemetry item to the packet. |
 | `OF-PKT-003` | `ERROR` | packets | Packet `max_payload_bytes` must be positive. | Set `max_payload_bytes` to a positive integer. |
+
+---
+
+## `OF-PAY-*` — Payload Contract rules
+
+These rules validate optional Payload / IOD Payload Contracts.
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-PAY-001` | `ERROR` | payloads | Payload subsystem reference must exist. | Add the subsystem or fix `payload.subsystem`. |
+| `OF-PAY-002` | `ERROR` | payloads | Payload subsystem must have type `payload`. | Link the payload contract to a payload subsystem. |
+| `OF-PAY-003` | `ERROR` | payloads | Payload lifecycle must define an initial state. | Add `lifecycle.initial_state`. |
+| `OF-PAY-004` | `ERROR` | payloads | Payload lifecycle initial state must exist in lifecycle states. | Add the state or fix `initial_state`. |
+| `OF-PAY-005` | `ERROR` | payloads | Payload telemetry reference must exist. | Add the telemetry or fix the reference. |
+| `OF-PAY-006` | `ERROR` | payloads | Payload command reference must exist. | Add the command or fix the reference. |
+| `OF-PAY-007` | `ERROR` | payloads | Payload event reference must exist. | Add the event or fix the reference. |
+| `OF-PAY-008` | `ERROR` | payloads | Payload fault reference must exist. | Add the fault or fix the reference. |
+| `OF-PAY-009` | `ERROR` | commands | Command payload lifecycle precondition references an unknown payload or state. | Fix the payload lifecycle precondition. |
+| `OF-PAY-010` | `ERROR` | commands | Command expected payload lifecycle effect references an unknown payload or state. | Fix the expected payload lifecycle effect. |
+
+Payload rules are contract-level rules. They do not validate payload firmware, drivers, buses or physical payload behavior.
+
+---
+
+## `OF-DP-*` — Data Product Contract rules
+
+These rules validate optional Data Product and Storage Contracts.
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-DP-002` | `ERROR` | data_products | Data product producer reference must exist. | Add the producer payload/subsystem or fix `producer`. |
+| `OF-DP-003` | `ERROR` | data_products | Optional data product payload reference must exist. | Add the payload contract or fix `payload`. |
+| `OF-DP-006` | `WARNING` | data_products | Data product storage intent should define retention. | Set `storage.retention` or remove storage intent if not retained. |
+| `OF-DP-007` | `WARNING` | data_products | Data product storage intent should define overflow policy. | Set `storage.overflow_policy` for retained data products. |
+| `OF-DP-008` | `WARNING` | data_products | High or critical priority data product should define downlink intent. | Set `downlink.policy`. |
+
+Structural validation covers additional data product constraints such as duplicate IDs, positive estimated size and known literal values for product type, storage class, overflow policy and downlink policy.
+
+Data Product rules are contract-level rules. They do not validate real storage, compression, contact windows or downlink runtime behavior.
 
 ---
 
@@ -296,7 +320,7 @@ steps
 
 ## Current command coverage
 
-Current v0.1.0 development preview behavior:
+Current behavior:
 
 | Command | Diagnostics produced |
 |---|---|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,11 @@ nav:
       - Lint Rules v0.1: reference/lint-rules-v0.1.md
       - Payload Contract Model: reference/payload-contract-model.md
       - Data Product Contract Model: reference/data-product-contract-model.md
+  - Releases:
+      - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
+      - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
+  - Communication:
+      - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 
   - ADR:
       - ADR-0001 Mission Model First: adr/ADR-0001-mission-model-first.md


### PR DESCRIPTION
## Summary

This PR polishes the public documentation after the `v0.3.0 — Data Product and Storage Contracts` release alignment.

It fixes navigation gaps and updates public-facing pages that were still partially describing the older v0.1/v0.2 snapshot.

## Changes

- exposes release notes in MkDocs navigation:
  - `v0.2.2 — Payload Contract Release Alignment`;
  - `v0.3.0 — Data Product and Storage Contracts`;
- exposes the Payload Contract Model communication draft in MkDocs navigation;
- updates the docs home page for `v0.3.0`;
- updates Quickstart expected version and generated docs output;
- updates Demo Walkthrough with:
  - `payloads.yaml`;
  - `data_products.yaml`;
  - synthetic `payload.radiation_histogram` data product;
  - generated `data_products.md`;
- updates the lint rule reference with:
  - optional `payloads.yaml` and `data_products.yaml`;
  - duplicate ID coverage for payloads and data products;
  - `OF-PAY-*` rules;
  - `OF-DP-*` rules.

## Boundary

This PR is documentation-only.

It intentionally does not change:

- code;
- model behavior;
- lint behavior;
- simulator behavior;
- generated outputs;
- release version.

`ARCHITECTURE.md` is intentionally left out because it is a broader architectural document still framed as MVP/v0.1 architecture. It should be refreshed in a dedicated follow-up PR rather than mixed into this navigation/public-doc polish.

## Validation

Recommended local check:

```bash
mkdocs build --strict
```
