### PR TITLE
docs: validate public documentation for v0.3

### DIFF
--- a/docs/CLEAN_ROOM_POLICY.md
+++ b/docs/CLEAN_ROOM_POLICY.md
@@ -1,6 +1,6 @@
 # OrbitFabric — Clean-Room Policy
 
-Version: 0.1-draft  
+Version: 0.3-draft  
 Status: Draft  
 Scope: Entire OrbitFabric project  
 
@@ -389,6 +389,8 @@ The canonical demo mission `demo-3u` must obey these rules:
 - it uses synthetic events;
 - it uses synthetic faults;
 - it uses synthetic recovery actions;
+- it uses synthetic data products;
+- it uses synthetic storage and downlink intent;
 - it does not include real bus maps;
 - it does not include real packet formats;
 - it does not include real payload behavior;
@@ -687,7 +689,7 @@ OrbitFabric must remain a generic open-source framework for mission data modelin
 
 Avoid adding content that could materially increase the operational capability of a restricted system or reveal sensitive implementation details.
 
-v0.1 must stay far from:
+v0.3 must stay far from:
 
 - real mission operations procedures;
 - real secure command handling;

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,6 +12,8 @@ OrbitFabric currently targets:
 Python 3.11+
 ```
 
+The CI validates Python 3.11 and Python 3.12.
+
 Development tools are installed through the project optional dependency group:
 
 ```text
@@ -38,6 +40,12 @@ orbitfabric --version
 orbitfabric --help
 ```
 
+Expected current version:
+
+```text
+orbitfabric 0.3.0
+```
+
 ---
 
 ## Local Quality Checks
@@ -47,18 +55,20 @@ Run:
 ```bash
 ruff check .
 pytest
+mkdocs build --strict
 ```
 
 Expected current baseline:
 
 ```text
-ruff check .  -> All checks passed
-pytest        -> 34 passed
+ruff check .          -> All checks passed
+pytest                -> passing
+mkdocs build --strict -> passing
 ```
 
 ---
 
-## Verify the v0.1 Vertical Slice
+## Verify the Current v0.3 Vertical Slice
 
 Run mission lint:
 
@@ -89,6 +99,19 @@ gen docs  -> Result: PASSED
 sim       -> Result: PASSED
 ```
 
+The generated mission documentation should include:
+
+```text
+generated/docs/telemetry.md
+generated/docs/commands.md
+generated/docs/events.md
+generated/docs/faults.md
+generated/docs/modes.md
+generated/docs/packets.md
+generated/docs/payloads.md
+generated/docs/data_products.md
+```
+
 ---
 
 ## Generated Outputs
@@ -110,6 +133,8 @@ The source of truth is:
 
 ```text
 examples/demo-3u/mission/*.yaml
+examples/demo-3u/mission/payloads.yaml
+examples/demo-3u/mission/data_products.yaml
 examples/demo-3u/scenarios/*.yaml
 ```
 
@@ -129,6 +154,8 @@ Preview locally:
 mkdocs serve
 ```
 
+The public site is deployed by the GitHub Pages workflow after pushes to `main`.
+
 ---
 
 ## Recommended Development Order
@@ -146,6 +173,8 @@ For new behavior, follow this order:
 Do not add simulator behavior that is not represented in the Mission Model.
 
 Do not add generated artifacts that bypass validation.
+
+Do not add runtime or ground integration artifacts before the relevant contract layer exists.
 
 ---
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,6 +1,6 @@
 # OrbitFabric — Project Charter
 
-Version: 0.2-draft  
+Version: 0.3-draft  
 Status: Draft  
 Scope: Mission Data Contract foundation and Mission Data Chain direction  
 
@@ -163,8 +163,8 @@ Examples:
 - a packet referencing unknown telemetry is an error;
 - a command without timeout is at least a warning;
 - an event without downlink priority is at least a warning;
-- a payload data product without storage intent is at least a warning;
-- a high-priority data product without downlink policy is at least a warning;
+- an incomplete data product storage intent is at least a warning;
+- a high-priority data product without downlink intent is at least a warning;
 - a contact profile referenced by downlink policy but missing from the model is an error.
 
 The lint system is a core feature, not a utility.
@@ -215,31 +215,28 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 ---
 
-## 7. MVP v0.1 Scope
+## 7. Completed Early Scope
 
-The goal of v0.1 is to demonstrate the complete OrbitFabric philosophy with a small but coherent vertical slice.
+The early OrbitFabric preview has already demonstrated the core philosophy with a small but coherent vertical slice.
 
-v0.1 must include:
+The current v0.3.0 baseline includes:
 
 - Mission Model YAML files;
 - model loading;
 - structural validation;
 - semantic linting;
 - generated Markdown documentation;
-- simple simulation runtime;
+- simple deterministic simulation runtime;
 - scenario runner;
-- mock EPS subsystem;
-- mock Payload subsystem;
-- minimal telemetry registry;
-- minimal command router;
-- minimal event bus;
-- minimal mode manager;
-- minimal fault monitor;
+- payload contract model;
+- data product contract model;
+- generated payload documentation;
+- generated data product documentation;
 - readable logs;
 - JSON reports;
 - one complete demo mission named `demo-3u`.
 
-v0.1 must support these commands:
+The current baseline supports these commands:
 
 ```bash
 orbitfabric lint examples/demo-3u/mission/
@@ -353,7 +350,7 @@ It contains:
 - OBC;
 - EPS mock;
 - Payload mock;
-- optional Radio mock;
+- Radio mock;
 - operational modes:
   - BOOT;
   - NOMINAL;
@@ -367,6 +364,8 @@ It contains:
 - EPS status command;
 - battery warning fault;
 - battery critical fault;
+- payload contract `demo_iod_payload`;
+- data product contract `payload.radiation_histogram`;
 - one scenario where the payload is active, battery voltage degrades, a warning event is emitted, the spacecraft transitions to DEGRADED and the payload is automatically stopped.
 
 The expected scenario narrative is:
@@ -374,16 +373,16 @@ The expected scenario narrative is:
 ```text
 [00:00] MODE=NOMINAL
 [00:05] COMMAND payload.start_acquisition -> ACCEPTED
-[00:06] EVENT payload.acquisition_started
-[00:30] INJECT eps.battery.voltage=6.7
-[00:33] EVENT eps.battery_low severity=WARNING
-[00:35] MODE TRANSITION PAYLOAD_ACTIVE -> DEGRADED
-[00:36] COMMAND payload.stop_acquisition -> AUTO_DISPATCHED
-[00:37] EVENT payload.acquisition_stopped
+[00:05] EVENT payload.acquisition_started
+[00:05] PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING
+[00:32] EVENT eps.battery_low severity=WARNING
+[00:32] MODE TRANSITION PAYLOAD_ACTIVE -> DEGRADED
+[00:32] COMMAND payload.stop_acquisition -> AUTO_DISPATCHED
+[00:32] PAYLOAD demo_iod_payload LIFECYCLE=READY
 [00:40] SCENARIO PASSED
 ```
 
-Future demo slices may extend this clean-room mission with synthetic data products, storage policies, downlink assumptions and contact windows.
+Future demo slices may extend this clean-room mission with contact windows and downlink assumptions.
 
 Those additions must remain generic and must not encode private mission details.
 
@@ -397,7 +396,7 @@ The recommended technical baseline is:
 - YAML for the Mission Model;
 - Pydantic v2 for typed model validation;
 - Typer for the command-line interface;
-- PyYAML or ruamel.yaml for YAML loading;
+- PyYAML for YAML loading;
 - pytest for tests;
 - ruff for formatting and linting;
 - MkDocs Material for documentation;
@@ -453,7 +452,7 @@ OrbitFabric is successful in the early public preview if a user can:
 7. understand the project positioning from the README in less than one minute;
 8. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
 9. understand how payload contracts fit into the Mission Data Contract;
-10. understand why data products, storage, downlink and contact assumptions belong in the roadmap before runtime skeletons.
+10. understand how data products, storage intent, downlink intent and contact assumptions fit into the roadmap before runtime skeletons.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 

--- a/docs/adr/ADR-0006-payload-contract-model.md
+++ b/docs/adr/ADR-0006-payload-contract-model.md
@@ -1,6 +1,6 @@
 # ADR-0006 — Payload / IOD Payload Contract Model
 
-Status: Proposed  
+Status: Accepted  
 Date: 2026-05-01
 
 ---
@@ -11,9 +11,7 @@ OrbitFabric is a model-first Mission Data Contract framework for small spacecraf
 
 The project already models spacecraft-level mission data such as telemetry, commands, events, faults, modes, packets and scenarios.
 
-The current demo mission also includes a generic `payload` subsystem and a scenario where payload activity is part of the operational narrative.
-
-However, payloads are not yet represented as a first-class mission contract concept.
+The demo mission also includes a generic `payload` subsystem and a scenario where payload activity is part of the operational narrative.
 
 IOD payloads and mission-specific payloads often introduce their own operational contracts:
 
@@ -34,7 +32,7 @@ Without a first-class payload contract model, these concepts remain scattered ac
 
 ## Decision
 
-OrbitFabric may introduce a first-class Payload / IOD Payload Contract Model as part of the v0.2.x Model Hardening phase.
+OrbitFabric introduces a first-class Payload / IOD Payload Contract Model as part of the Mission Data Contract.
 
 A payload contract describes a declarative mission data and behavior contract.
 
@@ -66,9 +64,9 @@ The canonical role of this model is:
 
 ## Initial Scope
 
-The first vertical slice must be deliberately narrow.
+The first vertical slice was deliberately narrow.
 
-It should include:
+It includes:
 
 ```text
 one synthetic IOD payload contract
@@ -77,11 +75,11 @@ two payload commands
 one payload state telemetry
 two payload events
 one nominal scenario
-one generated payload documentation page
+generated payload documentation
 a small set of payload lint rules
 ```
 
-The initial lifecycle should remain minimal:
+The initial lifecycle remains minimal:
 
 ```text
 OFF
@@ -90,7 +88,7 @@ ACQUIRING
 FAULT
 ```
 
-Additional states such as `STANDBY`, `WARMUP`, `PROCESSING` and `DOWNLINK_PENDING` may be added only after the first working slice is stable.
+Additional states such as `STANDBY`, `WARMUP`, `PROCESSING` and `DOWNLINK_PENDING` may be added only when a future model slice needs them.
 
 ---
 
@@ -126,9 +124,11 @@ Payloads become explicit model elements without turning OrbitFabric into a paylo
 
 The model can later support:
 
-- generated payload-oriented runtime skeletons in v0.3;
-- generated payload-oriented ground artifacts in v0.4;
-- payload-specific plugin extension points in v0.5.
+- Data Product and Storage Contracts;
+- Contact Windows and Downlink Flow Contracts;
+- future runtime skeletons;
+- future ground integration artifacts;
+- future payload-specific plugin extension points.
 
 The implementation order remains:
 

--- a/docs/adr/ADR-0007-mission-data-chain-before-runtime.md
+++ b/docs/adr/ADR-0007-mission-data-chain-before-runtime.md
@@ -1,6 +1,6 @@
 # ADR-0007 — Mission Data Chain Before Runtime Generation
 
-Status: Proposed  
+Status: Accepted  
 Date: 2026-05-01
 
 ---
@@ -39,7 +39,7 @@ Without that layer, generated runtime skeletons would be derived from an incompl
 
 OrbitFabric will introduce Mission Data Chain modeling before generated runtime skeletons.
 
-The roadmap will therefore place these model-first milestones before runtime generation:
+The roadmap therefore places these model-first milestones before runtime generation:
 
 ```text
 Data Product and Storage Contracts
@@ -48,7 +48,7 @@ Commandability and Autonomy Contracts
 End-to-End Mission Data Flow Evidence
 ```
 
-Generated runtime skeletons will be deferred until after these concepts are clear enough to be represented in the Mission Data Contract.
+Generated runtime skeletons are deferred until after these concepts are clear enough to be represented in the Mission Data Contract.
 
 The intended chain is:
 
@@ -190,7 +190,7 @@ The ground integration artifacts will also be stronger, because they will be der
 
 ## Expected Roadmap Impact
 
-The roadmap should include these milestones before runtime generation:
+The roadmap includes these milestones before runtime generation:
 
 ```text
 v0.3 Data Product and Storage Contracts
@@ -199,19 +199,19 @@ v0.5 Commandability and Autonomy Contracts
 v0.6 End-to-End Mission Data Flow Evidence
 ```
 
-Generated runtime skeletons should move later:
+Generated runtime skeletons are placed later:
 
 ```text
 v0.7 Generated Runtime Skeletons
 ```
 
-Ground integration artifacts should follow after the model contains enough ground-facing semantics:
+Ground integration artifacts follow after the model contains enough ground-facing semantics:
 
 ```text
 v0.8 Ground Integration Artifacts
 ```
 
-Plugin and extensibility work should remain after the core model has matured:
+Plugin and extensibility work remains after the core model has matured:
 
 ```text
 v0.9 Plugin and Extensibility Layer

--- a/docs/adr/ADR-0008-data-product-and-storage-contracts.md
+++ b/docs/adr/ADR-0008-data-product-and-storage-contracts.md
@@ -1,6 +1,6 @@
 # ADR-0008 — Data Product and Storage Contracts
 
-Status: Proposed  
+Status: Accepted  
 Date: 2026-05-01
 
 ---
@@ -39,7 +39,7 @@ OrbitFabric needs a contract-level way to describe them before runtime skeletons
 
 ## Decision
 
-OrbitFabric will introduce Data Product and Storage Contracts as the next model-first slice after Payload Contracts.
+OrbitFabric introduces Data Product and Storage Contracts as the next model-first slice after Payload Contracts.
 
 A data product is a declared mission-data object produced by a payload or subsystem.
 
@@ -63,9 +63,7 @@ Storage and downlink fields represent declared intent.
 
 They do not represent real storage implementation, file-system behavior, compression, contact-window simulation or downlink runtime behavior.
 
-The first implementation slice should remain narrow and should be introduced as an optional model domain.
-
-A candidate file name is:
+The first implementation slice is intentionally narrow and is introduced as an optional model domain:
 
 ```text
 mission/data_products.yaml
@@ -99,9 +97,9 @@ The data product describes a mission output object.
 
 ---
 
-## Candidate Minimal Shape
+## Minimal Shape
 
-The first data product slice may use a shape similar to:
+The first data product slice uses a shape similar to:
 
 ```yaml
 data_products:
@@ -119,15 +117,13 @@ data_products:
       policy: next_available_contact
 ```
 
-This is a candidate shape, not a frozen schema.
-
-The implementation may refine field names if that improves clarity or validation.
+This is implemented in v0.3.0, but it is not a frozen v1.0 schema.
 
 ---
 
 ## Initial Scope
 
-The first vertical slice should include:
+The first vertical slice includes:
 
 ```text
 optional data_products.yaml loading
@@ -144,7 +140,7 @@ invalid fixtures and tests
 one synthetic demo data product
 ```
 
-The slice should prove this relationship:
+The slice proves this relationship:
 
 ```text
 Payload Contract
@@ -185,21 +181,19 @@ Runtime skeletons and ground integration artifacts must remain deferred until th
 
 ## Linting Direction
 
-Data Product and Storage Contracts must be lintable from the beginning.
+Data Product and Storage Contracts are lintable from the beginning.
 
-Candidate lint rules include:
+Implemented lint direction includes:
 
 ```text
-ERROR: data product id is duplicated.
 ERROR: data product references an unknown producer.
 ERROR: data product references an unknown payload contract.
-ERROR: data product estimated size must be positive.
 WARNING: retained data product has no retention policy.
 WARNING: retained data product has no overflow policy.
 WARNING: high-priority data product has no downlink intent.
 ```
 
-Exact rule IDs and severities should be defined during implementation.
+Structural validation covers duplicate IDs, positive estimated size and known literal values.
 
 The principle is fixed:
 
@@ -209,15 +203,15 @@ The principle is fixed:
 
 ## Documentation Direction
 
-Generated documentation should expose data products from the validated Mission Model.
+Generated documentation exposes data products from the validated Mission Model.
 
-A candidate generated file is:
+The generated file is:
 
 ```text
 generated/docs/data_products.md
 ```
 
-The generated page should make clear that storage and downlink fields are contract intent, not executable runtime behavior.
+The generated page makes clear that storage and downlink fields are contract intent, not executable runtime behavior.
 
 ---
 
@@ -250,8 +244,8 @@ This ADR is satisfied when:
 - data products are clearly distinguished from telemetry and packets;
 - storage and downlink fields are described as intent, not implementation;
 - non-goals are explicit;
-- the public documentation exposes the proposed contract scope;
-- implementation can proceed through small follow-up issues.
+- the public documentation exposes the contract scope;
+- implementation is covered by model loading, lint rules, invalid fixtures, generated documentation and one synthetic demo data product.
 
 ---
 

--- a/docs/reference/data-product-contract-model.md
+++ b/docs/reference/data-product-contract-model.md
@@ -1,11 +1,11 @@
 # Data Product Contract Model
 
-Status: Proposed for OrbitFabric v0.3  
+Status: Implemented in OrbitFabric v0.3.0  
 Scope: Data Product and Storage Contract definition
 
 ## Purpose
 
-The Data Product Contract Model extends OrbitFabric with a proposed model domain for mission data objects produced by payloads or subsystems.
+The Data Product Contract Model extends OrbitFabric with an optional model domain for mission data objects produced by payloads or subsystems.
 
 A data product contract describes what mission data object is expected to be produced, who produces it, how large it is expected to be, how important it is, how it should be retained and how it should be prepared for future downlink planning.
 
@@ -15,7 +15,7 @@ It does not implement onboard storage, payload processing, compression, contact 
 
 ## Why Data Products Are Separate
 
-OrbitFabric must keep telemetry, packets and data products distinct.
+OrbitFabric keeps telemetry, packets and data products distinct.
 
 ```text
 Telemetry
@@ -75,17 +75,17 @@ A data product contract does not describe:
 - ground segment implementation;
 - runtime skeleton generation.
 
-Those are intentionally outside the proposed v0.3 scope.
+Those are intentionally outside the v0.3.0 scope.
 
-## Candidate YAML Shape
+## YAML Shape
 
-The first implementation slice may introduce an optional file:
+Data products are defined in the optional file:
 
 ```text
 mission/data_products.yaml
 ```
 
-A candidate shape is:
+Current shape:
 
 ```yaml
 data_products:
@@ -103,9 +103,7 @@ data_products:
       policy: next_available_contact
 ```
 
-This is a proposed shape for the v0.3 design direction.
-
-It is not yet a stable schema.
+This shape is implemented in v0.3.0, but OrbitFabric is still pre-1.0 and the schema may evolve.
 
 ## Relationship with Payload Contracts
 
@@ -127,9 +125,9 @@ Payload Contract
 
 A data product may reference a payload contract as its producer.
 
-The reference must remain declarative.
+The reference remains declarative.
 
-It must not imply payload runtime execution or data processing.
+It does not imply payload runtime execution or data processing.
 
 ## Storage Intent
 
@@ -156,44 +154,42 @@ Examples include:
 - deferred downlink;
 - manual or operator-selected downlink.
 
-The first data product slice should not implement contact windows or downlink simulation.
+The first data product slice does not implement contact windows or downlink simulation.
 
 Those belong to later Mission Data Chain milestones.
 
-## Linting Direction
+## Implemented Lint Rules
 
-Data Product Contracts should be linted semantically.
+Data Product Contracts are linted semantically.
 
-Candidate findings include:
+Implemented rule families include:
 
 ```text
-ERROR: data product id is duplicated.
-ERROR: data product references an unknown producer.
-ERROR: data product references an unknown payload contract.
-ERROR: estimated size must be positive.
-WARNING: retained data product has no retention policy.
-WARNING: retained data product has no overflow policy.
-WARNING: high-priority data product has no downlink intent.
+OF-DP-002  producer reference must be known
+OF-DP-003  optional payload reference must be known
+OF-DP-006  storage intent should define retention
+OF-DP-007  storage intent should define overflow_policy
+OF-DP-008  high-priority data product should define downlink intent
 ```
 
-Exact rule IDs and severities should be defined during implementation.
+Structural validation also covers duplicate IDs, positive estimated size and known literal values for product type, storage class, overflow policy and downlink policy.
 
-## Generated Documentation Direction
+## Generated Documentation
 
-When data products are present, OrbitFabric should be able to generate data product documentation from the validated Mission Model.
+When data products are present, OrbitFabric can generate data product documentation from the validated Mission Model.
 
-Candidate output:
+Current generated output:
 
 ```text
 generated/docs/data_products.md
 ```
 
-The generated page should expose data product identity, producer, type, estimated size, priority, storage intent and downlink intent.
+The generated page exposes data product identity, producer, type, estimated size, priority, storage intent and downlink intent.
 
 ## Current Status
 
-This page defines proposed v0.3 scope only.
+This page documents the implemented v0.3.0 Data Product Contract Model.
 
-It does not document an implemented schema yet.
+The model remains development-preview and pre-1.0.
 
-Implementation should proceed through small follow-up issues covering model loading, lint rules, invalid fixtures, generated documentation and one synthetic demo data product.
+Future milestones will add contact windows, downlink flow contracts, commandability contracts and end-to-end mission data flow evidence before runtime skeletons or ground artifacts are introduced.

--- a/docs/reference/json-reports-v0.1.md
+++ b/docs/reference/json-reports-v0.1.md
@@ -1,6 +1,12 @@
-# JSON Reports v0.1
+# JSON Reports
 
-This page documents the JSON reports currently produced by OrbitFabric v0.1.0 development preview.
+This page documents the JSON reports currently produced by OrbitFabric.
+
+Current documented baseline:
+
+```text
+v0.3.0 — Data Product and Storage Contracts
+```
 
 OrbitFabric JSON reports are generated artifacts intended for:
 
@@ -19,7 +25,7 @@ The source of truth remains the Mission Model YAML and scenario YAML.
 
 The JSON report structures documented here are development-preview contracts.
 
-They are intended to be stable enough for v0.1/v0.2 workflows, but they are not a v1.0 compatibility promise.
+They are stable enough for current v0.3 workflows, but they are not a v1.0 compatibility promise.
 
 Future versions may introduce:
 
@@ -35,12 +41,12 @@ Future versions may introduce:
 
 OrbitFabric JSON reports include the OrbitFabric tool/package version in the top-level `version` field.
 
-Example:
+Current example:
 
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.1.0.dev0"
+  "version": "0.3.0"
 }
 ```
 
@@ -93,7 +99,7 @@ orbitfabric-lint
 | `mission` | string | Mission ID loaded from the Mission Model. |
 | `model_version` | string | Mission Model version declared by the mission. |
 | `result` | string | Machine-readable lint result. |
-| `loaded` | object | Counts of loaded Mission Model domains. |
+| `loaded` | object | Counts of loaded core Mission Model domains. |
 | `summary` | object | Count of findings by severity. |
 | `findings` | array | List of lint findings. |
 
@@ -113,7 +119,7 @@ Current lint report `result` values:
 
 ## Lint `loaded` object
 
-The `loaded` object reports how many Mission Model objects were loaded.
+The `loaded` object reports how many core Mission Model objects were loaded.
 
 Current fields:
 
@@ -128,6 +134,8 @@ Current fields:
 | `events` | Number of event definitions. |
 | `faults` | Number of fault definitions. |
 | `packets` | Number of packet definitions. |
+
+Note: optional domains such as `payloads` and `data_products` are validated and documented, but they are not currently included in the lint JSON `loaded` object. This may be expanded in a future report schema revision.
 
 ---
 
@@ -164,12 +172,12 @@ Example:
 ```json
 {
   "severity": "WARNING",
-  "code": "OF-CMD-005",
-  "file": "commands.yaml",
-  "domain": "commands",
-  "object_id": "payload.start_acquisition",
-  "message": "command should define timeout_ms",
-  "suggestion": "Add timeout_ms to make command behavior testable."
+  "code": "OF-DP-008",
+  "file": "data_products.yaml",
+  "domain": "data_products",
+  "object_id": "payload.radiation_histogram",
+  "message": "high-priority data product should define downlink intent",
+  "suggestion": "Set downlink.policy for high or critical data products."
 }
 ```
 
@@ -182,7 +190,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.1.0.dev0",
+  "version": "0.3.0",
   "mission": "demo-3u",
   "model_version": "0.1.0",
   "result": "passed",
@@ -190,7 +198,7 @@ Compact example:
     "spacecraft": 1,
     "subsystems": 4,
     "modes": 6,
-    "mode_transitions": 5,
+    "mode_transitions": 6,
     "telemetry": 5,
     "commands": 4,
     "events": 8,
@@ -363,7 +371,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-sim",
-  "version": "0.1.0.dev0",
+  "version": "0.3.0",
   "mission": "demo-3u",
   "scenario": "battery_low_during_payload",
   "result": "passed",
@@ -389,7 +397,7 @@ Compact example:
 
 ## Current limitations
 
-Current v0.1.0 development preview reports do not yet include:
+Current development-preview reports do not yet include:
 
 - explicit report schema version;
 - JSON Schema URL;
@@ -398,7 +406,8 @@ Current v0.1.0 development preview reports do not yet include:
 - Git commit SHA;
 - environment metadata;
 - compatibility matrix;
-- stable v1.0 compatibility guarantee.
+- stable v1.0 compatibility guarantee;
+- optional payload/data product loaded counts in the lint report.
 
 These may be added later, but they are not part of the current report contract.
 

--- a/docs/reference/payload-contract-model.md
+++ b/docs/reference/payload-contract-model.md
@@ -1,7 +1,7 @@
 # Payload Contract Model
 
-Status: Development preview  
-Scope: OrbitFabric v0.2.x model hardening
+Status: Implemented  
+Scope: OrbitFabric Payload / IOD Payload Contract Model
 
 ## Purpose
 
@@ -44,7 +44,7 @@ A payload contract does not describe:
 - thermal, optical or scientific payload simulation;
 - ground segment implementation.
 
-These are intentionally outside the scope of the current Payload Contract Model.
+These are intentionally outside the scope of the Payload Contract Model.
 
 ## Relationship with the Mission Model
 
@@ -85,7 +85,7 @@ The first demo vertical slice uses:
 READY → ACQUIRING → READY
 ```
 
-Additional states such as `STANDBY`, `WARMUP`, `PROCESSING` or `DOWNLINK_PENDING` are not part of the current slice and should only be introduced after the model is stable.
+Additional states such as `STANDBY`, `WARMUP`, `PROCESSING` or `DOWNLINK_PENDING` should only be introduced when a later model slice needs them.
 
 ## Generated Documentation
 
@@ -107,10 +107,24 @@ The current demo mission includes a nominal payload lifecycle sequence where the
 
 The scenario also demonstrates how payload behavior can interact with spacecraft-level conditions, such as EPS degradation and automatic command dispatch.
 
+## Relationship with Data Products
+
+Payload Contracts describe expected payload behavior.
+
+Data Product Contracts describe mission-data objects produced by payloads or subsystems.
+
+In the current `demo-3u` mission, `demo_iod_payload` is the producer of the synthetic data product:
+
+```text
+payload.radiation_histogram
+```
+
+This relationship is declarative. It does not imply payload runtime execution or payload data processing.
+
 ## Current Boundary
 
 The current implementation is a deliberately narrow vertical slice.
 
-It is meant to validate the model shape, lint rules, generated documentation and minimal scenario behavior.
+It validates the model shape, lint rules, generated documentation and minimal scenario behavior.
 
 It is not a commitment to payload runtime execution, payload hardware integration or physical payload simulation.

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -29,10 +29,10 @@ It is shown by:
 orbitfabric --version
 ```
 
-Example:
+Current example:
 
 ```text
-orbitfabric 0.1.0.dev0
+orbitfabric 0.3.0
 ```
 
 This version answers the question:
@@ -55,7 +55,7 @@ For the current multi-file Mission Model, it is stored in:
 spacecraft.yaml
 ```
 
-Example:
+Current demo example:
 
 ```yaml
 spacecraft:
@@ -80,22 +80,20 @@ It is not the same as the OrbitFabric Python package version.
 
 Generated JSON reports include the OrbitFabric tool/package version.
 
-Example:
+Current example:
 
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.1.0.dev0",
-  "mission": {
-    "id": "demo-3u",
-    "model_version": "0.1.0"
-  }
+  "version": "0.3.0",
+  "mission": "demo-3u",
+  "model_version": "0.1.0"
 }
 ```
 
 The top-level `version` identifies the OrbitFabric tool that produced the report.
 
-The nested `mission.model_version` identifies the Mission Model version declared by the mission.
+The `model_version` identifies the Mission Model version declared by the mission.
 
 ---
 
@@ -106,7 +104,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.1.0.dev0
+OrbitFabric tool/package version: 0.3.0
 Mission Model version:           0.1.0
 ```
 
@@ -114,13 +112,13 @@ This is valid.
 
 It means:
 
-- the tool is still a development preview;
-- the mission declares the v0.1 Mission Model contract;
+- the tool has gained new capabilities such as Payload Contracts and Data Product Contracts;
+- the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record both pieces of information.
 
 ---
 
-## Current v0.1 rule
+## Current v0.3 rule
 
 For the current development preview:
 
@@ -129,7 +127,7 @@ For the current development preview:
 | `orbitfabric --version` | OrbitFabric CLI/package version. |
 | JSON report top-level `version` | OrbitFabric tool version that produced the report. |
 | `spacecraft.model_version` | Mission Model contract version declared by the mission. |
-| JSON report `mission.model_version` | Mission Model version copied from mission YAML. |
+| JSON report `model_version` | Mission Model version copied from mission YAML. |
 
 ---
 
@@ -155,4 +153,4 @@ Possible future additions include:
 - compatibility checks between tool version and Mission Model version;
 - JSON Schema export for Mission Model validation.
 
-These are not part of the current v0.1.0 development preview.
+These are not part of the current v0.3.0 development preview.


### PR DESCRIPTION
## Summary

This PR validates and aligns the public documentation after the `v0.3.0 — Data Product and Storage Contracts` release.

It fixes remaining public-doc pages that still described older v0.1/v0.2 assumptions or proposal-stage status even though the corresponding v0.3 work is now implemented.

## Changes

- updates `docs/DEVELOPMENT.md` for the current v0.3 vertical slice;
- updates `docs/PROJECT_CHARTER.md` to `0.3-draft` and aligns the completed early scope with Payload Contracts and Data Product Contracts;
- updates `docs/CLEAN_ROOM_POLICY.md` header and demo mission clean-room rules for data products and storage/downlink intent;
- updates `docs/reference/versioning.md` with current `orbitfabric 0.3.0` examples;
- updates `docs/reference/json-reports-v0.1.md` as the current JSON Reports reference:
  - tool version examples now use `0.3.0`;
  - loaded counts reflect the current demo mission;
  - optional payload/data product counts are explicitly documented as not currently part of the lint JSON `loaded` object;
- updates `docs/reference/payload-contract-model.md` status and relationship with Data Product Contracts;
- updates `docs/reference/data-product-contract-model.md` from proposed scope to implemented v0.3.0 reference;
- marks ADR-0006, ADR-0007 and ADR-0008 as accepted;
- updates ADR-0006/0008 wording to reflect implemented payload/data product slices rather than proposal-stage direction.

## Notes

Historical v0.1 documents and ADRs remain intentionally historical where appropriate.

This PR does not rename the `Mission Model v0.1` or legacy ADR scopes because those are versioned historical references, not current-status pages.

## Boundary

This PR is documentation-only.

It intentionally does not change:

- code;
- model behavior;
- lint behavior;
- simulator behavior;
- generated outputs;
- release version;
- roadmap structure.

## Validation

Recommended local check:

```bash
mkdocs build --strict
```

Optional full check:

```bash
ruff check .
pytest
mkdocs build --strict
```
