### PR TITLE
Align CLI output with current project baseline

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -34,6 +34,7 @@ app.add_typer(validate_app, name="validate")
 inspect_app = typer.Typer(help="Inspect OrbitFabric models and inputs.")
 app.add_typer(inspect_app, name="inspect")
 
+
 @app.callback()
 def main(
     version: Annotated[
@@ -77,7 +78,7 @@ def lint(
     ] = False,
 ) -> None:
     """Validate and semantically lint a Mission Model."""
-    typer.echo("OrbitFabric Mission Lint v0.1")
+    typer.echo(f"OrbitFabric Mission Lint {__version__}")
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -123,7 +124,7 @@ def gen_docs(
     ] = Path("generated/docs"),
 ) -> None:
     """Generate Markdown documentation from a Mission Model."""
-    typer.echo("OrbitFabric Docs Generator v0.1")
+    typer.echo(f"OrbitFabric Docs Generator {__version__}")
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -149,6 +150,7 @@ def gen_docs(
 
     typer.echo("\nResult: PASSED")
 
+
 @inspect_app.command("mission")
 def inspect_mission(
     mission_dir: Annotated[
@@ -163,7 +165,7 @@ def inspect_mission(
     ],
 ) -> None:
     """Inspect a Mission Model without linting or generating artifacts."""
-    typer.echo("OrbitFabric Mission Inspection v0.1")
+    typer.echo(f"OrbitFabric Mission Inspection {__version__}")
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -174,7 +176,8 @@ def inspect_mission(
     _print_loaded_model_summary(model)
 
     typer.echo("\nResult: PASSED")
-    
+
+
 @validate_app.command("scenario")
 def validate_scenario(
     scenario_file: Annotated[
@@ -189,7 +192,7 @@ def validate_scenario(
     ],
 ) -> None:
     """Validate a scenario without executing it."""
-    typer.echo("OrbitFabric Scenario Validation v0.1")
+    typer.echo(f"OrbitFabric Scenario Validation {__version__}")
 
     try:
         loaded = ScenarioLoader().load(scenario_file)
@@ -204,6 +207,7 @@ def validate_scenario(
     typer.echo(f"Steps: {len(loaded.scenario.steps)}")
 
     typer.echo("\nResult: PASSED")
+
 
 @app.command()
 def sim(
@@ -233,7 +237,7 @@ def sim(
     ] = None,
 ) -> None:
     """Run a scenario against a Mission Model."""
-    typer.echo("OrbitFabric Scenario Simulator v0.1")
+    typer.echo(f"OrbitFabric Scenario Simulator {__version__}")
 
     try:
         loaded = ScenarioLoader().load(scenario_file)
@@ -283,6 +287,8 @@ def _print_loaded_model_summary(model: MissionModel) -> None:
     typer.echo(f"  events: {len(model.events)}")
     typer.echo(f"  faults: {len(model.faults)}")
     typer.echo(f"  packets: {len(model.packets)}")
+    typer.echo(f"  payloads: {len(model.payloads)}")
+    typer.echo(f"  data products: {len(model.data_products)}")
 
 
 def _print_lint_report(report: LintReport) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,16 +29,17 @@ def test_lint_loads_demo_mission() -> None:
     result = runner.invoke(app, ["lint", "examples/demo-3u/mission"])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Mission Lint v0.1" in result.output
+    assert f"OrbitFabric Mission Lint {__version__}" in result.output
     assert "Mission: demo-3u" in result.output
     assert "No findings." in result.output
     assert "Result: PASSED" in result.output
+
 
 def test_inspect_mission_loads_demo_mission() -> None:
     result = runner.invoke(app, ["inspect", "mission", "examples/demo-3u/mission"])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Mission Inspection v0.1" in result.output
+    assert f"OrbitFabric Mission Inspection {__version__}" in result.output
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "subsystems: 4" in result.output
@@ -48,8 +49,11 @@ def test_inspect_mission_loads_demo_mission() -> None:
     assert "events:" in result.output
     assert "faults:" in result.output
     assert "packets:" in result.output
+    assert "payloads:" in result.output
+    assert "data products:" in result.output
     assert "Result: PASSED" in result.output
     assert "Findings:" not in result.output
+
 
 def test_inspect_mission_rejects_invalid_mission(tmp_path: Path) -> None:
     mission_dir = _copy_demo_mission_missing_required_file(tmp_path)
@@ -60,6 +64,7 @@ def test_inspect_mission_rejects_invalid_mission(tmp_path: Path) -> None:
     assert "OF-SYN-002" in result.output
     assert "required Mission Model file is missing" in result.output
     assert "Result: FAILED" in result.output
+
 
 def test_lint_with_warnings_passes_by_default(tmp_path: Path) -> None:
     mission_dir = _copy_demo_mission_with_warning(tmp_path)
@@ -102,6 +107,7 @@ def _copy_demo_mission_with_warning(tmp_path: Path) -> Path:
 
     return mission_dir
 
+
 def _copy_demo_mission_missing_required_file(tmp_path: Path) -> Path:
     source = Path("examples/demo-3u/mission")
     mission_dir = tmp_path / "mission"
@@ -109,4 +115,4 @@ def _copy_demo_mission_missing_required_file(tmp_path: Path) -> Path:
 
     (mission_dir / "telemetry.yaml").unlink()
 
-    return mission_dir 
+    return mission_dir

--- a/tests/test_doc_generator.py
+++ b/tests/test_doc_generator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.model.loader import MissionModelLoader
@@ -80,7 +81,7 @@ def test_gen_docs_cli_writes_markdown_files(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    assert "OrbitFabric Docs Generator v0.1" in result.output
+    assert f"OrbitFabric Docs Generator {__version__}" in result.output
     assert "Generated files:" in result.output
     assert "Result: PASSED" in result.output
 

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 from orbitfabric.model.errors import MissionModelError
 from orbitfabric.model.scenario_loader import ScenarioLoader
@@ -28,7 +29,7 @@ def test_sim_cli_loads_demo_scenario() -> None:
     result = runner.invoke(app, ["sim", str(DEMO_SCENARIO)])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Scenario Simulator v0.1" in result.output
+    assert f"OrbitFabric Scenario Simulator {__version__}" in result.output
     assert "Scenario: battery_low_during_payload" in result.output
     assert "Mission: demo-3u" in result.output
     assert "Result: PASSED" in result.output
@@ -45,7 +46,7 @@ def test_validate_scenario_cli_loads_demo_scenario() -> None:
     result = runner.invoke(app, ["validate", "scenario", str(DEMO_SCENARIO)])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Scenario Validation v0.1" in result.output
+    assert f"OrbitFabric Scenario Validation {__version__}" in result.output
     assert "Scenario: battery_low_during_payload" in result.output
     assert "Mission: demo-3u" in result.output
     assert "Initial mode: NOMINAL" in result.output
@@ -188,6 +189,7 @@ unexpected: true
     assert exc_info.value.diagnostics[0].suggestion == (
         "Remove or rename the unexpected scenario top-level key 'unexpected'."
     )
+
 
 def _copy_demo_scenario_with_replacement(
     tmp_path: Path,

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from orbitfabric import __version__
 from orbitfabric.cli import app
 from orbitfabric.model.scenario_loader import ScenarioLoader
 from orbitfabric.sim.runner import ScenarioRunner
@@ -64,7 +65,7 @@ def test_sim_cli_executes_demo_scenario() -> None:
     result = runner.invoke(app, ["sim", str(DEMO_SCENARIO)])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Scenario Simulator v0.1" in result.output
+    assert f"OrbitFabric Scenario Simulator {__version__}" in result.output
     assert "Scenario: battery_low_during_payload" in result.output
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "EVENT eps.battery_low severity=WARNING" in result.output
@@ -76,7 +77,7 @@ def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
     result = runner.invoke(app, ["sim", str(PAYLOAD_SCENARIO)])
 
     assert result.exit_code == 0
-    assert "OrbitFabric Scenario Simulator v0.1" in result.output
+    assert f"OrbitFabric Scenario Simulator {__version__}" in result.output
     assert "Scenario: nominal_payload_acquisition" in result.output
     assert "PAYLOAD demo_iod_payload LIFECYCLE=READY" in result.output
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output


### PR DESCRIPTION
## Summary

This PR fixes a project-coherence issue in the CLI output.

The repository, package version, README, roadmap and public documentation are aligned on `v0.3.0`, but several CLI command banners were still hardcoded as `v0.1`.

This is not a feature change. It is a baseline coherence fix.

## Changes

- Replace hardcoded CLI command banner versions with the package `__version__`.
- Extend the loaded Mission Model summary with:
  - payload count;
  - data product count.

## Rationale

OrbitFabric is currently positioned as an early, CLI/YAML-first, contract-first framework.

For project management and public technical material, terminal output must reflect the same baseline described by the repository documentation.

This avoids a visible mismatch between:

- `orbitfabric --version`;
- README / roadmap / changelog;
- CLI command banners;
- the current `v0.3.0 — Data Product and Storage Contracts` scope.

## Scope boundary

This PR intentionally does not introduce new features, new roadmap commitments, new generated artifacts or marketing-oriented wording.

## Validation

Not run in this environment. Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric inspect mission examples/demo-3u/mission/
orbitfabric lint examples/demo-3u/mission/
orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
```