### PR TITLE
Refine verification baseline and downlink wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ ruff check .
 
 pytest
 -> passing
+
+mkdocs build --strict
+-> passing
 ```
 
 ---
@@ -388,13 +391,15 @@ generated/logs/battery_low_during_payload.log
 ```bash
 ruff check .
 pytest
+mkdocs build --strict
 ```
 
 Current expected baseline:
 
 ```text
-ruff check .  -> All checks passed
-pytest        -> passing
+ruff check .           -> All checks passed
+pytest                 -> passing
+mkdocs build --strict  -> passing
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -391,7 +391,7 @@ OrbitFabric should let a mission designer ask:
 contact window model
 contact profile model
 link profile model
-estimated downlink budget
+declared downlink capacity assumption
 abstract downlink queue policy
 data product downlink eligibility
 scenario contact events
@@ -402,7 +402,7 @@ downlink consistency lint rules
 ### 9.3 Candidate Lint Rules
 
 ```text
-WARNING: produced data volume may exceed nominal contact budget.
+WARNING: produced data volume may exceed declared contact capacity.
 ERROR: downlink policy references unknown contact profile.
 WARNING: critical event has no immediate downlink class.
 WARNING: high-priority product is retained but never scheduled for downlink.


### PR DESCRIPTION
## Summary

This PR performs a small documentation coherence refinement after the v0.3.0 baseline alignment.

## Changes

- Add `mkdocs build --strict` to the README current verified baseline.
- Align the README test section with the same verification baseline.
- Replace `estimated downlink budget` wording in the roadmap with `declared downlink capacity assumption`.
- Rephrase the related candidate lint rule from `nominal contact budget` to `declared contact capacity`.

## Rationale

The repository already treats documentation as part of the verified development preview through MkDocs and the Pages workflow. The README should expose that consistently.

The roadmap wording is also tightened to keep v0.4 clearly contract-level. OrbitFabric should model declared contact/downlink assumptions, not imply RF/link budget computation.

## Scope boundary

This PR does not introduce new features, new roadmap commitments, runtime behavior, ground behavior or generated artifacts.

## Validation

Documentation-only change. Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```