### PR TITLE
docs: define v0.4 contact and downlink contract scope

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -379,40 +379,115 @@ It describes contract intent only.
 
 ### 9.1 Objective
 
-Model ground contact and downlink assumptions without becoming a ground segment or an orbital dynamics simulator.
+Model contact windows and downlink flow assumptions without becoming a ground segment, an orbital dynamics simulator, an RF simulator or a downlink runtime.
 
 OrbitFabric should let a mission designer ask:
 
-> Given the declared data products, priorities, storage policies and contact assumptions, is the data flow coherent?
+> Given the declared data products, priorities, storage policies, downlink intent and contact assumptions, is the mission data flow coherent?
 
-### 9.2 Candidate Features
+### 9.2 Architectural Question
+
+The v0.4 slice strengthens this contract chain:
 
 ```text
-contact window model
+Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+        -> Contact Window Assumptions
+        -> Downlink Flow Contract
+        -> future End-to-End Mission Data Flow Evidence
+```
+
+The model should expose assumptions that can be validated, linted and documented.
+
+It must not execute those assumptions.
+
+### 9.3 Initial Scope
+
+The first v0.4 implementation slice should remain narrow.
+
+Candidate scope:
+
+```text
+optional contacts.yaml domain
 contact profile model
 link profile model
-declared downlink capacity assumption
-abstract downlink queue policy
+contact window model
+declared contact capacity assumption
+downlink flow contract model
 data product downlink eligibility
-scenario contact events
-generated downlink documentation
-downlink consistency lint rules
+contact/downlink reference validation
+minimal contact/downlink semantic lint rules
+generated contact/downlink documentation
+one synthetic demo contact/downlink slice
 ```
 
-### 9.3 Candidate Lint Rules
+The preferred initial file is:
 
 ```text
-WARNING: produced data volume may exceed declared contact capacity.
-ERROR: downlink policy references unknown contact profile.
-WARNING: critical event has no immediate downlink class.
-WARNING: high-priority product is retained but never scheduled for downlink.
+mission/contacts.yaml
 ```
 
-### 9.4 Boundary
+The file may contain contact profiles, link profiles, contact windows and downlink flow contracts.
 
-v0.4 must not implement orbit propagation, antenna pointing, RF budgets, live ground links, Yamcs/OpenC3 services or real spacecraft operations.
+### 9.4 Deferred Items
 
-Contact windows are contract assumptions, not physical simulation.
+The following items are valid but should not be part of the first v0.4 implementation unless a later PR proves that they are necessary:
+
+```text
+scenario contact events
+partial downlink scenario behavior
+derived capacity from rate and duration
+multiple contact networks
+ground export artifacts
+runtime downlink queues
+```
+
+Scenario contact events are especially easy to over-scope.
+
+They should remain deferred until the model and lint slice are stable.
+
+### 9.5 Candidate Lint Rules
+
+Initial lint direction:
+
+```text
+ERROR: contact window references an unknown contact profile.
+ERROR: contact window references an unknown link profile.
+ERROR: downlink flow references an unknown contact profile.
+ERROR: downlink flow references an unknown link profile.
+ERROR: downlink flow references an unknown data product.
+WARNING: high-priority data product has downlink intent but no eligible downlink flow.
+WARNING: estimated data volume may exceed declared contact capacity.
+```
+
+Linting should expose ambiguity.
+
+It must not pretend to schedule real downlink operations.
+
+### 9.6 Boundary
+
+v0.4 must not implement:
+
+```text
+orbit propagation
+TLE parsing
+ground track computation
+antenna pointing
+RF link budgets
+live ground links
+real contact scheduling
+real downlink execution
+onboard downlink queues
+file transfer protocols
+CCSDS/PUS/CFDP implementation
+Yamcs/OpenC3 services
+real spacecraft operations
+runtime skeleton generation
+ground export generation
+```
+
+Contact windows and downlink flows are contract assumptions, not physical simulation or runtime behavior.
 
 ---
 

--- a/docs/adr/ADR-0009-contact-windows-and-downlink-flow-contracts.md
+++ b/docs/adr/ADR-0009-contact-windows-and-downlink-flow-contracts.md
@@ -1,0 +1,275 @@
+# ADR-0009 — Contact Windows and Downlink Flow Contracts
+
+Status: Accepted  
+Date: 2026-05-04
+
+---
+
+## Context
+
+OrbitFabric is a model-first Mission Data Contract framework for small spacecraft.
+
+The Data Product and Storage Contract Model introduced a contract-level way to describe mission data objects, their producers, estimated size, priority, storage intent, retention intent, overflow policy and downlink intent.
+
+That slice intentionally stopped before contact windows and downlink flow modeling.
+
+However, a data product with downlink intent is still incomplete unless the mission contract can also express the assumptions used to reason about delivery to the ground.
+
+OrbitFabric therefore needs a narrow contract-level model for:
+
+```text
+Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+        -> Contact Window Assumptions
+        -> Downlink Flow Contract
+```
+
+This is a Mission Data Contract concern.
+
+It is not a ground segment concern, not an orbit propagation concern, not an RF simulation concern and not a downlink runtime concern.
+
+---
+
+## Decision
+
+OrbitFabric will introduce Contact Windows and Downlink Flow Contracts as the next Mission Data Chain slice.
+
+The model will describe declared assumptions about contacts, links and downlink flows so that OrbitFabric can reason about consistency before runtime skeletons, ground integration artifacts or end-to-end mission data flow evidence are introduced.
+
+The first implementation slice should be optional and narrow.
+
+The preferred model entry point is:
+
+```text
+mission/contacts.yaml
+```
+
+The model may contain:
+
+```text
+contact profiles
+link profiles
+contact windows
+downlink flow contracts
+declared downlink capacity assumptions
+data product downlink eligibility
+```
+
+These concepts are declarative.
+
+They do not execute contacts, schedule passes, propagate orbits, model RF behavior, transmit data or integrate with live ground systems.
+
+---
+
+## Terminology
+
+OrbitFabric must keep these concepts distinct.
+
+```text
+Contact Profile
+    A declared abstract target or class of contact used by the mission contract.
+
+Link Profile
+    A declared abstract link assumption used for downlink reasoning.
+
+Contact Window
+    A declared availability window or assumed opportunity for contact.
+
+Downlink Flow Contract
+    A declared policy describing how eligible data products are intended to be downlinked.
+
+Declared Capacity
+    A contract-level capacity assumption used for linting and documentation.
+```
+
+A contact window is not an orbit pass computed by OrbitFabric.
+
+A link profile is not an RF link budget.
+
+A downlink flow contract is not a runtime queue implementation.
+
+---
+
+## Minimal Shape
+
+The first slice should use a shape similar to:
+
+```yaml
+contacts:
+  contact_profiles:
+    - id: primary_ground_contact
+      target: synthetic_ground_station
+      description: Synthetic primary ground contact used by the demo mission.
+
+  link_profiles:
+    - id: uhf_downlink_nominal
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: Abstract nominal downlink assumption.
+
+  contact_windows:
+    - id: demo_contact_001
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 600
+      assumed_capacity_bytes: 512000
+
+  downlink_flows:
+    - id: science_next_available_contact
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      queue_policy: priority_then_age
+      eligible_data_products:
+        - payload.radiation_histogram
+```
+
+This shape is a proposed v0.4.0 contract shape.
+
+It is not a frozen v1.0 schema.
+
+---
+
+## Initial Scope
+
+The first vertical slice should include:
+
+```text
+optional contacts.yaml loading
+typed contact/downlink model objects
+contact profile identity validation
+link profile identity validation
+contact window identity validation
+downlink flow identity validation
+reference validation between contact windows, profiles and link profiles
+reference validation from downlink flows to data products
+declared capacity linting direction
+generated contact/downlink documentation
+one synthetic demo contact/downlink slice
+```
+
+The slice should prove this relationship:
+
+```text
+Data Product Contract
+        -> Downlink Intent
+        -> Contact Assumption
+        -> Downlink Flow Contract
+```
+
+---
+
+## Non-Goals
+
+This decision must not introduce:
+
+```text
+orbit propagation
+TLE parsing
+ground track computation
+antenna pointing
+RF link budget simulation
+modulation or coding simulation
+live ground links
+real contact scheduling
+real downlink execution
+onboard downlink queues
+file transfer protocols
+CCSDS implementation
+PUS implementation
+CFDP implementation
+Yamcs runtime integration
+OpenC3 runtime integration
+ground station operations
+operator consoles
+runtime skeleton generation
+ground export generation
+private mission-specific contact data
+```
+
+These are not missing pieces of v0.4.0.
+
+They are intentionally outside the scope of this ADR.
+
+---
+
+## Linting Direction
+
+Contact Windows and Downlink Flow Contracts must be lintable from the beginning.
+
+Initial linting direction should include:
+
+```text
+ERROR: contact window references an unknown contact profile.
+ERROR: contact window references an unknown link profile.
+ERROR: downlink flow references an unknown contact profile.
+ERROR: downlink flow references an unknown link profile.
+ERROR: downlink flow references an unknown data product.
+WARNING: high-priority data product has downlink intent but no eligible downlink flow.
+WARNING: estimated data volume may exceed declared contact capacity.
+```
+
+The principle is fixed:
+
+> If a downlink assumption can become operationally ambiguous, the ambiguity must be visible before runtime or ground artifacts are generated.
+
+---
+
+## Documentation Direction
+
+Generated documentation should expose contact and downlink assumptions from the validated Mission Model.
+
+The expected generated file is:
+
+```text
+generated/docs/contacts.md
+```
+
+The generated page should make clear that contacts, link profiles, capacity and downlink flows are contract assumptions only.
+
+---
+
+## Consequences
+
+This decision extends OrbitFabric from data product and storage intent modeling toward declared onboard-to-ground flow reasoning.
+
+It makes the next Mission Data Chain step explicit:
+
+```text
+payload or subsystem produces data product
+        -> data product declares storage intent
+        -> data product declares downlink intent
+        -> contact/downlink assumptions define expected delivery path
+```
+
+This strengthens later milestones.
+
+End-to-End Mission Data Flow Evidence will be able to reason about produced, retained, queued, eligible and downlinked data products at contract level.
+
+Runtime skeletons and ground integration artifacts will eventually be derived from a stronger model.
+
+---
+
+## Acceptance Criteria for This Decision
+
+This ADR is satisfied when:
+
+- the scope of Contact Windows and Downlink Flow Contracts is documented;
+- contact profiles, link profiles, contact windows and downlink flows are defined as contract assumptions;
+- non-goals are explicit;
+- the model remains optional;
+- contact/downlink concepts are connected to Data Product Contracts;
+- initial linting direction is documented;
+- generated documentation direction is documented;
+- implementation remains narrow, synthetic and clean-room.
+
+---
+
+## Final Position
+
+OrbitFabric must not jump from data product downlink intent directly to runtime or ground integration.
+
+The next correct step is to model the contact and downlink assumptions used to reason about the mission data chain.
+
+That model must stay declarative.

--- a/docs/reference/contact-downlink-contract-model.md
+++ b/docs/reference/contact-downlink-contract-model.md
@@ -1,0 +1,305 @@
+# Contact and Downlink Contract Model
+
+Status: Proposed for OrbitFabric v0.4.0  
+Scope: Contact Windows and Downlink Flow Contract definition
+
+---
+
+## Purpose
+
+The Contact and Downlink Contract Model extends OrbitFabric with an optional model domain for declared contact and downlink assumptions.
+
+Its purpose is to answer a contract-level question:
+
+> Given the declared data products, priorities, storage policies, downlink intent and contact assumptions, is the mission data flow coherent?
+
+The model does not execute downlink.
+
+It does not compute orbital passes.
+
+It does not simulate RF performance.
+
+It does not implement a ground segment.
+
+---
+
+## Relationship with Data Products
+
+The Data Product Contract Model describes mission data objects produced by payloads or subsystems.
+
+The Contact and Downlink Contract Model describes the assumptions used to reason about how those data products are expected to become eligible for downlink.
+
+The relationship is:
+
+```text
+Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+        -> Contact Window Assumption
+        -> Downlink Flow Contract
+```
+
+A data product may declare downlink intent.
+
+A downlink flow contract may declare which data products are eligible for a given abstract contact/link path.
+
+This is declarative.
+
+It does not imply runtime queue execution or file transfer.
+
+---
+
+## What the Model May Describe
+
+A contact/downlink contract may describe:
+
+```text
+contact profile identity
+abstract contact target
+link profile identity
+abstract downlink rate assumption
+contact window identity
+contact window start
+contact window duration
+declared downlink capacity
+downlink flow identity
+queue policy intent
+eligible data products
+```
+
+These fields exist to support validation, linting and generated documentation.
+
+---
+
+## What the Model Does Not Describe
+
+A contact/downlink contract does not describe:
+
+```text
+orbit propagation
+ground track computation
+TLE ingestion
+antenna pointing
+RF link budget
+modulation and coding behavior
+real contact scheduling
+real ground station operations
+live downlink execution
+onboard downlink queues
+file transfer protocols
+CCSDS/PUS/CFDP implementation
+Yamcs/OpenC3 runtime integration
+operator consoles
+runtime skeletons
+ground export artifacts
+```
+
+Those are intentionally outside the v0.4.0 scope.
+
+---
+
+## YAML Shape
+
+Contact and downlink assumptions are expected to be defined in the optional file:
+
+```text
+mission/contacts.yaml
+```
+
+Proposed shape:
+
+```yaml
+contacts:
+  contact_profiles:
+    - id: primary_ground_contact
+      target: synthetic_ground_station
+      description: Synthetic primary ground contact used by the demo mission.
+
+  link_profiles:
+    - id: uhf_downlink_nominal
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: Abstract nominal downlink assumption.
+
+  contact_windows:
+    - id: demo_contact_001
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 600
+      assumed_capacity_bytes: 512000
+
+  downlink_flows:
+    - id: science_next_available_contact
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      queue_policy: priority_then_age
+      eligible_data_products:
+        - payload.radiation_histogram
+```
+
+This shape is intentionally minimal.
+
+OrbitFabric is still pre-1.0 and the schema may evolve before stabilization.
+
+---
+
+## Contact Profiles
+
+A contact profile describes an abstract contact target or contact class.
+
+Examples:
+
+```text
+primary_ground_contact
+backup_ground_contact
+commercial_ground_network
+lab_emulated_contact
+```
+
+A contact profile is not a real ground station configuration.
+
+It is a contract-level target used by contact windows and downlink flows.
+
+---
+
+## Link Profiles
+
+A link profile describes an abstract link assumption.
+
+Examples:
+
+```text
+uhf_downlink_nominal
+s_band_downlink_nominal
+lab_downlink_emulated
+```
+
+A link profile may include an assumed data rate.
+
+That rate is a declared assumption used for linting and documentation.
+
+It is not an RF budget.
+
+---
+
+## Contact Windows
+
+A contact window describes an assumed contact opportunity.
+
+A contact window may reference:
+
+```text
+contact profile
+link profile
+start time
+duration
+declared capacity
+```
+
+The declared capacity may be explicit or derived later from declared rate and duration.
+
+In the first v0.4.0 slice, explicit `assumed_capacity_bytes` is preferred because it avoids pretending to perform physical link simulation.
+
+---
+
+## Downlink Flow Contracts
+
+A downlink flow contract describes how data products are intended to become eligible for downlink.
+
+It may reference:
+
+```text
+contact profile
+link profile
+queue policy intent
+eligible data products
+```
+
+Queue policy is intent only.
+
+Examples:
+
+```text
+priority_then_age
+oldest_first
+manual_selection
+critical_first
+```
+
+The model does not implement a runtime queue.
+
+---
+
+## Initial Lint Direction
+
+Initial lint rules should focus on reference integrity and obvious consistency issues.
+
+Expected rule direction:
+
+```text
+ERROR: contact window references an unknown contact profile.
+ERROR: contact window references an unknown link profile.
+ERROR: downlink flow references an unknown contact profile.
+ERROR: downlink flow references an unknown link profile.
+ERROR: downlink flow references an unknown data product.
+WARNING: high-priority data product has downlink intent but no eligible downlink flow.
+WARNING: estimated data volume may exceed declared contact capacity.
+```
+
+Warnings should expose engineering ambiguity without pretending to solve scheduling.
+
+---
+
+## Generated Documentation
+
+When contact/downlink contracts are present, OrbitFabric should generate Markdown documentation from the validated Mission Model.
+
+Expected generated output:
+
+```text
+generated/docs/contacts.md
+```
+
+The generated page should expose:
+
+```text
+contact profiles
+link profiles
+contact windows
+declared capacities
+downlink flows
+eligible data products
+```
+
+Generated documentation must state that these are contract assumptions, not runtime behavior.
+
+---
+
+## Current Boundary
+
+The v0.4.0 model must remain narrow.
+
+It should strengthen the Mission Data Chain without introducing runtime behavior.
+
+The correct v0.4.0 outcome is:
+
+```text
+Data Product Contract
+        -> Downlink Intent
+        -> Contact/Downlink Contract
+        -> Lintable consistency
+        -> Generated documentation
+```
+
+The incorrect v0.4.0 outcome is:
+
+```text
+orbit simulator
+RF simulator
+ground segment
+downlink runtime
+contact scheduler
+```
+
+That boundary is strict.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Lint Rules v0.1: reference/lint-rules-v0.1.md
       - Payload Contract Model: reference/payload-contract-model.md
       - Data Product Contract Model: reference/data-product-contract-model.md
+  - Contact and Downlink Contract Model: reference/contact-downlink-contract-model.md
   - Releases:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
@@ -41,6 +42,7 @@ nav:
       - ADR-0006 Payload Contract Model: adr/ADR-0006-payload-contract-model.md
       - ADR-0007 Mission Data Chain Before Runtime: adr/ADR-0007-mission-data-chain-before-runtime.md
       - ADR-0008 Data Product and Storage Contracts: adr/ADR-0008-data-product-and-storage-contracts.md
+  - ADR-0009 Contact Windows and Downlink Flow Contracts: adr/ADR-0009-contact-windows-and-downlink-flow-contracts.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

Defines the architectural scope for the v0.4 Contact Windows and Downlink Flow Contracts milestone.

This PR adds:

- ADR-0009 for Contact Windows and Downlink Flow Contracts
- an initial reference page for the Contact and Downlink Contract Model
- a refined v0.4 roadmap section
- MkDocs navigation entries for the new ADR and reference page

## Boundary

This PR is documentation-only.

It does not introduce:

- model code
- YAML loader changes
- lint rules
- generated documentation changes
- demo mission updates
- runtime behavior

## Non-goals

v0.4 remains contract-level only.

This PR explicitly excludes:

- orbit propagation
- RF link budget simulation
- live ground links
- real contact scheduling
- real downlink execution
- Yamcs/OpenC3 runtime integration
- CCSDS/PUS/CFDP implementation
- runtime skeleton generation
- ground export generation

## Validation

- [x] git diff --check
- [x] mkdocs build --strict