### PR TITLE
lint: add contact downlink consistency rules

### DIFF
--- a/src/orbitfabric/lint/engine.py
+++ b/src/orbitfabric/lint/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from orbitfabric.lint.finding import LintReport
 from orbitfabric.lint.rules_commands import check_commands
+from orbitfabric.lint.rules_contacts import check_contacts
 from orbitfabric.lint.rules_data_products import check_data_products
 from orbitfabric.lint.rules_events import check_events
 from orbitfabric.lint.rules_faults import check_faults
@@ -22,6 +23,7 @@ class LintEngine:
         findings.extend(check_modes(model))
         findings.extend(check_payloads(model))
         findings.extend(check_data_products(model))
+        findings.extend(check_contacts(model))
         findings.extend(check_telemetry(model))
         findings.extend(check_commands(model))
         findings.extend(check_events(model))

--- a/src/orbitfabric/lint/rules_contacts.py
+++ b/src/orbitfabric/lint/rules_contacts.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from orbitfabric.lint.finding import LintFinding
+from orbitfabric.model.mission import ContactWindow, DownlinkFlowContract, MissionModel
+
+
+def check_contacts(model: MissionModel) -> list[LintFinding]:
+    """Check Contact Windows and Downlink Flow Contract consistency."""
+    findings: list[LintFinding] = []
+
+    for contact_window in model.contacts.contact_windows:
+        findings.extend(_check_contact_window_references(model, contact_window))
+
+    for downlink_flow in model.contacts.downlink_flows:
+        findings.extend(_check_downlink_flow_references(model, downlink_flow))
+
+    if _has_contact_domain_content(model):
+        findings.extend(_check_high_priority_products_are_eligible(model))
+        findings.extend(_check_declared_contact_capacity(model))
+
+    return findings
+
+
+def _check_contact_window_references(
+    model: MissionModel,
+    contact_window: ContactWindow,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if contact_window.contact_profile not in model.contact_profile_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CON-001",
+                file="contacts.yaml",
+                domain="contact_windows",
+                object_id=contact_window.id,
+                message=(
+                    "contact window references unknown contact profile "
+                    f"'{contact_window.contact_profile}'"
+                ),
+                suggestion="Add the contact profile or fix contact_window.contact_profile.",
+            )
+        )
+
+    if contact_window.link_profile not in model.link_profile_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CON-002",
+                file="contacts.yaml",
+                domain="contact_windows",
+                object_id=contact_window.id,
+                message=(
+                    "contact window references unknown link profile "
+                    f"'{contact_window.link_profile}'"
+                ),
+                suggestion="Add the link profile or fix contact_window.link_profile.",
+            )
+        )
+
+    return findings
+
+
+def _check_downlink_flow_references(
+    model: MissionModel,
+    downlink_flow: DownlinkFlowContract,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if downlink_flow.contact_profile not in model.contact_profile_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-DL-001",
+                file="contacts.yaml",
+                domain="downlink_flows",
+                object_id=downlink_flow.id,
+                message=(
+                    "downlink flow references unknown contact profile "
+                    f"'{downlink_flow.contact_profile}'"
+                ),
+                suggestion="Add the contact profile or fix downlink_flow.contact_profile.",
+            )
+        )
+
+    if downlink_flow.link_profile not in model.link_profile_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-DL-002",
+                file="contacts.yaml",
+                domain="downlink_flows",
+                object_id=downlink_flow.id,
+                message=(
+                    "downlink flow references unknown link profile "
+                    f"'{downlink_flow.link_profile}'"
+                ),
+                suggestion="Add the link profile or fix downlink_flow.link_profile.",
+            )
+        )
+
+    for data_product_id in downlink_flow.eligible_data_products:
+        if data_product_id in model.data_product_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-DL-003",
+                file="contacts.yaml",
+                domain="downlink_flows",
+                object_id=downlink_flow.id,
+                message=(
+                    "downlink flow references unknown eligible data product "
+                    f"'{data_product_id}'"
+                ),
+                suggestion="Add the data product or fix downlink_flow.eligible_data_products.",
+            )
+        )
+
+    return findings
+
+
+def _check_high_priority_products_are_eligible(model: MissionModel) -> list[LintFinding]:
+    eligible_ids = _eligible_data_product_ids(model.contacts.downlink_flows)
+    findings: list[LintFinding] = []
+
+    for data_product in model.data_products:
+        if data_product.priority not in {"high", "critical"}:
+            continue
+
+        if data_product.downlink is None or data_product.downlink.policy in {None, "none"}:
+            continue
+
+        if data_product.id in eligible_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-DL-004",
+                file="data_products.yaml",
+                domain="data_products",
+                object_id=data_product.id,
+                message=(
+                    "high-priority data product has downlink intent but is not "
+                    "eligible in any downlink flow"
+                ),
+                suggestion=(
+                    "Add the data product to a downlink flow eligible_data_products "
+                    "list, or revise its downlink intent."
+                ),
+            )
+        )
+
+    return findings
+
+
+def _check_declared_contact_capacity(model: MissionModel) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    data_product_sizes = {
+        data_product.id: data_product.estimated_size_bytes
+        for data_product in model.data_products
+    }
+
+    for downlink_flow in model.contacts.downlink_flows:
+        estimated_size = sum(
+            data_product_sizes[data_product_id]
+            for data_product_id in downlink_flow.eligible_data_products
+            if data_product_id in data_product_sizes
+        )
+        if estimated_size == 0:
+            continue
+
+        declared_capacity = _declared_capacity_for_flow(model, downlink_flow)
+        if declared_capacity is None or estimated_size <= declared_capacity:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-DL-005",
+                file="contacts.yaml",
+                domain="downlink_flows",
+                object_id=downlink_flow.id,
+                message=(
+                    "estimated eligible data product volume may exceed declared "
+                    "contact capacity"
+                ),
+                suggestion=(
+                    "Increase declared contact capacity, reduce eligible data volume, "
+                    "or split the flow across multiple contacts."
+                ),
+            )
+        )
+
+    return findings
+
+
+def _declared_capacity_for_flow(
+    model: MissionModel,
+    downlink_flow: DownlinkFlowContract,
+) -> int | None:
+    capacities = [
+        contact_window.assumed_capacity_bytes
+        for contact_window in model.contacts.contact_windows
+        if contact_window.contact_profile == downlink_flow.contact_profile
+        and contact_window.link_profile == downlink_flow.link_profile
+        and contact_window.assumed_capacity_bytes is not None
+    ]
+
+    if not capacities:
+        return None
+
+    return sum(capacities)
+
+
+def _eligible_data_product_ids(
+    downlink_flows: Iterable[DownlinkFlowContract],
+) -> set[str]:
+    eligible_ids: set[str] = set()
+
+    for downlink_flow in downlink_flows:
+        eligible_ids.update(downlink_flow.eligible_data_products)
+
+    return eligible_ids
+
+
+def _has_contact_domain_content(model: MissionModel) -> bool:
+    return any(
+        (
+            model.contacts.contact_profiles,
+            model.contacts.link_profiles,
+            model.contacts.contact_windows,
+            model.contacts.downlink_flows,
+        )
+    )

--- a/tests/test_lint_contacts.py
+++ b/tests/test_lint_contacts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.lint.engine import LintEngine
+from orbitfabric.model.loader import MissionModelLoader
+from orbitfabric.model.mission import (
+    ContactContracts,
+    ContactProfile,
+    ContactWindow,
+    DownlinkFlowContract,
+    LinkProfile,
+)
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def _model_with_valid_contacts():
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.contacts = ContactContracts(
+        contact_profiles=[
+            ContactProfile(
+                id="primary_ground_contact",
+                target="synthetic_ground_station",
+            )
+        ],
+        link_profiles=[
+            LinkProfile(
+                id="uhf_downlink_nominal",
+                direction="downlink",
+                assumed_rate_bps=9600,
+            )
+        ],
+        contact_windows=[
+            ContactWindow(
+                id="demo_contact_001",
+                contact_profile="primary_ground_contact",
+                link_profile="uhf_downlink_nominal",
+                start="2026-01-01T00:00:00Z",
+                duration_seconds=600,
+                assumed_capacity_bytes=8192,
+            )
+        ],
+        downlink_flows=[
+            DownlinkFlowContract(
+                id="science_next_available_contact",
+                contact_profile="primary_ground_contact",
+                link_profile="uhf_downlink_nominal",
+                queue_policy="priority_then_age",
+                eligible_data_products=["payload.radiation_histogram"],
+            )
+        ],
+    )
+    return model
+
+
+def _codes_for(model) -> set[str]:
+    report = LintEngine().run(model)
+    return {finding.code for finding in report.findings}
+
+
+def test_demo_mission_without_contacts_still_has_no_findings() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    assert _codes_for(model) == set()
+
+
+def test_valid_contact_downlink_contracts_have_no_findings() -> None:
+    model = _model_with_valid_contacts()
+
+    assert _codes_for(model) == set()
+
+
+def test_contact_window_unknown_contact_profile_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.contact_windows[0].contact_profile = "missing_contact_profile"
+
+    report = LintEngine().run(model)
+
+    assert "OF-CON-001" in {finding.code for finding in report.findings}
+    assert report.has_errors
+
+
+def test_contact_window_unknown_link_profile_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.contact_windows[0].link_profile = "missing_link_profile"
+
+    report = LintEngine().run(model)
+
+    assert "OF-CON-002" in {finding.code for finding in report.findings}
+    assert report.has_errors
+
+
+def test_downlink_flow_unknown_contact_profile_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.downlink_flows[0].contact_profile = "missing_contact_profile"
+
+    report = LintEngine().run(model)
+
+    assert "OF-DL-001" in {finding.code for finding in report.findings}
+    assert report.has_errors
+
+
+def test_downlink_flow_unknown_link_profile_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.downlink_flows[0].link_profile = "missing_link_profile"
+
+    report = LintEngine().run(model)
+
+    assert "OF-DL-002" in {finding.code for finding in report.findings}
+    assert report.has_errors
+
+
+def test_downlink_flow_unknown_data_product_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.downlink_flows[0].eligible_data_products = ["payload.missing_product"]
+
+    report = LintEngine().run(model)
+
+    assert "OF-DL-003" in {finding.code for finding in report.findings}
+    assert report.has_errors
+
+
+def test_contact_domain_without_downlink_flows_warns_about_high_priority_product() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.downlink_flows = []
+
+    report = LintEngine().run(model)
+
+    assert "OF-DL-004" in {finding.code for finding in report.findings}
+    assert report.warning_count == 1
+
+
+def test_downlink_flow_capacity_warning_is_reported() -> None:
+    model = _model_with_valid_contacts()
+    model.contacts.contact_windows[0].assumed_capacity_bytes = 1024
+
+    report = LintEngine().run(model)
+
+    assert "OF-DL-005" in {finding.code for finding in report.findings}
+    assert report.warning_count == 1


### PR DESCRIPTION
## Summary

Adds the first semantic lint rules for the v0.4 Contact Windows and Downlink Flow Contracts domain.

This PR introduces:

- `rules_contacts.py`
- Contact/domain reference checks
- Downlink flow reference checks
- High-priority data product downlink eligibility warning
- Declared contact capacity warning
- Contact lint integration in `LintEngine`
- Focused lint tests for the new rules

## Rules

- `OF-CON-001`: contact window references unknown contact profile
- `OF-CON-002`: contact window references unknown link profile
- `OF-DL-001`: downlink flow references unknown contact profile
- `OF-DL-002`: downlink flow references unknown link profile
- `OF-DL-003`: downlink flow references unknown data product
- `OF-DL-004`: high-priority data product has downlink intent but no eligible downlink flow
- `OF-DL-005`: estimated data product volume may exceed declared contact capacity

## Boundary

This PR is lint-only.

It does not introduce:

- new model fields
- loader changes
- generated documentation
- demo mission contact assumptions
- scenario contact events
- runtime behavior
- version bump

## Non-goals

The checks remain contract-level only.

This PR does not implement:

- orbit propagation
- RF/link budget simulation
- real contact scheduling
- downlink runtime queues
- live ground links
- CCSDS/PUS/CFDP behavior
- Yamcs/OpenC3 integration

## Validation

- [x] ruff check .
- [x] pytest
- [x] git diff --check