### PR TITLE
docs: generate contact downlink contract reference

### DIFF
--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -6,13 +6,17 @@ from typing import Any
 from orbitfabric.model.mission import (
     Command,
     CommandArgument,
+    ContactProfile,
+    ContactWindow,
     DataProductContract,
     DataProductDownlinkIntent,
     DataProductStorageIntent,
+    DownlinkFlowContract,
     Event,
     Fault,
     FaultCondition,
     FaultRecovery,
+    LinkProfile,
     MissionModel,
     Packet,
     PayloadContract,
@@ -43,6 +47,11 @@ def generate_markdown_docs(model: MissionModel, output_dir: Path) -> list[Path]:
     if model.data_products:
         generated_files.append(
             _write(output_dir / "data_products.md", _render_data_products(model))
+        )
+
+    if _has_contact_contracts(model):
+        generated_files.append(
+            _write(output_dir / "contacts.md", _render_contacts(model))
         )
 
     return generated_files
@@ -356,6 +365,143 @@ def _render_data_product_row(
         f"| {_format_downlink_intent(data_product.downlink)} "
         f"| {_text(data_product.description or '-')} |\n"
     )
+
+
+def _has_contact_contracts(model: MissionModel) -> bool:
+    return any(
+        (
+            model.contacts.contact_profiles,
+            model.contacts.link_profiles,
+            model.contacts.contact_windows,
+            model.contacts.downlink_flows,
+        )
+    )
+
+
+def _render_contacts(model: MissionModel) -> str:
+    lines = [_header("Contact and Downlink Contract Reference", model)]
+
+    lines.append("## Summary\n\n")
+    lines.append(f"- Contact profiles: `{len(model.contacts.contact_profiles)}`\n")
+    lines.append(f"- Link profiles: `{len(model.contacts.link_profiles)}`\n")
+    lines.append(f"- Contact windows: `{len(model.contacts.contact_windows)}`\n")
+    lines.append(f"- Downlink flows: `{len(model.contacts.downlink_flows)}`\n\n")
+    lines.append(
+        "Contact windows, link profiles, declared capacities and downlink flows "
+        "describe contract assumptions only. They do not imply orbit propagation, "
+        "RF simulation, contact scheduling or downlink runtime behavior.\n\n"
+    )
+
+    lines.append(_render_contact_profiles(model.contacts.contact_profiles))
+    lines.append(_render_link_profiles(model.contacts.link_profiles))
+    lines.append(_render_contact_windows(model.contacts.contact_windows))
+    lines.append(_render_downlink_flows(model.contacts.downlink_flows))
+
+    return "".join(lines)
+
+
+def _render_contact_profiles(contact_profiles: list[ContactProfile]) -> str:
+    lines = ["## Contact profiles\n\n"]
+
+    if not contact_profiles:
+        lines.append("No contact profiles declared.\n\n")
+        return "".join(lines)
+
+    lines.append("| ID | Target | Description |\n")
+    lines.append("|---|---|---|\n")
+
+    for profile in sorted(contact_profiles, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(profile.id)} "
+            f"| {_code(profile.target)} "
+            f"| {_text(profile.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_link_profiles(link_profiles: list[LinkProfile]) -> str:
+    lines = ["## Link profiles\n\n"]
+
+    if not link_profiles:
+        lines.append("No link profiles declared.\n\n")
+        return "".join(lines)
+
+    lines.append("| ID | Direction | Assumed Rate bps | Description |\n")
+    lines.append("|---|---|---:|---|\n")
+
+    for profile in sorted(link_profiles, key=lambda item: item.id):
+        rate = profile.assumed_rate_bps if profile.assumed_rate_bps is not None else "-"
+        lines.append(
+            f"| {_code(profile.id)} "
+            f"| {_code(profile.direction)} "
+            f"| {rate} "
+            f"| {_text(profile.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_contact_windows(contact_windows: list[ContactWindow]) -> str:
+    lines = ["## Contact windows\n\n"]
+
+    if not contact_windows:
+        lines.append("No contact windows declared.\n\n")
+        return "".join(lines)
+
+    lines.append(
+        "| ID | Contact Profile | Link Profile | Start | Duration s | "
+        "Assumed Capacity Bytes | Description |\n"
+    )
+    lines.append("|---|---|---|---|---:|---:|---|\n")
+
+    for window in sorted(contact_windows, key=lambda item: item.id):
+        capacity = (
+            window.assumed_capacity_bytes
+            if window.assumed_capacity_bytes is not None
+            else "-"
+        )
+        lines.append(
+            f"| {_code(window.id)} "
+            f"| {_code(window.contact_profile)} "
+            f"| {_code(window.link_profile)} "
+            f"| {_code(window.start)} "
+            f"| {window.duration_seconds} "
+            f"| {capacity} "
+            f"| {_text(window.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_downlink_flows(downlink_flows: list[DownlinkFlowContract]) -> str:
+    lines = ["## Downlink flows\n\n"]
+
+    if not downlink_flows:
+        lines.append("No downlink flows declared.\n\n")
+        return "".join(lines)
+
+    lines.append(
+        "| ID | Contact Profile | Link Profile | Queue Policy | "
+        "Eligible Data Products | Description |\n"
+    )
+    lines.append("|---|---|---|---|---|---|\n")
+
+    for flow in sorted(downlink_flows, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(flow.id)} "
+            f"| {_code(flow.contact_profile)} "
+            f"| {_code(flow.link_profile)} "
+            f"| {_code(flow.queue_policy)} "
+            f"| {_format_list(flow.eligible_data_products)} "
+            f"| {_text(flow.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
 
 
 def _producer_heading(model: MissionModel, data_product: DataProductContract) -> str:

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -5,9 +5,14 @@ from pathlib import Path
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.model.loader import MissionModelLoader
 from orbitfabric.model.mission import (
+    ContactContracts,
+    ContactProfile,
+    ContactWindow,
     DataProductContract,
     DataProductDownlinkIntent,
     DataProductStorageIntent,
+    DownlinkFlowContract,
+    LinkProfile,
 )
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
@@ -30,6 +35,46 @@ def make_valid_data_product() -> DataProductContract:
         ),
         downlink=DataProductDownlinkIntent(policy="priority_based"),
         description="Synthetic payload histogram data product.",
+    )
+
+
+def make_valid_contacts() -> ContactContracts:
+    return ContactContracts(
+        contact_profiles=[
+            ContactProfile(
+                id="primary_ground_contact",
+                target="synthetic_ground_station",
+                description="Synthetic primary ground contact.",
+            )
+        ],
+        link_profiles=[
+            LinkProfile(
+                id="uhf_downlink_nominal",
+                direction="downlink",
+                assumed_rate_bps=9600,
+                description="Abstract nominal downlink assumption.",
+            )
+        ],
+        contact_windows=[
+            ContactWindow(
+                id="demo_contact_001",
+                contact_profile="primary_ground_contact",
+                link_profile="uhf_downlink_nominal",
+                start="2026-01-01T00:00:00Z",
+                duration_seconds=600,
+                assumed_capacity_bytes=512000,
+            )
+        ],
+        downlink_flows=[
+            DownlinkFlowContract(
+                id="science_next_available_contact",
+                contact_profile="primary_ground_contact",
+                link_profile="uhf_downlink_nominal",
+                queue_policy="priority_then_age",
+                eligible_data_products=["payload.radiation_histogram"],
+                description="Synthetic science downlink flow.",
+            )
+        ],
     )
 
 
@@ -127,3 +172,44 @@ def test_data_product_contract_docs_are_skipped_without_data_products(
 
     assert "data_products.md" not in generated_names
     assert not (tmp_path / "data_products.md").exists()
+
+def test_generate_contact_downlink_contract_docs(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.contacts = make_valid_contacts()
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    contacts_path = tmp_path / "contacts.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "contacts.md" in generated_names
+    assert contacts_path.exists()
+
+    content = contacts_path.read_text(encoding="utf-8")
+
+    assert "# Contact and Downlink Contract Reference" in content
+    assert "contract assumptions only" in content
+    assert "`primary_ground_contact`" in content
+    assert "`synthetic_ground_station`" in content
+    assert "`uhf_downlink_nominal`" in content
+    assert "`downlink`" in content
+    assert "9600" in content
+    assert "`demo_contact_001`" in content
+    assert "`2026-01-01T00:00:00Z`" in content
+    assert "512000" in content
+    assert "`science_next_available_contact`" in content
+    assert "`priority_then_age`" in content
+    assert "`payload.radiation_histogram`" in content
+
+
+def test_contact_downlink_docs_are_skipped_without_contact_contracts(
+    tmp_path: Path,
+) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.contacts = ContactContracts()
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+    generated_names = {path.name for path in generated_files}
+
+    assert "contacts.md" not in generated_names
+    assert not (tmp_path / "contacts.md").exists()


### PR DESCRIPTION
## Summary

Adds generated Markdown documentation for the v0.4 Contact and Downlink Contract domain.

This PR introduces:

- conditional generation of `contacts.md`
- Contact and Downlink Contract Reference rendering
- contact profile table
- link profile table
- contact window table
- downlink flow table
- docs generator tests for the generated contact/downlink reference

## Boundary

This PR is generated-docs only.

It does not introduce:

- model changes
- loader changes
- lint changes
- demo mission contact assumptions
- scenario contact events
- runtime behavior
- version bump

## Non-goals

Generated contact/downlink documentation remains contract-level only.

This PR does not implement:

- orbit propagation
- RF/link budget simulation
- real contact scheduling
- downlink runtime queues
- live ground links
- CCSDS/PUS/CFDP behavior
- Yamcs/OpenC3 integration

## Validation

- [x] git diff --check
- [x] ruff check .
- [x] pytest