### PR TITLE
demo: add contact downlink assumptions

### DIFF
--- a/examples/demo-3u/mission/contacts.yaml
+++ b/examples/demo-3u/mission/contacts.yaml
@@ -1,0 +1,29 @@
+contacts:
+  contact_profiles:
+    - id: primary_ground_contact
+      target: synthetic_ground_station
+      description: Synthetic primary ground contact used by the demo mission.
+
+  link_profiles:
+    - id: uhf_downlink_nominal
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: Abstract nominal downlink assumption for contract-level reasoning.
+
+  contact_windows:
+    - id: demo_contact_001
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 600
+      assumed_capacity_bytes: 512000
+      description: Synthetic contact window used to demonstrate downlink flow assumptions.
+
+  downlink_flows:
+    - id: science_next_available_contact
+      contact_profile: primary_ground_contact
+      link_profile: uhf_downlink_nominal
+      queue_policy: priority_then_age
+      eligible_data_products:
+        - payload.radiation_histogram
+      description: Synthetic science downlink flow used by the demo mission.

--- a/tests/test_doc_generator.py
+++ b/tests/test_doc_generator.py
@@ -28,6 +28,7 @@ def test_generate_markdown_docs(tmp_path: Path) -> None:
         "packets.md",
         "payloads.md",
         "data_products.md",
+        "contacts.md",
     }
 
     telemetry_doc = (tmp_path / "telemetry.md").read_text(encoding="utf-8")

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -140,6 +140,31 @@ def test_generate_demo_data_product_contract_docs(tmp_path: Path) -> None:
     assert "Synthetic payload histogram data product used to demonstrate" in content
 
 
+def test_generate_demo_contact_downlink_contract_docs(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    contacts_path = tmp_path / "contacts.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "contacts.md" in generated_names
+    assert contacts_path.exists()
+
+    content = contacts_path.read_text(encoding="utf-8")
+
+    assert "# Contact and Downlink Contract Reference" in content
+    assert "contract assumptions only" in content
+    assert "`primary_ground_contact`" in content
+    assert "`synthetic_ground_station`" in content
+    assert "`uhf_downlink_nominal`" in content
+    assert "`demo_contact_001`" in content
+    assert "512000" in content
+    assert "`science_next_available_contact`" in content
+    assert "`priority_then_age`" in content
+    assert "`payload.radiation_histogram`" in content
+
+
 def test_generate_data_product_contract_docs_from_model_object(tmp_path: Path) -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
     model.data_products = [make_valid_data_product()]

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -78,10 +78,10 @@ def test_load_demo_mission() -> None:
     assert len(model.events) >= 8
     assert len(model.faults) == 2
     assert len(model.packets) >= 3
-    assert model.contacts.contact_profiles == []
-    assert model.contacts.link_profiles == []
-    assert model.contacts.contact_windows == []
-    assert model.contacts.downlink_flows == []
+    assert len(model.contacts.contact_profiles) == 1
+    assert len(model.contacts.link_profiles) == 1
+    assert len(model.contacts.contact_windows) == 1
+    assert len(model.contacts.downlink_flows) == 1
 
 
 def test_load_demo_payload_contract() -> None:
@@ -160,6 +160,31 @@ def test_load_demo_data_product_contract() -> None:
     assert data_product.downlink.policy == "next_available_contact"
     assert data_product.description is not None
     assert model.data_product_ids == {"payload.radiation_histogram"}
+
+
+def test_load_demo_contact_downlink_contract() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contact_profile = model.contacts.contact_profiles[0]
+    link_profile = model.contacts.link_profiles[0]
+    contact_window = model.contacts.contact_windows[0]
+    downlink_flow = model.contacts.downlink_flows[0]
+
+    assert contact_profile.id == "primary_ground_contact"
+    assert contact_profile.target == "synthetic_ground_station"
+    assert link_profile.id == "uhf_downlink_nominal"
+    assert link_profile.direction == "downlink"
+    assert link_profile.assumed_rate_bps == 9600
+    assert contact_window.id == "demo_contact_001"
+    assert contact_window.contact_profile == "primary_ground_contact"
+    assert contact_window.link_profile == "uhf_downlink_nominal"
+    assert contact_window.duration_seconds == 600
+    assert contact_window.assumed_capacity_bytes == 512000
+    assert downlink_flow.id == "science_next_available_contact"
+    assert downlink_flow.contact_profile == "primary_ground_contact"
+    assert downlink_flow.link_profile == "uhf_downlink_nominal"
+    assert downlink_flow.queue_policy == "priority_then_age"
+    assert downlink_flow.eligible_data_products == ["payload.radiation_histogram"]
 
 
 def test_optional_data_products_file_can_be_absent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the first synthetic Contact and Downlink Contract assumptions to the demo mission.

This PR introduces:

- `examples/demo-3u/mission/contacts.yaml`
- a synthetic contact profile
- a synthetic downlink link profile
- a synthetic contact window with declared capacity
- a downlink flow for `payload.radiation_histogram`
- updated model-loader and docs-generator tests for the demo mission

## Boundary

This PR is demo/evidence only.

It does not introduce:

- model changes
- loader changes
- lint changes
- docs generator changes
- scenario contact events
- runtime behavior
- version bump

## Contract chain demonstrated

```text
Data Product Contract
    -> Downlink Intent
    -> Contact Window Assumption
    -> Downlink Flow Contract
```

## Non-goals

The demo contact/downlink assumptions remain synthetic and declarative.

This PR does not implement:

- orbit propagation
- RF/link budget simulation
- real contact scheduling
- downlink runtime queues
- live ground links
- CCSDS/PUS/CFDP behavior
- Yamcs/OpenC3 integration

## Validation

- [x] git diff --check
- [x] ruff check .
- [x] pytest