### PR TITLE
Feature/university cubesat minislice

### DIFF
--- a/examples/university-cubesat-minislice/mission/commands.yaml
+++ b/examples/university-cubesat-minislice/mission/commands.yaml
@@ -126,7 +126,7 @@ commands:
       - LOW_POWER
     requires_ack: true
     timeout_ms: 1000
-    risk: medium
+    risk: low
     emits:
       - obc.fault_cleared
     expected_effects:

--- a/examples/university-cubesat-minislice/mission/commands.yaml
+++ b/examples/university-cubesat-minislice/mission/commands.yaml
@@ -1,0 +1,188 @@
+commands:
+  - id: obc.request_health_telemetry
+    target: obc_or_cdh
+    description: Request current critical housekeeping and health telemetry products.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - PAYLOAD_ACQUISITION
+      - DOWNLINK
+      - LOW_POWER
+      - SAFE
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - obc.health_telemetry_requested
+    expected_effects:
+      no_state_change: true
+
+  - id: comms.request_payload_data
+    target: comms
+    description: Request payload data eligibility for the next prioritized downlink flow.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+      - DOWNLINK
+    preconditions:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DATA_READY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.payload_data_requested
+    expected_effects:
+      no_state_change: true
+
+  - id: payload.schedule_acquisition
+    target: payload
+    description: Schedule and complete a bounded generic payload acquisition, producing an observation data product.
+    arguments:
+      - name: duration_s
+        type: uint16
+        min: 1
+        max: 600
+        description: Requested acquisition duration in seconds.
+    allowed_modes:
+      - NOMINAL
+    preconditions:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: READY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: medium
+    emits:
+      - payload.data_generated
+    expected_effects:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DATA_READY
+      telemetry:
+        payload.status: DATA_READY
+        payload.data_generated_bytes: 32000
+        payload.data_pending_bytes: 18000
+        data_storage.used_bytes: 32000
+
+  - id: obc.enter_safe_mode
+    target: obc_or_cdh
+    description: Request transition to safe mode.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - PAYLOAD_ACQUISITION
+      - DOWNLINK
+      - LOW_POWER
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: high
+    emits:
+      - obc.safe_mode_requested
+    expected_effects:
+      telemetry:
+        payload.status: IDLE
+      mode_transition:
+        to: SAFE
+
+  - id: comms.set_downlink_priority
+    target: comms
+    description: Select the priority policy used by the constrained downlink flow.
+    arguments:
+      - name: policy
+        type: enum
+        enum:
+          - critical_first
+          - priority_then_age
+          - manual_selection
+        default: critical_first
+        description: Abstract queue selection policy for the next downlink opportunity.
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+      - DOWNLINK
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - comms.downlink_priority_set
+    expected_effects:
+      no_state_change: true
+
+  - id: obc.clear_fault
+    target: obc_or_cdh
+    description: Clear a recorded warning or fault after ground review.
+    arguments:
+      - name: fault_id
+        type: string
+        description: Fault identifier to clear.
+    allowed_modes:
+      - SAFE
+      - FAULT_RECOVERY
+      - LOW_POWER
+    requires_ack: true
+    timeout_ms: 1000
+    risk: medium
+    emits:
+      - obc.fault_cleared
+    expected_effects:
+      no_state_change: true
+
+  - id: comms.start_downlink
+    target: comms
+    description: Start the prioritized downlink flow for the current abstract contact window.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+    preconditions:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DATA_READY
+    requires_ack: true
+    timeout_ms: 1500
+    risk: medium
+    emits:
+      - comms.contact_window_started
+      - comms.downlink_started
+      - comms.beacon_transmitted
+      - comms.downlink_partial
+      - payload.data_pending
+      - comms.downlink_capacity_insufficient
+    expected_effects:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DOWNLINK_PENDING
+      telemetry:
+        comms.link_status: DOWNLINK_ACTIVE
+        downlink.capacity_remaining_bytes: 0
+        payload.data_pending_bytes: 13680
+        payload.status: DOWNLINK_PENDING
+      mode_transition:
+        to: DOWNLINK
+
+  - id: comms.end_downlink
+    target: comms
+    description: Close the current contact window and record remaining pending payload data.
+    arguments: []
+    allowed_modes:
+      - DOWNLINK
+    preconditions:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DOWNLINK_PENDING
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.contact_window_ended
+    expected_effects:
+      telemetry:
+        comms.link_status: NO_CONTACT
+        payload.status: BACKLOG
+      mode_transition:
+        to: LOW_POWER

--- a/examples/university-cubesat-minislice/mission/contacts.yaml
+++ b/examples/university-cubesat-minislice/mission/contacts.yaml
@@ -1,0 +1,33 @@
+contacts:
+  contact_profiles:
+    - id: university_ground_contact
+      target: generic_university_ground_station
+      description: Abstract university ground contact used for clean-room downlink contract assumptions.
+
+  link_profiles:
+    - id: low_rate_uhf_downlink
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: Generic low-rate UHF-like downlink assumption for constrained contact reasoning.
+
+  contact_windows:
+    - id: low_rate_contact_001
+      contact_profile: university_ground_contact
+      link_profile: low_rate_uhf_downlink
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 300
+      assumed_capacity_bytes: 12000
+      description: Synthetic low-rate contact window with intentionally limited capacity.
+
+  downlink_flows:
+    - id: university_priority_downlink
+      contact_profile: university_ground_contact
+      link_profile: low_rate_uhf_downlink
+      queue_policy: critical_first
+      eligible_data_products:
+        - critical_housekeeping_packet
+        - health_beacon
+        - downlink_summary_report
+        - scenario_evidence_log
+        - compressed_payload_bundle
+      description: Priority-based downlink flow demonstrating health-first allocation and pending payload data.

--- a/examples/university-cubesat-minislice/mission/data_products.yaml
+++ b/examples/university-cubesat-minislice/mission/data_products.yaml
@@ -1,0 +1,86 @@
+data_products:
+  - id: critical_housekeeping_packet
+    producer: obc_or_cdh
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 1024
+    priority: critical
+    storage:
+      class: housekeeping
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Critical housekeeping product containing EPS and bus health telemetry.
+
+  - id: health_beacon
+    producer: comms
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 512
+    priority: high
+    storage:
+      class: housekeeping
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+    description: Low-rate health beacon product prioritized before payload data.
+
+  - id: downlink_summary_report
+    producer: obc_or_cdh
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 2048
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Summary of contact capacity usage and remaining pending payload data.
+
+  - id: payload_observation_record
+    producer: generic_observation_payload
+    producer_type: payload
+    type: sample_batch
+    estimated_size_bytes: 32000
+    priority: medium
+    payload: generic_observation_payload
+    storage:
+      class: science
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: deferred
+    description: Generic raw observation record produced by the payload and retained onboard.
+
+  - id: compressed_payload_bundle
+    producer: generic_observation_payload
+    producer_type: payload
+    type: compressed_product
+    estimated_size_bytes: 18000
+    priority: medium
+    payload: generic_observation_payload
+    storage:
+      class: science
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Compressed payload bundle eligible for downlink after critical housekeeping and beacon data.
+
+  - id: scenario_evidence_log
+    producer: obc_or_cdh
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Scenario evidence log explaining why payload data remained partially pending.

--- a/examples/university-cubesat-minislice/mission/events.yaml
+++ b/examples/university-cubesat-minislice/mission/events.yaml
@@ -1,0 +1,133 @@
+events:
+  - id: comms.beacon_transmitted
+    source: comms
+    severity: info
+    description: Health beacon transmitted during a contact opportunity.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: payload.data_generated
+    source: payload
+    severity: info
+    description: Payload observation data product generated and stored onboard.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_started
+    source: comms
+    severity: info
+    description: Abstract low-rate contact window started.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_ended
+    source: comms
+    severity: info
+    description: Abstract low-rate contact window ended.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: comms.downlink_started
+    source: comms
+    severity: info
+    description: Prioritized downlink flow started for the available contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_completed
+    source: comms
+    severity: info
+    description: Downlink flow completed without remaining eligible payload data.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: comms.downlink_partial
+    source: comms
+    severity: warning
+    description: Downlink flow was capacity-constrained and only part of the eligible payload data could be sent.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: payload.data_pending
+    source: payload
+    severity: warning
+    description: Payload data remains pending after the constrained contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: eps.low_power_warning_raised
+    source: eps
+    severity: warning
+    description: Battery state of charge crossed the low-power warning threshold.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: eps.low_battery_critical_raised
+    source: eps
+    severity: critical
+    description: Battery state of charge crossed the critical threshold.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: obc.mode_changed
+    source: obc_or_cdh
+    severity: info
+    description: Spacecraft operational mode changed.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: obc.health_telemetry_requested
+    source: obc_or_cdh
+    severity: info
+    description: Ground requested health telemetry.
+    downlink_priority: medium
+    persistence: store
+
+  - id: comms.payload_data_requested
+    source: comms
+    severity: info
+    description: Ground requested payload data during an available contact opportunity.
+    downlink_priority: medium
+    persistence: store
+
+  - id: comms.downlink_priority_set
+    source: comms
+    severity: info
+    description: Downlink priority policy was selected for the contact opportunity.
+    downlink_priority: medium
+    persistence: store
+
+  - id: obc.safe_mode_requested
+    source: obc_or_cdh
+    severity: warning
+    description: Safe mode was requested by command or recovery logic.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: obc.fault_cleared
+    source: obc_or_cdh
+    severity: info
+    description: Fault state was cleared by ground command.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: adcs.attitude_not_ready
+    source: adcs
+    severity: warning
+    description: ADCS was not ready for payload acquisition or pointing-constrained operations.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Onboard storage usage exceeded the warning threshold.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Declared contact capacity is insufficient for the eligible downlink set.
+    downlink_priority: high
+    persistence: store_and_downlink

--- a/examples/university-cubesat-minislice/mission/faults.yaml
+++ b/examples/university-cubesat-minislice/mission/faults.yaml
@@ -1,0 +1,79 @@
+faults:
+  - id: eps.low_battery_warning
+    source: eps
+    severity: warning
+    description: Battery state of charge remains below the warning threshold for two consecutive samples.
+    condition:
+      telemetry: eps.battery.state_of_charge
+      operator: <
+      value: 30.0
+      debounce_samples: 2
+    emits:
+      - eps.low_power_warning_raised
+    recovery:
+      mode_transition: LOW_POWER
+      auto_commands: []
+
+  - id: eps.low_battery_critical
+    source: eps
+    severity: critical
+    description: Battery state of charge remains below the critical threshold.
+    condition:
+      telemetry: eps.battery.state_of_charge
+      operator: <
+      value: 15.0
+      debounce_samples: 1
+    emits:
+      - eps.low_battery_critical_raised
+    recovery:
+      mode_transition: SAFE
+      auto_commands: []
+
+  - id: payload.data_backlog
+    source: payload
+    severity: warning
+    description: Payload data remains pending for downlink above the retained-backlog warning threshold.
+    condition:
+      telemetry: payload.data_pending_bytes
+      operator: >
+      value: 20000
+      debounce_samples: 1
+    emits:
+      - payload.data_pending
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Downlink capacity is exhausted while payload data remains pending.
+    condition:
+      telemetry: downlink.capacity_remaining_bytes
+      operator: ==
+      value: 0
+      debounce_samples: 1
+    emits:
+      - comms.downlink_capacity_insufficient
+      - comms.downlink_partial
+
+  - id: adcs.not_ready
+    source: adcs
+    severity: warning
+    description: ADCS readiness is false when payload activity would require attitude readiness.
+    condition:
+      telemetry: adcs.attitude_ready
+      operator: ==
+      value: false
+      debounce_samples: 1
+    emits:
+      - adcs.attitude_not_ready
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Onboard storage usage exceeds the warning threshold.
+    condition:
+      telemetry: data_storage.used_bytes
+      operator: >
+      value: 50000000
+      debounce_samples: 1
+    emits:
+      - data_storage.high_usage

--- a/examples/university-cubesat-minislice/mission/modes.yaml
+++ b/examples/university-cubesat-minislice/mission/modes.yaml
@@ -1,0 +1,78 @@
+modes:
+  SAFE:
+    description: Protective mode with payload activity disabled and only essential operations allowed.
+
+  STANDBY:
+    description: Low-activity mode used before nominal operations or after recovery.
+
+  NOMINAL:
+    description: Standard operational mode for routine telemetry collection, command handling and scheduled payload activity.
+    initial: true
+
+  PAYLOAD_ACQUISITION:
+    description: Payload acquisition is active or recently completed, with payload data expected to be stored onboard.
+
+  DOWNLINK:
+    description: Spacecraft is using an available contact window to downlink prioritized mission data.
+
+  LOW_POWER:
+    description: Reduced-power mode entered after a battery warning; critical telemetry and beacon remain prioritized.
+
+  FAULT_RECOVERY:
+    description: Controlled recovery mode used after a severe warning or fault condition.
+
+mode_transitions:
+  - from: STANDBY
+    to: NOMINAL
+    reason: ground_authorized_nominal
+    description: Ground authorizes transition from standby to nominal operations.
+
+  - from: NOMINAL
+    to: PAYLOAD_ACQUISITION
+    reason: payload_acquisition_scheduled
+    description: Payload acquisition command is accepted in nominal mode.
+
+  - from: PAYLOAD_ACQUISITION
+    to: NOMINAL
+    reason: payload_data_generated
+    description: Payload data is generated and acquisition state is closed.
+
+  - from: NOMINAL
+    to: LOW_POWER
+    reason: eps_low_power_warning
+    description: EPS battery state of charge falls below the warning threshold.
+
+  - from: PAYLOAD_ACQUISITION
+    to: LOW_POWER
+    reason: eps_low_power_warning
+    description: EPS warning interrupts payload-oriented operations.
+
+  - from: LOW_POWER
+    to: DOWNLINK
+    reason: contact_window_started
+    description: A constrained contact window starts while the spacecraft remains power-limited.
+
+  - from: NOMINAL
+    to: DOWNLINK
+    reason: contact_window_started
+    description: A contact window starts during nominal operations.
+
+  - from: DOWNLINK
+    to: LOW_POWER
+    reason: contact_window_ended
+    description: Contact ends and the spacecraft remains in reduced-power operations.
+
+  - from: LOW_POWER
+    to: SAFE
+    reason: eps_low_battery_critical
+    description: Battery condition becomes critical.
+
+  - from: SAFE
+    to: FAULT_RECOVERY
+    reason: ground_clear_fault
+    description: Ground starts a controlled recovery sequence.
+
+  - from: FAULT_RECOVERY
+    to: STANDBY
+    reason: recovery_completed
+    description: Recovery completes and the spacecraft returns to standby.

--- a/examples/university-cubesat-minislice/mission/packets.yaml
+++ b/examples/university-cubesat-minislice/mission/packets.yaml
@@ -1,0 +1,45 @@
+packets:
+  - id: critical_housekeeping_packet
+    name: Critical Housekeeping Packet
+    type: json
+    max_payload_bytes: 512
+    period: 30s
+    telemetry:
+      - eps.battery.state_of_charge
+      - eps.battery.voltage
+      - eps.battery.temperature
+      - eps.solar.input_power
+    description: Compact critical housekeeping packet prioritized during constrained contacts.
+
+  - id: health_beacon_packet
+    name: Health Beacon Packet
+    type: json
+    max_payload_bytes: 256
+    period: 60s
+    telemetry:
+      - obc.uptime
+      - comms.link_status
+      - payload.data_pending_bytes
+    description: Periodic health beacon packet for low-rate contact opportunities.
+
+  - id: payload_status_packet
+    name: Payload Status Packet
+    type: json
+    max_payload_bytes: 256
+    period: on_change
+    telemetry:
+      - adcs.attitude_ready
+      - payload.status
+      - payload.data_generated_bytes
+      - payload.data_pending_bytes
+    description: Payload status packet exposing generated and pending payload data.
+
+  - id: downlink_summary_packet
+    name: Downlink Summary Packet
+    type: json
+    max_payload_bytes: 512
+    period: on_contact
+    telemetry:
+      - downlink.capacity_remaining_bytes
+      - data_storage.used_bytes
+    description: Contact summary packet used as scenario evidence for constrained downlink behavior.

--- a/examples/university-cubesat-minislice/mission/payloads.yaml
+++ b/examples/university-cubesat-minislice/mission/payloads.yaml
@@ -1,0 +1,29 @@
+payloads:
+  - id: generic_observation_payload
+    subsystem: payload
+    profile: mission_specific
+    lifecycle:
+      initial_state: READY
+      states:
+        - OFF
+        - READY
+        - ACQUIRING
+        - DATA_READY
+        - DOWNLINK_PENDING
+        - FAULT
+    telemetry:
+      produced:
+        - payload.status
+        - payload.data_generated_bytes
+        - payload.data_pending_bytes
+    commands:
+      accepted:
+        - payload.schedule_acquisition
+    events:
+      generated:
+        - payload.data_generated
+        - payload.data_pending
+    faults:
+      possible:
+        - payload.data_backlog
+    description: Generic observation payload contract used by the university CubeSat minislice.

--- a/examples/university-cubesat-minislice/mission/payloads.yaml
+++ b/examples/university-cubesat-minislice/mission/payloads.yaml
@@ -5,7 +5,7 @@ payloads:
     lifecycle:
       initial_state: READY
       states:
-        - OFF
+        - "OFF"
         - READY
         - ACQUIRING
         - DATA_READY

--- a/examples/university-cubesat-minislice/mission/policies.yaml
+++ b/examples/university-cubesat-minislice/mission/policies.yaml
@@ -1,0 +1,35 @@
+policies:
+  persistence:
+    allowed_values:
+      - none
+      - store
+      - downlink_only
+      - store_and_downlink
+
+  downlink_priority:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  command_risk:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  event_severity:
+    allowed_values:
+      - info
+      - warning
+      - error
+      - critical
+
+  telemetry_criticality:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical

--- a/examples/university-cubesat-minislice/mission/spacecraft.yaml
+++ b/examples/university-cubesat-minislice/mission/spacecraft.yaml
@@ -1,0 +1,7 @@
+spacecraft:
+  id: university-cubesat-minislice
+  name: University CubeSat Minislice
+  class: cubesat
+  form_factor: 3U
+  mission_type: university_technology_demonstrator
+  model_version: 0.4.0-demo

--- a/examples/university-cubesat-minislice/mission/subsystems.yaml
+++ b/examples/university-cubesat-minislice/mission/subsystems.yaml
@@ -1,0 +1,48 @@
+subsystems:
+  - id: spacecraft_bus
+    name: Spacecraft Bus
+    type: bus
+    criticality: critical
+    description: Generic CubeSat bus context coordinating power, data handling and spacecraft-level operational state.
+
+  - id: obc_or_cdh
+    name: OBC / C&DH
+    type: core
+    criticality: critical
+    description: Generic command and data handling function responsible for command routing, telemetry collection, storage coordination and mode control.
+
+  - id: eps
+    name: Electrical Power System
+    type: subsystem
+    criticality: critical
+    description: Generic power subsystem providing battery, solar input and power-state telemetry.
+
+  - id: comms
+    name: Communications Subsystem
+    type: communication
+    criticality: high
+    description: Generic low-rate communication subsystem supporting beacon, telecommand reception and constrained downlink.
+
+  - id: adcs
+    name: Attitude Determination and Control
+    type: subsystem
+    criticality: high
+    description: Minimal attitude readiness context used to gate payload acquisition and downlink-relevant operations.
+
+  - id: payload
+    name: Generic Observation Payload
+    type: payload
+    criticality: medium
+    description: Generic university CubeSat payload producing observation data products.
+
+  - id: data_storage
+    name: Onboard Data Storage
+    type: storage
+    criticality: high
+    description: Generic onboard storage context for retained housekeeping, payload and scenario evidence products.
+
+  - id: ground_station_context
+    name: Ground Station Context
+    type: ground_context
+    criticality: medium
+    description: Abstract ground contact context used only for contact and downlink contract assumptions.

--- a/examples/university-cubesat-minislice/mission/telemetry.yaml
+++ b/examples/university-cubesat-minislice/mission/telemetry.yaml
@@ -1,0 +1,196 @@
+telemetry:
+  - id: eps.battery.state_of_charge
+    name: Battery State of Charge
+    type: float32
+    unit: percent
+    source: eps
+    sampling: 1Hz
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    limits:
+      warning_low: 30.0
+      critical_low: 15.0
+    quality:
+      required: true
+      default: good
+    description: Battery state of charge used to drive low-power and safe-mode implications.
+
+  - id: eps.battery.voltage
+    name: Battery Voltage
+    type: float32
+    unit: V
+    source: eps
+    sampling: 1Hz
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    limits:
+      warning_low: 6.8
+      critical_low: 6.4
+    quality:
+      required: true
+      default: good
+    description: Battery bus voltage included in critical housekeeping and health beacon products.
+
+  - id: eps.battery.temperature
+    name: Battery Temperature
+    type: float32
+    unit: degC
+    source: eps
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_low: -5.0
+      warning_high: 45.0
+      critical_high: 55.0
+    quality:
+      required: true
+      default: good
+    description: Battery temperature used as a generic EPS health indicator.
+
+  - id: eps.solar.input_power
+    name: Solar Input Power
+    type: float32
+    unit: W
+    source: eps
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store
+    downlink_priority: medium
+    limits:
+      warning_low: 1.0
+    quality:
+      required: true
+      default: good
+    description: Estimated solar input power used to contextualize low-power behavior.
+
+  - id: data_storage.used_bytes
+    name: Onboard Storage Used
+    type: uint32
+    unit: bytes
+    source: data_storage
+    sampling: 0.1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 50000000
+      critical_high: 80000000
+    quality:
+      required: true
+      default: good
+    description: Generic onboard storage occupancy used to expose retained payload and evidence data.
+
+  - id: obc.uptime
+    name: OBC Uptime
+    type: uint32
+    unit: s
+    source: obc_or_cdh
+    sampling: 1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    quality:
+      required: true
+      default: good
+    description: OBC uptime included in health and beacon products.
+
+  - id: comms.link_status
+    name: Communications Link Status
+    type: enum
+    unit: none
+    source: comms
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - NO_CONTACT
+      - CONTACT_AVAILABLE
+      - DOWNLINK_ACTIVE
+    quality:
+      required: true
+      default: good
+    description: Abstract contact/downlink status for scenario evidence.
+
+  - id: adcs.attitude_ready
+    name: ADCS Attitude Ready
+    type: bool
+    unit: none
+    source: adcs
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Minimal attitude readiness flag used by payload acquisition and imaging-derived future examples.
+
+  - id: payload.status
+    name: Payload Status
+    type: enum
+    unit: none
+    source: payload
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - IDLE
+      - ACQUIRING
+      - DATA_READY
+      - DOWNLINK_PENDING
+      - BACKLOG
+      - FAULT
+    quality:
+      required: true
+      default: good
+    description: Abstract payload status used to track data generation and pending downlink.
+
+  - id: payload.data_generated_bytes
+    name: Payload Data Generated
+    type: uint32
+    unit: bytes
+    source: payload
+    sampling: on_change
+    criticality: medium
+    persistence: store
+    downlink_priority: low
+    quality:
+      required: true
+      default: good
+    description: Size of the latest generic payload observation before compression and downlink selection.
+
+  - id: payload.data_pending_bytes
+    name: Payload Data Pending
+    type: uint32
+    unit: bytes
+    source: payload
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 1
+    quality:
+      required: true
+      default: good
+    description: Payload bytes still pending after prioritized contact downlink allocation.
+
+  - id: downlink.capacity_remaining_bytes
+    name: Downlink Capacity Remaining
+    type: uint32
+    unit: bytes
+    source: comms
+    sampling: on_change
+    criticality: medium
+    persistence: store
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Contract-level scenario evidence for remaining capacity after prioritized downlink allocation.

--- a/examples/university-cubesat-minislice/scenarios/payload_data_constrained_downlink.yaml
+++ b/examples/university-cubesat-minislice/scenarios/payload_data_constrained_downlink.yaml
@@ -1,0 +1,131 @@
+scenario:
+  id: payload_data_constrained_downlink
+  name: Payload data constrained by low-rate downlink
+  description: Generic university CubeSat minislice where payload data is generated, low-power warning is raised, and a constrained contact prioritizes health data before leaving payload data partially pending.
+
+mission:
+  path: ../mission
+
+initial_state:
+  mode: NOMINAL
+  telemetry:
+    eps.battery.state_of_charge: 55.0
+    eps.battery.voltage: 7.6
+    eps.battery.temperature: 22.0
+    eps.solar.input_power: 6.0
+    data_storage.used_bytes: 0
+    obc.uptime: 4200
+    comms.link_status: NO_CONTACT
+    adcs.attitude_ready: true
+    payload.status: IDLE
+    payload.data_generated_bytes: 0
+    payload.data_pending_bytes: 0
+    downlink.capacity_remaining_bytes: 12000
+
+steps:
+  - t: 0
+    expect_mode: NOMINAL
+
+  - t: 5
+    command: payload.schedule_acquisition
+    args:
+      duration_s: 120
+    expect:
+      command_status: ACCEPTED
+
+  - t: 6
+    expect_event: payload.data_generated
+
+  - t: 7
+    expect:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DATA_READY
+
+  - t: 8
+    expect_telemetry:
+      payload.status: DATA_READY
+      payload.data_generated_bytes: 32000
+      payload.data_pending_bytes: 18000
+      data_storage.used_bytes: 32000
+
+  - t: 12
+    command: obc.request_health_telemetry
+    expect:
+      command_status: ACCEPTED
+
+  - t: 13
+    expect_event: obc.health_telemetry_requested
+
+  - t: 20
+    inject:
+      telemetry: eps.battery.state_of_charge
+      value: 28.0
+
+  - t: 21
+    inject:
+      telemetry: eps.battery.state_of_charge
+      value: 28.0
+
+  - t: 22
+    expect_event: eps.low_power_warning_raised
+
+  - t: 23
+    expect_mode: LOW_POWER
+
+  - t: 30
+    command: comms.start_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 31
+    expect_event: comms.contact_window_started
+
+  - t: 32
+    expect_event: comms.downlink_started
+
+  - t: 33
+    expect_event: comms.beacon_transmitted
+
+  - t: 34
+    expect_event: comms.downlink_partial
+
+  - t: 35
+    expect_event: payload.data_pending
+
+  - t: 36
+    expect_mode: DOWNLINK
+
+  - t: 37
+    expect:
+      payload_lifecycle:
+        payload: generic_observation_payload
+        state: DOWNLINK_PENDING
+
+  - t: 38
+    expect_telemetry:
+      comms.link_status: DOWNLINK_ACTIVE
+      downlink.capacity_remaining_bytes: 0
+      payload.status: DOWNLINK_PENDING
+      payload.data_pending_bytes: 13680
+
+  - t: 45
+    command: comms.end_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 46
+    expect_event: comms.contact_window_ended
+
+  - t: 47
+    expect_mode: LOW_POWER
+
+  - t: 48
+    expect_telemetry:
+      comms.link_status: NO_CONTACT
+      payload.status: BACKLOG
+      payload.data_pending_bytes: 13680
+
+  - t: 50
+    expect:
+      scenario_status: PASSED


### PR DESCRIPTION
## Summary

Add a new clean-room university CubeSat minislice demo under:

`examples/university-cubesat-minislice/`

The demo models a generic university CubeSat mission-data chain:

- payload data generation;
- EPS low-power warning;
- constrained low-rate contact window;
- prioritized health / critical data downlink;
- partial payload downlink;
- remaining payload backlog;
- scenario evidence through events, telemetry, mode transitions and simulation logs.

## Validation

```bash
orbitfabric lint examples/university-cubesat-minislice/mission/
orbitfabric gen docs examples/university-cubesat-minislice/mission/
orbitfabric validate scenario examples/university-cubesat-minislice/scenarios/payload_data_constrained_downlink.yaml
orbitfabric sim examples/university-cubesat-minislice/scenarios/payload_data_constrained_downlink.yaml \
  --json generated/reports/university_payload_data_constrained_downlink_report.json \
  --log generated/logs/university_payload_data_constrained_downlink.log
```