### PR TITLE
Add OreSat-inspired minislice example

### DIFF
--- a/examples/oresat-inspired-minislice/mission/commands.yaml
+++ b/examples/oresat-inspired-minislice/mission/commands.yaml
@@ -1,0 +1,196 @@
+commands:
+  - id: c3.request_health_telemetry
+    target: c3
+    description: Request current critical housekeeping and health telemetry products.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - PAYLOAD_ACQUISITION
+      - DOWNLINK
+      - LOW_POWER
+      - SAFE
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - c3.health_telemetry_requested
+    expected_effects:
+      no_state_change: true
+
+  - id: comms.request_payload_data
+    target: comms
+    description: Request CFC-style payload data eligibility for the next prioritized downlink flow.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+      - DOWNLINK
+    preconditions:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DATA_READY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.payload_data_requested
+    expected_effects:
+      no_state_change: true
+
+  - id: cfc.schedule_capture
+    target: cfc_payload
+    description: Schedule and complete a bounded CFC-style capture producing an image-derived data product.
+    arguments:
+      - name: capture_count
+        type: uint8
+        min: 1
+        max: 4
+        default: 1
+        description: Number of conceptual CFC captures to acquire.
+      - name: integration_time_ms
+        type: uint16
+        min: 1
+        max: 80000
+        default: 1000
+        description: Conceptual integration time for the capture.
+    allowed_modes:
+      - NOMINAL
+    preconditions:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: READY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: medium
+    emits:
+      - cfc.data_generated
+    expected_effects:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DATA_READY
+      telemetry:
+        cfc.camera_status: DATA_READY
+        payload.data_generated_bytes: 64000
+        payload.data_pending_bytes: 32000
+        c3.storage_used: 3.5
+        data_storage.used_bytes: 64000
+
+  - id: comms.set_downlink_priority
+    target: comms
+    description: Select the priority policy used by the constrained downlink flow.
+    arguments:
+      - name: policy
+        type: enum
+        enum:
+          - critical_first
+          - priority_then_age
+          - manual_selection
+        default: critical_first
+        description: Abstract queue selection policy for the next downlink opportunity.
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+      - DOWNLINK
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - comms.downlink_priority_set
+    expected_effects:
+      no_state_change: true
+
+  - id: comms.start_downlink
+    target: comms
+    description: Start the prioritized downlink flow for the current abstract contact window.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - LOW_POWER
+    preconditions:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DATA_READY
+    requires_ack: true
+    timeout_ms: 1500
+    risk: medium
+    emits:
+      - comms.contact_window_started
+      - comms.downlink_started
+      - comms.beacon_transmitted
+      - comms.downlink_partial
+      - comms.downlink_capacity_insufficient
+      - payload.data_pending
+    expected_effects:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DOWNLINK_PENDING
+      telemetry:
+        comms.link_status: DOWNLINK_ACTIVE
+        downlink.capacity_remaining_bytes: 0
+        payload.data_pending_bytes: 29216
+        cfc.camera_status: DOWNLINK_PENDING
+      mode_transition:
+        to: DOWNLINK
+
+  - id: comms.end_downlink
+    target: comms
+    description: Close the current contact window and record remaining pending CFC-style payload data.
+    arguments: []
+    allowed_modes:
+      - DOWNLINK
+    preconditions:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DOWNLINK_PENDING
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.contact_window_ended
+    expected_effects:
+      telemetry:
+        comms.link_status: NO_CONTACT
+        cfc.camera_status: BACKLOG
+      mode_transition:
+        to: LOW_POWER
+
+  - id: c3.enter_safe_mode
+    target: c3
+    description: Request transition to safe mode.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - PAYLOAD_ACQUISITION
+      - DOWNLINK
+      - LOW_POWER
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: high
+    emits:
+      - c3.safe_mode_requested
+    expected_effects:
+      telemetry:
+        cfc.camera_status: "OFF"
+      mode_transition:
+        to: SAFE
+
+  - id: c3.clear_fault
+    target: c3
+    description: Clear a recorded warning or fault after ground review.
+    arguments:
+      - name: fault_id
+        type: string
+        description: Fault identifier to clear.
+    allowed_modes:
+      - SAFE
+      - FAULT_RECOVERY
+      - LOW_POWER
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - c3.fault_cleared
+    expected_effects:
+      no_state_change: true

--- a/examples/oresat-inspired-minislice/mission/contacts.yaml
+++ b/examples/oresat-inspired-minislice/mission/contacts.yaml
@@ -1,0 +1,42 @@
+contacts:
+  contact_profiles:
+    - id: oresat_inspired_ground_contact
+      target: abstract_public_demo_ground_context
+      description: >
+        Synthetic ground contact profile for the OreSat-inspired public demo. This is
+        an assumption for contract reasoning only, not a real OreSat contact schedule.
+
+  link_profiles:
+    - id: low_rate_uhf_downlink
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: >
+        Generic low-rate downlink assumption for constrained contact reasoning. No
+        real frequency, callsign or operational link budget is modeled.
+
+  contact_windows:
+    - id: oresat_inspired_contact_001
+      contact_profile: oresat_inspired_ground_contact
+      link_profile: low_rate_uhf_downlink
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 300
+      assumed_capacity_bytes: 12000
+      description: Synthetic limited-capacity contact window used to force priority-based allocation.
+
+  downlink_flows:
+    - id: oresat_inspired_priority_downlink
+      contact_profile: oresat_inspired_ground_contact
+      link_profile: low_rate_uhf_downlink
+      queue_policy: critical_first
+      eligible_data_products:
+        - health_beacon
+        - critical_housekeeping_packet
+        - gps_state_sample
+        - adcs_sensor_snapshot
+        - downlink_summary_report
+        - scenario_evidence_log
+        - compressed_cfc_bundle
+        - dxwifi_image_bundle
+      description: >
+        Priority-based downlink flow demonstrating beacon/health-first allocation and
+        retained CFC-style payload data under limited contact capacity.

--- a/examples/oresat-inspired-minislice/mission/data_products.yaml
+++ b/examples/oresat-inspired-minislice/mission/data_products.yaml
@@ -1,0 +1,128 @@
+data_products:
+  - id: health_beacon
+    producer: comms
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 512
+    priority: critical
+    storage:
+      class: housekeeping
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+    description: Compact health beacon prioritized before payload data.
+
+  - id: critical_housekeeping_packet
+    producer: c3
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 1024
+    priority: critical
+    storage:
+      class: housekeeping
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Critical housekeeping product containing battery, solar, C3, GPS and ADCS health fields.
+
+  - id: cfc_image_capture
+    producer: cfc_payload
+    producer_type: payload
+    type: image
+    estimated_size_bytes: 64000
+    priority: medium
+    payload: cfc_payload
+    storage:
+      class: science
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: deferred
+    description: Conceptual raw CFC-style image capture retained onboard.
+
+  - id: compressed_cfc_bundle
+    producer: cfc_payload
+    producer_type: payload
+    type: compressed_product
+    estimated_size_bytes: 32000
+    priority: medium
+    payload: cfc_payload
+    storage:
+      class: science
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Compressed CFC-style bundle eligible after beacon and critical housekeeping.
+
+  - id: dxwifi_image_bundle
+    producer: dxwifi
+    producer_type: subsystem
+    type: image
+    estimated_size_bytes: 48000
+    priority: low
+    storage:
+      class: science
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: deferred
+    description: DxWiFi-style image/data bundle included as context but not required for the main scenario.
+
+  - id: gps_state_sample
+    producer: gps
+    producer_type: subsystem
+    type: sample_batch
+    estimated_size_bytes: 512
+    priority: high
+    storage:
+      class: housekeeping
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Compact GPS fix and time-sync state sample.
+
+  - id: adcs_sensor_snapshot
+    producer: adcs
+    producer_type: subsystem
+    type: sample_batch
+    estimated_size_bytes: 1024
+    priority: high
+    storage:
+      class: housekeeping
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Compact ADCS manager/readiness snapshot.
+
+  - id: downlink_summary_report
+    producer: c3
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 2048
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Summary of contact capacity usage and remaining pending payload data.
+
+  - id: scenario_evidence_log
+    producer: c3
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Scenario evidence log explaining why CFC-style payload data remained partially pending.

--- a/examples/oresat-inspired-minislice/mission/events.yaml
+++ b/examples/oresat-inspired-minislice/mission/events.yaml
@@ -1,0 +1,154 @@
+events:
+  - id: comms.beacon_transmitted
+    source: comms
+    severity: info
+    description: Health beacon transmitted during a contact opportunity.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: cfc.data_generated
+    source: cfc_payload
+    severity: info
+    description: CFC-style payload data product generated and stored onboard.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: eps.low_power_warning_raised
+    source: eps
+    severity: warning
+    description: Battery state of charge crossed the low-power warning threshold.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: eps.low_battery_critical_raised
+    source: eps
+    severity: critical
+    description: Battery state of charge crossed the critical threshold.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_started
+    source: comms
+    severity: info
+    description: Abstract constrained public-demo contact window started.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_ended
+    source: comms
+    severity: info
+    description: Abstract constrained public-demo contact window ended.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: comms.downlink_started
+    source: comms
+    severity: info
+    description: Prioritized downlink flow started for the available contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_partial
+    source: comms
+    severity: warning
+    description: Downlink flow was capacity-constrained and only part of the eligible payload data could be sent.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: payload.data_pending
+    source: cfc_payload
+    severity: warning
+    description: Payload data remains pending after the constrained contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Declared contact capacity is insufficient for the eligible downlink set.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: c3.mode_changed
+    source: c3
+    severity: info
+    description: Spacecraft operational mode changed.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: adcs.mode_changed
+    source: adcs
+    severity: info
+    description: ADCS manager mode changed.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: gps.lock_acquired
+    source: gps
+    severity: info
+    description: GPS lock acquired.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: gps.lock_lost
+    source: gps
+    severity: warning
+    description: GPS lock lost or not available.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: cfc.camera_temperature_high
+    source: cfc_payload
+    severity: warning
+    description: CFC-style camera temperature exceeded the warning threshold.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: adcs.not_ready
+    source: adcs
+    severity: warning
+    description: ADCS was not ready for payload acquisition or pointing-constrained operations.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Onboard storage usage exceeded the warning threshold.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: c3.health_telemetry_requested
+    source: c3
+    severity: info
+    description: Ground requested health telemetry.
+    downlink_priority: medium
+    persistence: store
+
+  - id: comms.payload_data_requested
+    source: comms
+    severity: info
+    description: Ground requested payload data during an available contact opportunity.
+    downlink_priority: medium
+    persistence: store
+
+  - id: comms.downlink_priority_set
+    source: comms
+    severity: info
+    description: Downlink priority policy was selected for the contact opportunity.
+    downlink_priority: medium
+    persistence: store
+
+  - id: c3.safe_mode_requested
+    source: c3
+    severity: warning
+    description: Safe mode was requested by command or recovery logic.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: c3.fault_cleared
+    source: c3
+    severity: info
+    description: Fault state was cleared by ground command.
+    downlink_priority: medium
+    persistence: store_and_downlink

--- a/examples/oresat-inspired-minislice/mission/faults.yaml
+++ b/examples/oresat-inspired-minislice/mission/faults.yaml
@@ -1,0 +1,103 @@
+faults:
+  - id: eps.low_battery_warning
+    source: eps
+    severity: warning
+    description: Battery state of charge remains below the warning threshold for two consecutive samples.
+    condition:
+      telemetry: eps.battery.state_of_charge
+      operator: <
+      value: 30.0
+      debounce_samples: 2
+    emits:
+      - eps.low_power_warning_raised
+    recovery:
+      mode_transition: LOW_POWER
+      auto_commands: []
+
+  - id: eps.low_battery_critical
+    source: eps
+    severity: critical
+    description: Battery state of charge remains below the critical threshold.
+    condition:
+      telemetry: eps.battery.state_of_charge
+      operator: <
+      value: 15.0
+      debounce_samples: 1
+    emits:
+      - eps.low_battery_critical_raised
+    recovery:
+      mode_transition: SAFE
+      auto_commands: []
+
+  - id: cfc.camera_temperature_high
+    source: cfc_payload
+    severity: warning
+    description: CFC-style camera temperature exceeds the warning threshold.
+    condition:
+      telemetry: cfc.camera_temperature
+      operator: '>'
+      value: 45.0
+      debounce_samples: 1
+    emits:
+      - cfc.camera_temperature_high
+
+  - id: cfc.data_backlog
+    source: cfc_payload
+    severity: warning
+    description: CFC-style payload data remains pending for downlink above the retained-backlog warning threshold.
+    condition:
+      telemetry: payload.data_pending_bytes
+      operator: '>'
+      value: 20000
+      debounce_samples: 1
+    emits:
+      - payload.data_pending
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Downlink capacity is exhausted while payload data remains pending.
+    condition:
+      telemetry: downlink.capacity_remaining_bytes
+      operator: ==
+      value: 0
+      debounce_samples: 1
+    emits:
+      - comms.downlink_capacity_insufficient
+      - comms.downlink_partial
+
+  - id: gps.not_locked
+    source: gps
+    severity: warning
+    description: GPS fix is not locked when a time/position sample is expected.
+    condition:
+      telemetry: gps.fix_status
+      operator: ==
+      value: NO_FIX
+      debounce_samples: 1
+    emits:
+      - gps.lock_lost
+
+  - id: adcs.not_ready
+    source: adcs
+    severity: warning
+    description: ADCS readiness is false when payload activity would require attitude readiness.
+    condition:
+      telemetry: adcs.attitude_ready
+      operator: ==
+      value: false
+      debounce_samples: 1
+    emits:
+      - adcs.not_ready
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Onboard storage usage exceeds the warning threshold.
+    condition:
+      telemetry: data_storage.used_bytes
+      operator: '>'
+      value: 50000000
+      debounce_samples: 1
+    emits:
+      - data_storage.high_usage

--- a/examples/oresat-inspired-minislice/mission/modes.yaml
+++ b/examples/oresat-inspired-minislice/mission/modes.yaml
@@ -1,0 +1,78 @@
+modes:
+  SAFE:
+    description: Protective mode with payload activity disabled and only essential operations allowed.
+
+  STANDBY:
+    description: Low-activity mode used before nominal operations or after recovery.
+
+  NOMINAL:
+    description: Routine telemetry collection, command handling and scheduled payload activity.
+    initial: true
+
+  PAYLOAD_ACQUISITION:
+    description: CFC-style payload acquisition is active or recently completed.
+
+  DOWNLINK:
+    description: Spacecraft is using an available contact window to downlink prioritized mission data.
+
+  LOW_POWER:
+    description: Reduced-power mode entered after a battery warning; beacon and critical telemetry remain prioritized.
+
+  FAULT_RECOVERY:
+    description: Controlled recovery mode used after a severe warning or fault condition.
+
+mode_transitions:
+  - from: STANDBY
+    to: NOMINAL
+    reason: ground_authorized_nominal
+    description: Ground authorizes transition from standby to nominal operations.
+
+  - from: NOMINAL
+    to: PAYLOAD_ACQUISITION
+    reason: cfc_capture_scheduled
+    description: CFC-style capture command is accepted in nominal mode.
+
+  - from: PAYLOAD_ACQUISITION
+    to: NOMINAL
+    reason: cfc_data_generated
+    description: CFC-style data is generated and acquisition state is closed.
+
+  - from: NOMINAL
+    to: LOW_POWER
+    reason: eps_low_power_warning
+    description: Battery state of charge falls below the warning threshold.
+
+  - from: PAYLOAD_ACQUISITION
+    to: LOW_POWER
+    reason: eps_low_power_warning
+    description: EPS warning interrupts payload-oriented operations.
+
+  - from: LOW_POWER
+    to: DOWNLINK
+    reason: contact_window_started
+    description: A constrained contact window starts while the spacecraft remains power-limited.
+
+  - from: NOMINAL
+    to: DOWNLINK
+    reason: contact_window_started
+    description: A contact window starts during nominal operations.
+
+  - from: DOWNLINK
+    to: LOW_POWER
+    reason: contact_window_ended
+    description: Contact ends and the spacecraft remains in reduced-power operations.
+
+  - from: LOW_POWER
+    to: SAFE
+    reason: eps_low_battery_critical
+    description: Battery condition becomes critical.
+
+  - from: SAFE
+    to: FAULT_RECOVERY
+    reason: ground_clear_fault
+    description: Ground starts a controlled recovery sequence.
+
+  - from: FAULT_RECOVERY
+    to: STANDBY
+    reason: recovery_completed
+    description: Recovery completes and the spacecraft returns to standby.

--- a/examples/oresat-inspired-minislice/mission/packets.yaml
+++ b/examples/oresat-inspired-minislice/mission/packets.yaml
@@ -1,0 +1,63 @@
+packets:
+  - id: oresat_inspired_health_beacon_packet
+    name: OreSat-Inspired Health Beacon Packet
+    type: json
+    max_payload_bytes: 512
+    period: 60s
+    telemetry:
+      - c3.uptime
+      - c3.storage_used
+      - comms.link_status
+      - eps.battery.state_of_charge
+      - eps.battery.voltage
+      - payload.data_pending_bytes
+    description: >
+      Compact health beacon packet prioritized during constrained contacts. This is
+      an OreSat-inspired public demo packet, not an official OreSat beacon definition.
+
+  - id: critical_housekeeping_packet
+    name: Critical Housekeeping Packet
+    type: json
+    max_payload_bytes: 1024
+    period: 30s
+    telemetry:
+      - eps.battery.state_of_charge
+      - eps.battery.voltage
+      - eps.battery.temperature
+      - solar.input_power
+      - gps.fix_status
+      - gps.time_sync_status
+      - adcs.manager_mode
+      - adcs.attitude_ready
+    description: >
+      Critical housekeeping packet carrying representative power, GPS and ADCS
+      health fields for priority-first downlink reasoning.
+
+  - id: cfc_payload_status_packet
+    name: CFC Payload Status Packet
+    type: json
+    max_payload_bytes: 512
+    period: on_change
+    telemetry:
+      - cfc.camera_status
+      - cfc.camera_temperature
+      - dxwifi.status
+      - payload.data_generated_bytes
+      - payload.data_pending_bytes
+    description: >
+      CFC/DxWiFi-style payload status packet exposing generated and pending payload
+      data without modeling the full public object dictionary.
+
+  - id: downlink_summary_packet
+    name: Downlink Summary Packet
+    type: json
+    max_payload_bytes: 512
+    period: on_contact
+    telemetry:
+      - comms.link_status
+      - downlink.capacity_remaining_bytes
+      - data_storage.used_bytes
+      - payload.data_pending_bytes
+    description: >
+      Contact summary packet used as scenario evidence for constrained downlink
+      behavior and retained payload backlog.

--- a/examples/oresat-inspired-minislice/mission/payloads.yaml
+++ b/examples/oresat-inspired-minislice/mission/payloads.yaml
@@ -1,0 +1,34 @@
+payloads:
+  - id: cfc_payload
+    subsystem: cfc_payload
+    profile: mission_specific
+    lifecycle:
+      initial_state: READY
+      states:
+        - "OFF"
+        - READY
+        - CAPTURING
+        - DATA_READY
+        - DOWNLINK_PENDING
+        - BACKLOG
+        - FAULT
+    telemetry:
+      produced:
+        - cfc.camera_status
+        - cfc.camera_temperature
+        - payload.data_generated_bytes
+        - payload.data_pending_bytes
+    commands:
+      accepted:
+        - cfc.schedule_capture
+    events:
+      generated:
+        - cfc.data_generated
+        - payload.data_pending
+    faults:
+      possible:
+        - cfc.camera_temperature_high
+        - cfc.data_backlog
+    description: >
+      Conceptual CFC-style payload contract used by the OreSat-inspired public demo.
+      This is a small representative contract, not an import of OreSat object dictionaries.

--- a/examples/oresat-inspired-minislice/mission/policies.yaml
+++ b/examples/oresat-inspired-minislice/mission/policies.yaml
@@ -1,0 +1,35 @@
+policies:
+  persistence:
+    allowed_values:
+      - none
+      - store
+      - downlink_only
+      - store_and_downlink
+
+  downlink_priority:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  command_risk:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  event_severity:
+    allowed_values:
+      - info
+      - warning
+      - error
+      - critical
+
+  telemetry_criticality:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical

--- a/examples/oresat-inspired-minislice/mission/spacecraft.yaml
+++ b/examples/oresat-inspired-minislice/mission/spacecraft.yaml
@@ -1,0 +1,7 @@
+spacecraft:
+  id: oresat-inspired-minislice
+  name: OreSat-inspired Minislice
+  class: cubesat
+  form_factor: 2U-inspired
+  mission_type: publicly_derived_conceptual_university_technology_demonstrator
+  model_version: 0.4.0-demo

--- a/examples/oresat-inspired-minislice/mission/subsystems.yaml
+++ b/examples/oresat-inspired-minislice/mission/subsystems.yaml
@@ -1,0 +1,82 @@
+subsystems:
+  - id: spacecraft_bus
+    name: Spacecraft Bus
+    type: bus
+    criticality: critical
+    description: Conceptual CubeSat bus context coordinating spacecraft-level operational state.
+
+  - id: c3
+    name: C3 / Command, Control and Communication
+    type: core
+    criticality: critical
+    description: >
+      OreSat-inspired C3 context for command routing, telemetry collection, storage
+      coordination, beacon handling and spacecraft mode control.
+
+  - id: eps
+    name: Electrical Power System
+    type: subsystem
+    criticality: critical
+    description: Conceptual EPS context aggregating battery and solar health constraints.
+
+  - id: battery
+    name: Battery
+    type: subsystem
+    criticality: critical
+    description: OreSat-inspired battery telemetry context for voltage, temperature and state of charge.
+
+  - id: solar
+    name: Solar Input
+    type: subsystem
+    criticality: high
+    description: OreSat-inspired solar input telemetry context for available input power.
+
+  - id: gps
+    name: GPS
+    type: subsystem
+    criticality: medium
+    description: OreSat-inspired GPS state and time synchronization context.
+
+  - id: adcs
+    name: ADCS
+    type: subsystem
+    criticality: high
+    description: OreSat-inspired ADCS readiness and manager-mode context.
+
+  - id: star_tracker
+    name: Star Tracker
+    type: subsystem
+    criticality: medium
+    description: OreSat-inspired star-tracker status context used only as attitude-supporting telemetry.
+
+  - id: dxwifi
+    name: DxWiFi
+    type: payload_support
+    criticality: medium
+    description: OreSat-inspired high-volume image/data transmission payload-support context.
+
+  - id: cfc_payload
+    name: CFC-style Payload
+    type: payload
+    criticality: medium
+    description: Conceptual CFC-style imaging payload producing data products retained for constrained downlink.
+
+  - id: comms
+    name: Beacon and Downlink Context
+    type: communication
+    criticality: high
+    description: Conceptual beacon, EDL and constrained downlink context.
+
+  - id: data_storage
+    name: Onboard Data Storage
+    type: storage
+    criticality: high
+    description: Storage/evidence context for housekeeping, payload products and scenario evidence.
+
+  - id: ground_station_context
+    name: Ground Station Context
+    type: ground_context
+    criticality: medium
+    description: >
+      Abstract public-demo ground contact context. SatNOGS/UniClOGS wording may be
+      used only as public inspiration, not as a real operational schedule or link model.

--- a/examples/oresat-inspired-minislice/mission/telemetry.yaml
+++ b/examples/oresat-inspired-minislice/mission/telemetry.yaml
@@ -1,0 +1,331 @@
+telemetry:
+  - id: eps.battery.state_of_charge
+    name: Battery State of Charge
+    type: float32
+    unit: percent
+    source: battery
+    sampling: 1Hz
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    limits:
+      warning_low: 30.0
+      critical_low: 15.0
+    quality:
+      required: true
+      default: good
+    description: Battery reported state of charge used to drive low-power and safe-mode implications.
+
+  - id: eps.battery.voltage
+    name: Battery Voltage
+    type: float32
+    unit: V
+    source: battery
+    sampling: 1Hz
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    limits:
+      warning_low: 6.8
+      critical_low: 6.4
+    quality:
+      required: true
+      default: good
+    description: Battery pack voltage included in critical housekeeping and health beacon products.
+
+  - id: eps.battery.temperature
+    name: Battery Temperature
+    type: float32
+    unit: degC
+    source: battery
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_low: -5.0
+      warning_high: 45.0
+      critical_high: 55.0
+    quality:
+      required: true
+      default: good
+    description: Battery temperature used as a power-system health indicator.
+
+  - id: solar.input_power
+    name: Solar Input Power
+    type: float32
+    unit: W
+    source: solar
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store
+    downlink_priority: medium
+    limits:
+      warning_low: 1.0
+    quality:
+      required: true
+      default: good
+    description: Estimated solar input power used to contextualize low-power behavior.
+
+  - id: c3.uptime
+    name: C3 Uptime
+    type: uint32
+    unit: s
+    source: c3
+    sampling: 1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    quality:
+      required: true
+      default: good
+    description: C3 uptime included in health and beacon products.
+
+  - id: c3.storage_used
+    name: C3 Storage Used
+    type: float32
+    unit: percent
+    source: c3
+    sampling: 0.1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 80.0
+      critical_high: 95.0
+    quality:
+      required: true
+      default: good
+    description: C3 storage percentage inspired by public beacon storage fields.
+
+  - id: data_storage.used_bytes
+    name: Onboard Storage Used
+    type: uint32
+    unit: bytes
+    source: data_storage
+    sampling: 0.1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 50000000
+      critical_high: 80000000
+    quality:
+      required: true
+      default: good
+    description: Retained housekeeping, payload and evidence storage occupancy.
+
+  - id: comms.link_status
+    name: Communications Link Status
+    type: enum
+    unit: none
+    source: comms
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - NO_CONTACT
+      - CONTACT_AVAILABLE
+      - DOWNLINK_ACTIVE
+    quality:
+      required: true
+      default: good
+    description: Abstract contact/downlink status for scenario evidence.
+
+  - id: gps.fix_status
+    name: GPS Fix Status
+    type: enum
+    unit: none
+    source: gps
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - NO_FIX
+      - SEARCHING
+      - LOCKED
+      - ERROR
+    quality:
+      required: true
+      default: good
+    description: GPS lock status used as a compact public-demo substitute for detailed GPS object dictionary fields.
+
+  - id: gps.time_sync_status
+    name: GPS Time Sync Status
+    type: bool
+    unit: none
+    source: gps
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Whether spacecraft time is synchronized to GPS time.
+
+  - id: adcs.manager_mode
+    name: ADCS Manager Mode
+    type: enum
+    unit: none
+    source: adcs
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - NONE
+      - STANDBY
+      - HOLD
+      - CALIBRATE
+      - SPINDOWN
+      - DETUMBLE
+      - BBQ
+      - POINT
+      - MANUAL
+    quality:
+      required: true
+      default: good
+    description: Compact ADCS manager-mode context inspired by public C3 ADCS manager fields.
+
+  - id: adcs.attitude_ready
+    name: ADCS Attitude Ready
+    type: bool
+    unit: none
+    source: adcs
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Minimal attitude readiness flag used to gate payload acquisition and pointing-relevant products.
+
+  - id: star_tracker.status
+    name: Star Tracker Status
+    type: enum
+    unit: none
+    source: star_tracker
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - "OFF"
+      - BOOT
+      - STANDBY
+      - LOW_POWER
+      - STAR_TRACK
+      - CAPTURE
+      - ERROR
+    quality:
+      required: true
+      default: good
+    description: Star-tracker status retained as a small attitude-supporting field.
+
+  - id: cfc.camera_status
+    name: CFC Camera Status
+    type: enum
+    unit: none
+    source: cfc_payload
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - "OFF"
+      - STANDBY
+      - CAPTURE
+      - DATA_READY
+      - BOOT_LOCKOUT
+      - ERROR
+    quality:
+      required: true
+      default: good
+    description: CFC-style camera state used by the conceptual payload lifecycle.
+
+  - id: cfc.camera_temperature
+    name: CFC Camera Temperature
+    type: float32
+    unit: degC
+    source: cfc_payload
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    limits:
+      warning_high: 45.0
+      critical_high: 55.0
+    quality:
+      required: true
+      default: good
+    description: CFC-style camera temperature retained as representative payload health telemetry.
+
+  - id: dxwifi.status
+    name: DxWiFi Status
+    type: enum
+    unit: none
+    source: dxwifi
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - "OFF"
+      - BOOT
+      - STANDBY
+      - FILM
+      - TRANSMIT
+      - PURGE
+      - ERROR
+    quality:
+      required: true
+      default: good
+    description: DxWiFi-style status retained for image/data transmission context.
+
+  - id: payload.data_generated_bytes
+    name: Payload Data Generated
+    type: uint32
+    unit: bytes
+    source: cfc_payload
+    sampling: on_change
+    criticality: medium
+    persistence: store
+    downlink_priority: low
+    quality:
+      required: true
+      default: good
+    description: Size of the latest conceptual CFC-style capture before downlink selection.
+
+  - id: payload.data_pending_bytes
+    name: Payload Data Pending
+    type: uint32
+    unit: bytes
+    source: cfc_payload
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 1
+    quality:
+      required: true
+      default: good
+    description: Payload bytes still pending after prioritized contact downlink allocation.
+
+  - id: downlink.capacity_remaining_bytes
+    name: Downlink Capacity Remaining
+    type: uint32
+    unit: bytes
+    source: comms
+    sampling: on_change
+    criticality: medium
+    persistence: store
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Contract-level scenario evidence for remaining capacity after prioritized downlink allocation.

--- a/examples/oresat-inspired-minislice/scenarios/low_power_cfc_data_pending.yaml
+++ b/examples/oresat-inspired-minislice/scenarios/low_power_cfc_data_pending.yaml
@@ -1,0 +1,156 @@
+scenario:
+  id: low_power_cfc_data_pending
+  name: Low power leaves CFC-style payload data pending
+  description: >
+    OreSat-inspired public minislice where a CFC-style payload generates data, a
+    low-power warning is raised, and a constrained contact prioritizes beacon and
+    critical housekeeping before leaving payload data partially pending.
+
+mission:
+  path: ../mission
+
+initial_state:
+  mode: NOMINAL
+  telemetry:
+    eps.battery.state_of_charge: 55.0
+    eps.battery.voltage: 7.6
+    eps.battery.temperature: 22.0
+    solar.input_power: 6.0
+    c3.uptime: 4200
+    c3.storage_used: 0.0
+    data_storage.used_bytes: 0
+    comms.link_status: NO_CONTACT
+    gps.fix_status: LOCKED
+    gps.time_sync_status: true
+    adcs.manager_mode: POINT
+    adcs.attitude_ready: true
+    star_tracker.status: STANDBY
+    cfc.camera_status: STANDBY
+    cfc.camera_temperature: 20.0
+    dxwifi.status: STANDBY
+    payload.data_generated_bytes: 0
+    payload.data_pending_bytes: 0
+    downlink.capacity_remaining_bytes: 12000
+
+steps:
+  - t: 0
+    expect_mode: NOMINAL
+
+  - t: 5
+    command: cfc.schedule_capture
+    args:
+      capture_count: 1
+      integration_time_ms: 1000
+    expect:
+      command_status: ACCEPTED
+
+  - t: 6
+    expect_event: cfc.data_generated
+
+  - t: 7
+    expect:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DATA_READY
+
+  - t: 8
+    expect_telemetry:
+      cfc.camera_status: DATA_READY
+      payload.data_generated_bytes: 64000
+      payload.data_pending_bytes: 32000
+      c3.storage_used: 3.5
+      data_storage.used_bytes: 64000
+
+  - t: 12
+    command: c3.request_health_telemetry
+    expect:
+      command_status: ACCEPTED
+
+  - t: 13
+    expect_event: c3.health_telemetry_requested
+
+  - t: 20
+    inject:
+      telemetry: eps.battery.state_of_charge
+      value: 28.0
+
+  - t: 21
+    inject:
+      telemetry: eps.battery.state_of_charge
+      value: 28.0
+
+  - t: 22
+    expect_event: eps.low_power_warning_raised
+
+  - t: 23
+    expect_mode: LOW_POWER
+
+  - t: 30
+    command: comms.set_downlink_priority
+    args:
+      policy: critical_first
+    expect:
+      command_status: ACCEPTED
+
+  - t: 31
+    expect_event: comms.downlink_priority_set
+
+  - t: 32
+    command: comms.start_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 33
+    expect_event: comms.contact_window_started
+
+  - t: 34
+    expect_event: comms.downlink_started
+
+  - t: 35
+    expect_event: comms.beacon_transmitted
+
+  - t: 36
+    expect_event: comms.downlink_partial
+
+  - t: 37
+    expect_event: comms.downlink_capacity_insufficient
+
+  - t: 38
+    expect_event: payload.data_pending
+
+  - t: 39
+    expect_mode: DOWNLINK
+
+  - t: 40
+    expect:
+      payload_lifecycle:
+        payload: cfc_payload
+        state: DOWNLINK_PENDING
+
+  - t: 41
+    expect_telemetry:
+      comms.link_status: DOWNLINK_ACTIVE
+      downlink.capacity_remaining_bytes: 0
+      cfc.camera_status: DOWNLINK_PENDING
+      payload.data_pending_bytes: 29216
+
+  - t: 45
+    command: comms.end_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 46
+    expect_event: comms.contact_window_ended
+
+  - t: 47
+    expect_mode: LOW_POWER
+
+  - t: 48
+    expect_telemetry:
+      comms.link_status: NO_CONTACT
+      cfc.camera_status: BACKLOG
+      payload.data_pending_bytes: 29216
+
+  - t: 50
+    expect:
+      scenario_status: PASSED


### PR DESCRIPTION
Adds a small OreSat-inspired public conceptual minislice derived from the existing university CubeSat minislice pattern.

Scope:
- public-material-derived conceptual example
- not official
- not endorsed
- not a conversion of OreSat configs
- no replacement of OreSat CANopen/config/ground tooling
- downlink flows remain modeled inside mission/contacts.yaml

Validation:
- orbitfabric lint examples/oresat-inspired-minislice/mission
  - passed with one expected OF-DL-005 warning because the eligible downlink volume intentionally exceeds the declared contact capacity
- orbitfabric gen docs examples/oresat-inspired-minislice/mission
- orbitfabric sim examples/oresat-inspired-minislice/scenarios/low_power_cfc_data_pending.yaml