### PR TITLE
Add SpaceLab-inspired communications minislice

### DIFF
--- a/examples/spacelab-inspired-communications-minislice/README.md
+++ b/examples/spacelab-inspired-communications-minislice/README.md
@@ -1,0 +1,529 @@
+# SpaceLab-inspired Communications Minislice
+
+This example is a small **SpaceLab-inspired public communications demo** for OrbitFabric.
+
+It is derived from the generic and specialized minislice pattern used by:
+
+```text
+examples/university-cubesat-minislice/
+examples/oresat-inspired-minislice/
+examples/finch-inspired-minislice/
+```
+
+The example is inspired by publicly available SpaceLab UFSC / FloripaSat / GOLDS-UFSC material, especially public descriptions of OBDH, TT&C, beacon, telecommanded data request and decoder workflows.
+
+## Status and scope
+
+This example is:
+
+- public-material-derived;
+- conceptual;
+- intentionally small;
+- communications / TT&C / OBDH oriented;
+- intended for OrbitFabric validation, simulation and documentation generation;
+- an external open-source example;
+- not an official SpaceLab, FloripaSat or GOLDS-UFSC model.
+
+This example is **not**:
+
+- an official FloripaSat model;
+- endorsed by SpaceLab UFSC, UFSC, FloripaSat or GOLDS-UFSC;
+- a statement that SpaceLab UFSC uses OrbitFabric;
+- a collaboration announcement;
+- a conversion of FloripaSat architecture, firmware, packet formats or operational plans into OrbitFabric;
+- a replacement for SpaceLab decoder, transmitter, TT&C, OBDH, firmware or ground station software;
+- a real mission operations model.
+
+The correct description is:
+
+```text
+SpaceLab-inspired public communications demo
+```
+
+or:
+
+```text
+publicly derived conceptual communications example
+```
+
+or:
+
+```text
+SpaceLab UFSC / FloripaSat-inspired TT&C minislice
+```
+
+Avoid describing it as:
+
+```text
+official FloripaSat model
+SpaceLab OrbitFabric model
+SpaceLab uses OrbitFabric
+conversion of the FloripaSat architecture into OrbitFabric
+replacement for SpaceLab decoder / transmitter / TT&C / OBDH / ground software
+```
+
+## Why this example exists
+
+OrbitFabric is a model-first mission data fabric for small spacecraft. It is not flight software, not an OBC firmware, not a dynamic simulator and not a ground segment.
+
+This minislice demonstrates a narrow communications-oriented mission-data contract:
+
+```text
+periodic beacon available
+-> ground contact starts
+-> TT&C receives an abstract data-request telecommand
+-> TT&C forwards the request to OBDH
+-> OBDH selects stored telemetry/data frames
+-> OBDH packages frames for downlink
+-> beacon and critical housekeeping are prioritized first
+-> requested frames are partially downlinked
+-> remaining requested frames stay pending onboard
+-> decoder evidence records received frames and partial completion
+```
+
+The point is not to reproduce SpaceLab or FloripaSat. The point is to test OrbitFabric's contract-layer approach against a recognizable public CubeSat communications pattern.
+
+## Public inspiration
+
+The example is inspired by public SpaceLab / FloripaSat material, especially:
+
+- SpaceLab UFSC website: https://spacelab.ufsc.br/
+- FloripaSat-1 website: https://floripasat.ufsc.br/
+- FloripaSat-2 mission page: https://spacelab.ufsc.br/en/floripasat2/
+- GOLDS-UFSC / FloripaSat-2 documentation repository: https://github.com/spacelab-ufsc/floripasat2-doc
+- SpaceLab Decoder documentation: https://spacelab-ufsc.github.io/spacelab-decoder/
+- SpaceLab Transmitter telecommands documentation: https://spacelab-ufsc.github.io/spacelab-transmitter/telecommands.html
+
+The example intentionally uses only a reduced subset of public concepts:
+
+- OBDH-style data handling and stored frame selection;
+- TT&C-style beacon and telecommand reception;
+- periodic beacon context;
+- abstract requested telemetry/data frames;
+- constrained downlink flow;
+- decoder-side received-frame evidence.
+
+It does not import or mechanically translate real packet formats, keys, callsigns, frequencies, TLEs, operational schedules, decoder configuration files or ground station procedures.
+
+## Directory layout
+
+```text
+examples/spacelab-inspired-communications-minislice/
+├── README.md
+├── mission
+│   ├── spacecraft.yaml
+│   ├── subsystems.yaml
+│   ├── modes.yaml
+│   ├── telemetry.yaml
+│   ├── commands.yaml
+│   ├── events.yaml
+│   ├── faults.yaml
+│   ├── packets.yaml
+│   ├── policies.yaml
+│   ├── payloads.yaml
+│   ├── data_products.yaml
+│   └── contacts.yaml
+└── scenarios
+    └── ttc_data_request_constrained_downlink.yaml
+```
+
+There is deliberately no `mission/downlink.yaml`.
+
+In OrbitFabric v0.4.0-style examples, downlink flows are modeled inside:
+
+```text
+mission/contacts.yaml
+```
+
+through:
+
+```yaml
+contacts:
+  contact_profiles:
+  link_profiles:
+  contact_windows:
+  downlink_flows:
+```
+
+## Main scenario
+
+The main scenario is:
+
+```text
+scenarios/ttc_data_request_constrained_downlink.yaml
+```
+
+Scenario id:
+
+```text
+ttc_data_request_constrained_downlink
+```
+
+Conceptual sequence:
+
+1. The spacecraft starts in `NOMINAL`.
+2. A periodic beacon product is available.
+3. A synthetic ground contact starts.
+4. TT&C receives an abstract data-request telecommand.
+5. OBDH accepts the request.
+6. OBDH selects stored telemetry/data frames.
+7. OBDH packages the selected frames for downlink.
+8. Downlink priority is set to `critical_first`.
+9. TT&C/comms start downlink.
+10. Beacon and critical housekeeping are prioritized first.
+11. Requested telemetry/data frames are only partially downlinked.
+12. Remaining requested frames remain pending onboard.
+13. Decoder evidence records received frames and partial completion.
+14. The contact ends.
+15. The scenario passes with partial completion explicitly recorded.
+
+The expected end state is:
+
+```text
+scenario passed
+requested frames still pending
+spacecraft back in NOMINAL after contact
+```
+
+## Mode model
+
+The demo uses a compact communications-oriented mode model:
+
+```text
+SAFE
+STANDBY
+NOMINAL
+CONTACT
+DATA_REQUEST_HANDLING
+DOWNLINK
+HIBERNATION
+FAULT_RECOVERY
+```
+
+These modes are conceptual OrbitFabric mission-data states. They are not intended to represent an official SpaceLab, FloripaSat or GOLDS-UFSC mode table.
+
+## Subsystems
+
+The example models a small representative subsystem set:
+
+```text
+spacecraft_bus
+obdh
+ttc
+beacon_context
+data_storage
+comms
+rf
+transceiver
+ground_station_context
+decoder_context
+eps
+thermal
+```
+
+The mapping is intentionally compact:
+
+| OrbitFabric subsystem | SpaceLab-inspired role |
+|---|---|
+| `obdh` | command/data-handling, stored frame selection and packaging context |
+| `ttc` | telecommand reception, beacon and downlink context |
+| `beacon_context` | periodic beacon availability and transmission evidence |
+| `data_storage` | retained telemetry/data frame and evidence storage context |
+| `comms` | contact-window and downlink-flow coordination context |
+| `rf` | abstract RF downlink state with no operational parameters |
+| `transceiver` | receive/transmit/standby state context |
+| `ground_station_context` | synthetic contact assumption context |
+| `decoder_context` | ground-side received-frame evidence context |
+| `eps` | battery state context |
+| `thermal` | board-temperature context |
+
+This is not a complete SpaceLab subsystem model.
+
+## Telemetry focus
+
+The telemetry model keeps only representative fields needed by the scenario:
+
+```text
+obdh.uptime
+obdh.storage_used_bytes
+data_storage.used_bytes
+ttc.link_status
+ttc.beacon_status
+ttc.command_rx_status
+ttc.downlink_status
+comms.contact_status
+rf.downlink_status
+transceiver.status
+downlink.capacity_remaining_bytes
+requested_data.frames_selected
+requested_data.frames_pending
+decoder.frames_received
+decoder.partial_completion_status
+eps.battery.state_of_charge
+thermal.board_temperature
+```
+
+The selected fields are deliberately small and contract-oriented. They are not intended to mirror complete FloripaSat, GOLDS-UFSC or SpaceLab Decoder telemetry definitions.
+
+## Commands
+
+The command set is minimal:
+
+```text
+obdh.request_health_telemetry
+ttc.receive_data_request
+obdh.select_requested_data
+obdh.package_downlink_frames
+comms.set_downlink_priority
+comms.start_downlink
+comms.end_downlink
+obdh.enter_safe_mode
+obdh.clear_fault
+```
+
+Commands are modeled as mission-data contracts: allowed modes, expected effects and emitted events.
+
+They are not flight-software commands and do not encode real telecommand packets.
+
+## Events
+
+Representative events include:
+
+```text
+ttc.beacon_transmitted
+comms.contact_window_started
+ttc.telecommand_received
+obdh.data_request_accepted
+obdh.data_frames_selected
+obdh.downlink_frames_packaged
+comms.downlink_started
+comms.downlink_partial
+requested_data.frames_pending
+decoder.frames_received
+decoder.partial_reception_recorded
+comms.contact_window_ended
+```
+
+These events are used to explain the scenario outcome and generate evidence.
+
+## Faults and warnings
+
+The fault model includes warning/fault conditions such as:
+
+```text
+ttc.command_authentication_failed
+comms.downlink_capacity_insufficient
+requested_data.backlog
+data_storage.high_usage
+eps.low_battery_warning
+thermal.board_temperature_high
+```
+
+The main scenario does not center on authentication. Authentication failure is included only as a simple optional branch concept.
+
+The primary downlink constraint is:
+
+```text
+comms.downlink_capacity_insufficient
+```
+
+## Payload and data products
+
+This example is communications-oriented and does not model a mission-specific payload.
+
+The payload contract file is intentionally empty:
+
+```yaml
+payloads: []
+```
+
+Representative data products are:
+
+```text
+periodic_beacon_packet
+critical_housekeeping_packet
+requested_telemetry_frame_batch
+requested_data_frame_batch
+downlink_summary_report
+decoder_reception_log
+scenario_evidence_log
+```
+
+The scenario intentionally creates more eligible data volume than the declared contact capacity can downlink.
+
+## Contact and downlink model
+
+The contact model is synthetic:
+
+```text
+contact profile: spacelab_inspired_ground_contact
+link profile: constrained_ttc_downlink
+contact window: spacelab_inspired_contact_001
+downlink flow: spacelab_inspired_priority_downlink
+queue policy: critical_first
+```
+
+The contact window declares:
+
+```text
+assumed_capacity_bytes: 12000
+```
+
+The eligible data products exceed that capacity by design.
+
+This should cause the expected OrbitFabric lint warning:
+
+```text
+WARNING OF-DL-005 contacts.yaml spacelab_inspired_priority_downlink estimated eligible data product volume may exceed declared contact capacity
+```
+
+This warning is intentional. It is the behavior the example is designed to demonstrate.
+
+Do not fix this warning by increasing contact capacity unless the purpose of the example changes.
+
+## Validation
+
+From the repository root:
+
+```bash
+orbitfabric lint examples/spacelab-inspired-communications-minislice/mission
+```
+
+Expected result:
+
+```text
+Result: PASSED WITH WARNINGS
+```
+
+Expected warning:
+
+```text
+OF-DL-005 estimated eligible data product volume may exceed declared contact capacity
+```
+
+This warning is part of the scenario design.
+
+Generate documentation:
+
+```bash
+orbitfabric gen docs examples/spacelab-inspired-communications-minislice/mission
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+Run the scenario:
+
+```bash
+orbitfabric sim examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```
+
+## Interpretation of the expected warning
+
+The warning means:
+
+```text
+eligible downlink volume > declared contact capacity
+```
+
+In this example, that is intentional.
+
+The model is demonstrating that OrbitFabric can make this contract-level mismatch explicit:
+
+```text
+beacon and critical housekeeping are prioritized
+requested telemetry/data frames are only partially downlinked
+remaining requested frames are retained onboard
+scenario evidence and decoder context record the reason
+```
+
+This is the core behavior of the minislice.
+
+## What this example proves
+
+This example proves that OrbitFabric can describe and validate a mission-data slice involving:
+
+- spacecraft modes;
+- subsystem telemetry;
+- commands;
+- events;
+- faults/warnings;
+- data products;
+- packets;
+- contact windows;
+- downlink flows;
+- decoder evidence context;
+- scenario evidence.
+
+It also shows that the same controlled-specialization pattern used by the university, OreSat-inspired and FINCH-inspired minislices can be applied to a communications-oriented public CubeSat architecture without claiming official compatibility.
+
+## What this example does not prove
+
+This example does not prove:
+
+- compatibility with SpaceLab OBDH or TT&C firmware;
+- compatibility with FloripaSat or GOLDS-UFSC packet formats;
+- compatibility with SpaceLab Decoder or SpaceLab Transmitter;
+- correctness of real SpaceLab operational data;
+- correctness of real contact windows, rates, callsigns, keys, frequencies or ground station procedures;
+- completeness of any SpaceLab, FloripaSat or GOLDS-UFSC mission model.
+
+It is a conceptual OrbitFabric example only.
+
+## Naming guidance
+
+Use:
+
+```text
+SpaceLab-inspired public communications demo
+publicly derived conceptual communications example
+SpaceLab UFSC / FloripaSat-inspired TT&C minislice
+```
+
+Do not use:
+
+```text
+SpaceLab OrbitFabric model
+official FloripaSat model
+SpaceLab uses OrbitFabric
+FloripaSat conversion
+SpaceLab replacement model
+```
+
+## Recommended use
+
+Use this example when explaining OrbitFabric as a contract layer between:
+
+```text
+mission design
+onboard software expectations
+TT&C / OBDH data flow
+telemetry
+commands
+events
+faults
+data products
+contact windows
+downlink behavior
+decoder evidence
+generated documentation
+```
+
+Do not use it as a source of truth for SpaceLab, FloripaSat or GOLDS-UFSC.
+
+## License and attribution
+
+This example is part of OrbitFabric.
+
+SpaceLab UFSC, FloripaSat, GOLDS-UFSC and related repository names are referenced only as public inspiration and attribution context.
+
+No endorsement or collaboration is implied.

--- a/examples/spacelab-inspired-communications-minislice/mission/commands.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/commands.yaml
@@ -1,0 +1,196 @@
+commands:
+  - id: obdh.request_health_telemetry
+    target: obdh
+    description: Request current critical housekeeping and communications health telemetry products.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - CONTACT
+      - DATA_REQUEST_HANDLING
+      - DOWNLINK
+      - SAFE
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - obdh.health_telemetry_requested
+    expected_effects:
+      no_state_change: true
+
+  - id: ttc.receive_data_request
+    target: ttc
+    description: Receive an abstract ground data-request telecommand and forward it to OBDH for contract-level handling.
+    arguments:
+      - name: request_id
+        type: string
+        description: Abstract request identifier used only for public-demo scenario evidence.
+      - name: requested_frame_count
+        type: uint16
+        min: 1
+        max: 256
+        default: 12
+        description: Number of conceptual stored frames requested by ground.
+    allowed_modes:
+      - CONTACT
+    requires_ack: true
+    timeout_ms: 1000
+    risk: medium
+    emits:
+      - ttc.telecommand_received
+      - obdh.data_request_accepted
+    expected_effects:
+      telemetry:
+        ttc.command_rx_status: ACCEPTED
+        transceiver.status: RX_COMMAND
+      mode_transition:
+        to: DATA_REQUEST_HANDLING
+
+  - id: obdh.select_requested_data
+    target: obdh
+    description: Select stored telemetry/data frames matching the accepted abstract data request.
+    arguments: []
+    allowed_modes:
+      - DATA_REQUEST_HANDLING
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - obdh.data_frames_selected
+    expected_effects:
+      telemetry:
+        requested_data.frames_selected: 12
+        requested_data.frames_pending: 12
+        obdh.storage_used_bytes: 42000
+        data_storage.used_bytes: 42000
+
+  - id: obdh.package_downlink_frames
+    target: obdh
+    description: Package selected stored frames into downlink-eligible requested telemetry and data batches.
+    arguments: []
+    allowed_modes:
+      - DATA_REQUEST_HANDLING
+    requires_ack: true
+    timeout_ms: 1500
+    risk: medium
+    emits:
+      - obdh.downlink_frames_packaged
+    expected_effects:
+      telemetry:
+        ttc.downlink_status: IDLE
+      mode_transition:
+        to: DOWNLINK
+
+  - id: comms.set_downlink_priority
+    target: comms
+    description: Select the priority policy used by the constrained TT&C downlink flow.
+    arguments:
+      - name: policy
+        type: enum
+        enum:
+          - critical_first
+          - priority_then_age
+          - manual_selection
+        default: critical_first
+        description: Abstract queue selection policy for the next downlink opportunity.
+    allowed_modes:
+      - CONTACT
+      - DATA_REQUEST_HANDLING
+      - DOWNLINK
+    requires_ack: true
+    timeout_ms: 500
+    risk: low
+    emits:
+      - comms.downlink_priority_set
+    expected_effects:
+      no_state_change: true
+
+  - id: comms.start_downlink
+    target: comms
+    description: Start the prioritized downlink flow for the current abstract contact window.
+    arguments: []
+    allowed_modes:
+      - DOWNLINK
+    requires_ack: true
+    timeout_ms: 1500
+    risk: medium
+    emits:
+      - ttc.beacon_transmitted
+      - comms.downlink_started
+      - comms.downlink_partial
+      - comms.downlink_capacity_insufficient
+      - requested_data.frames_pending
+      - decoder.frames_received
+      - decoder.partial_reception_recorded
+    expected_effects:
+      telemetry:
+        ttc.link_status: DOWNLINK_ACTIVE
+        ttc.beacon_status: TRANSMITTED
+        ttc.downlink_status: PARTIAL
+        comms.contact_status: ACTIVE_CONTACT
+        rf.downlink_status: PARTIAL
+        transceiver.status: TX_DOWNLINK
+        downlink.capacity_remaining_bytes: 0
+        requested_data.frames_selected: 12
+        requested_data.frames_pending: 8
+        decoder.frames_received: 4
+        decoder.partial_completion_status: PARTIAL
+
+  - id: comms.end_downlink
+    target: comms
+    description: Close the current contact window and retain remaining requested frames onboard.
+    arguments: []
+    allowed_modes:
+      - DOWNLINK
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.contact_window_ended
+    expected_effects:
+      telemetry:
+        ttc.link_status: NO_CONTACT
+        ttc.downlink_status: PARTIAL
+        comms.contact_status: CONTACT_ENDED
+        rf.downlink_status: PARTIAL
+        transceiver.status: STANDBY
+      mode_transition:
+        to: NOMINAL
+
+  - id: obdh.enter_safe_mode
+    target: obdh
+    description: Request transition to safe mode.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - CONTACT
+      - DATA_REQUEST_HANDLING
+      - DOWNLINK
+      - HIBERNATION
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: high
+    emits:
+      - obdh.safe_mode_requested
+    expected_effects:
+      mode_transition:
+        to: SAFE
+
+  - id: obdh.clear_fault
+    target: obdh
+    description: Clear a recorded warning or fault after ground review.
+    arguments:
+      - name: fault_id
+        type: string
+        description: Fault identifier to clear.
+    allowed_modes:
+      - SAFE
+      - FAULT_RECOVERY
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - obdh.fault_cleared
+    expected_effects:
+      no_state_change: true

--- a/examples/spacelab-inspired-communications-minislice/mission/commands.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/commands.yaml
@@ -18,6 +18,28 @@ commands:
     expected_effects:
       no_state_change: true
 
+  - id: comms.start_contact
+    target: comms
+    description: Open the synthetic public-demo contact window and make TT&C available for beacon and command reception.
+    arguments: []
+    allowed_modes:
+      - NOMINAL
+      - HIBERNATION
+    requires_ack: true
+    timeout_ms: 1000
+    risk: low
+    emits:
+      - comms.contact_window_started
+      - ttc.beacon_transmitted
+    expected_effects:
+      telemetry:
+        comms.contact_status: ACTIVE_CONTACT
+        ttc.link_status: CONTACT_AVAILABLE
+        ttc.beacon_status: TRANSMITTED
+        transceiver.status: RX_COMMAND
+      mode_transition:
+        to: CONTACT
+
   - id: ttc.receive_data_request
     target: ttc
     description: Receive an abstract ground data-request telecommand and forward it to OBDH for contract-level handling.
@@ -115,7 +137,6 @@ commands:
     timeout_ms: 1500
     risk: medium
     emits:
-      - ttc.beacon_transmitted
       - comms.downlink_started
       - comms.downlink_partial
       - comms.downlink_capacity_insufficient
@@ -125,7 +146,6 @@ commands:
     expected_effects:
       telemetry:
         ttc.link_status: DOWNLINK_ACTIVE
-        ttc.beacon_status: TRANSMITTED
         ttc.downlink_status: PARTIAL
         comms.contact_status: ACTIVE_CONTACT
         rf.downlink_status: PARTIAL

--- a/examples/spacelab-inspired-communications-minislice/mission/contacts.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/contacts.yaml
@@ -1,0 +1,43 @@
+contacts:
+  contact_profiles:
+    - id: spacelab_inspired_ground_contact
+      target: abstract_public_demo_ground_context
+      description: >
+        Synthetic ground contact profile for the SpaceLab-inspired public communications
+        demo. This is an assumption for contract reasoning only, not a real SpaceLab,
+        FloripaSat or GOLDS-UFSC contact schedule.
+
+  link_profiles:
+    - id: constrained_ttc_downlink
+      direction: downlink
+      assumed_rate_bps: 9600
+      description: >
+        Generic constrained TT&C downlink assumption for contract reasoning. No real
+        frequency, callsign, key, ground station, TLE, operational schedule or link
+        budget is modeled.
+
+  contact_windows:
+    - id: spacelab_inspired_contact_001
+      contact_profile: spacelab_inspired_ground_contact
+      link_profile: constrained_ttc_downlink
+      start: "2026-01-01T00:00:00Z"
+      duration_seconds: 300
+      assumed_capacity_bytes: 12000
+      description: Synthetic limited-capacity contact window used to force partial requested-frame downlink.
+
+  downlink_flows:
+    - id: spacelab_inspired_priority_downlink
+      contact_profile: spacelab_inspired_ground_contact
+      link_profile: constrained_ttc_downlink
+      queue_policy: critical_first
+      eligible_data_products:
+        - periodic_beacon_packet
+        - critical_housekeeping_packet
+        - downlink_summary_report
+        - decoder_reception_log
+        - scenario_evidence_log
+        - requested_telemetry_frame_batch
+        - requested_data_frame_batch
+      description: >
+        Priority-based downlink flow demonstrating beacon/critical-housekeeping/evidence-first
+        allocation, followed by requested telemetry/data frames under limited contact capacity.

--- a/examples/spacelab-inspired-communications-minislice/mission/data_products.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/data_products.yaml
@@ -36,7 +36,7 @@ data_products:
     estimated_size_bytes: 8000
     priority: high
     storage:
-      class: telemetry
+      class: housekeeping
       retention: 14d
       overflow_policy: drop_oldest
     downlink:
@@ -50,7 +50,7 @@ data_products:
     estimated_size_bytes: 24000
     priority: medium
     storage:
-      class: mission_data
+      class: engineering
       retention: 14d
       overflow_policy: drop_oldest
     downlink:

--- a/examples/spacelab-inspired-communications-minislice/mission/data_products.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/data_products.yaml
@@ -1,0 +1,100 @@
+data_products:
+  - id: periodic_beacon_packet
+    producer: beacon_context
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 512
+    priority: critical
+    storage:
+      class: housekeeping
+      retention: 7d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: next_available_contact
+    description: >
+      Periodic beacon product prioritized before requested data. This is a conceptual
+      public-demo product, not an official SpaceLab packet definition.
+
+  - id: critical_housekeeping_packet
+    producer: obdh
+    producer_type: subsystem
+    type: generic
+    estimated_size_bytes: 1024
+    priority: critical
+    storage:
+      class: housekeeping
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Critical housekeeping product containing OBDH, TT&C, EPS and thermal context.
+
+  - id: requested_telemetry_frame_batch
+    producer: obdh
+    producer_type: subsystem
+    type: sample_batch
+    estimated_size_bytes: 8000
+    priority: high
+    storage:
+      class: telemetry
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Abstract stored telemetry frame batch selected after a ground data request.
+
+  - id: requested_data_frame_batch
+    producer: data_storage
+    producer_type: subsystem
+    type: sample_batch
+    estimated_size_bytes: 24000
+    priority: medium
+    storage:
+      class: mission_data
+      retention: 14d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Larger requested stored-data frame batch eligible after beacon, housekeeping and evidence products.
+
+  - id: downlink_summary_report
+    producer: obdh
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 2048
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Summary of contact capacity usage and remaining requested-frame backlog.
+
+  - id: decoder_reception_log
+    producer: decoder_context
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 2048
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Conceptual decoder evidence log for received frames and partial completion status.
+
+  - id: scenario_evidence_log
+    producer: obdh
+    producer_type: subsystem
+    type: diagnostic_dump
+    estimated_size_bytes: 4096
+    priority: high
+    storage:
+      class: diagnostic
+      retention: 30d
+      overflow_policy: drop_oldest
+    downlink:
+      policy: priority_based
+    description: Scenario evidence log explaining why requested frames remained partially pending.

--- a/examples/spacelab-inspired-communications-minislice/mission/events.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/events.yaml
@@ -1,0 +1,161 @@
+events:
+  - id: ttc.beacon_transmitted
+    source: ttc
+    severity: info
+    description: Periodic beacon product transmitted during a contact opportunity.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_started
+    source: comms
+    severity: info
+    description: Abstract constrained public-demo contact window started.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: ttc.telecommand_received
+    source: ttc
+    severity: info
+    description: Abstract data-request telecommand received by TT&C.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: obdh.data_request_accepted
+    source: obdh
+    severity: info
+    description: OBDH accepted the abstract data request forwarded by TT&C.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: obdh.data_frames_selected
+    source: obdh
+    severity: info
+    description: OBDH selected stored telemetry/data frames for the accepted request.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: obdh.downlink_frames_packaged
+    source: obdh
+    severity: info
+    description: OBDH packaged selected frames into downlink-eligible batches.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_started
+    source: comms
+    severity: info
+    description: Prioritized TT&C downlink flow started for the available contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.downlink_partial
+    source: comms
+    severity: warning
+    description: Downlink flow was capacity-constrained and only part of the requested frame set could be sent.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: requested_data.frames_pending
+    source: data_storage
+    severity: warning
+    description: Requested frames remain pending onboard after the constrained contact window.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: decoder.frames_received
+    source: decoder_context
+    severity: info
+    description: Ground-side decoder context recorded received downlink frames.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: decoder.partial_reception_recorded
+    source: decoder_context
+    severity: warning
+    description: Decoder evidence context recorded partial completion of the requested transfer.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: comms.contact_window_ended
+    source: comms
+    severity: info
+    description: Abstract constrained public-demo contact window ended.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: obdh.mode_changed
+    source: obdh
+    severity: info
+    description: Spacecraft operational mode changed.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: obdh.data_request_rejected
+    source: obdh
+    severity: warning
+    description: OBDH rejected an abstract data request due to authorization or request-validity constraints.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Declared contact capacity is insufficient for the eligible downlink set.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: ttc.command_authentication_failed
+    source: ttc
+    severity: warning
+    description: Abstract command authentication or authorization failed; no requested-data selection is performed.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: obdh.health_telemetry_requested
+    source: obdh
+    severity: info
+    description: Ground requested OBDH/communications health telemetry.
+    downlink_priority: medium
+    persistence: store
+
+  - id: comms.downlink_priority_set
+    source: comms
+    severity: info
+    description: Downlink priority policy was selected for the contact opportunity.
+    downlink_priority: medium
+    persistence: store
+
+  - id: obdh.safe_mode_requested
+    source: obdh
+    severity: warning
+    description: Safe mode was requested by command or recovery logic.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: obdh.fault_cleared
+    source: obdh
+    severity: info
+    description: Fault state was cleared by ground command.
+    downlink_priority: medium
+    persistence: store_and_downlink
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Non-volatile data storage usage exceeded the warning threshold.
+    downlink_priority: high
+    persistence: store_and_downlink
+
+  - id: eps.low_power_warning_raised
+    source: eps
+    severity: warning
+    description: Battery state of charge crossed the low-power warning threshold.
+    downlink_priority: critical
+    persistence: store_and_downlink
+
+  - id: thermal.board_temperature_high
+    source: thermal
+    severity: warning
+    description: Board temperature exceeded the communications-readiness warning threshold.
+    downlink_priority: high
+    persistence: store_and_downlink

--- a/examples/spacelab-inspired-communications-minislice/mission/faults.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/faults.yaml
@@ -1,0 +1,78 @@
+faults:
+  - id: ttc.command_authentication_failed
+    source: ttc
+    severity: warning
+    description: Abstract command authentication or authorization fails for a received data request.
+    condition:
+      telemetry: ttc.command_rx_status
+      operator: ==
+      value: REJECTED
+      debounce_samples: 1
+    emits:
+      - ttc.command_authentication_failed
+      - obdh.data_request_rejected
+
+  - id: comms.downlink_capacity_insufficient
+    source: comms
+    severity: warning
+    description: Downlink capacity is exhausted while requested frames remain pending.
+    condition:
+      telemetry: downlink.capacity_remaining_bytes
+      operator: ==
+      value: 0
+      debounce_samples: 1
+    emits:
+      - comms.downlink_capacity_insufficient
+      - comms.downlink_partial
+
+  - id: requested_data.backlog
+    source: data_storage
+    severity: warning
+    description: Requested data frames remain pending after contact completion.
+    condition:
+      telemetry: requested_data.frames_pending
+      operator: '>'
+      value: 0
+      debounce_samples: 1
+    emits:
+      - requested_data.frames_pending
+      - decoder.partial_reception_recorded
+
+  - id: data_storage.high_usage
+    source: data_storage
+    severity: warning
+    description: Non-volatile storage usage exceeds the warning threshold.
+    condition:
+      telemetry: data_storage.used_bytes
+      operator: '>'
+      value: 50000000
+      debounce_samples: 1
+    emits:
+      - data_storage.high_usage
+
+  - id: eps.low_battery_warning
+    source: eps
+    severity: warning
+    description: Battery state of charge remains below the warning threshold for two consecutive samples.
+    condition:
+      telemetry: eps.battery.state_of_charge
+      operator: <
+      value: 30.0
+      debounce_samples: 2
+    emits:
+      - eps.low_power_warning_raised
+    recovery:
+      mode_transition: HIBERNATION
+      auto_commands: []
+
+  - id: thermal.board_temperature_high
+    source: thermal
+    severity: warning
+    description: Board temperature exceeds the communications-readiness warning threshold.
+    condition:
+      telemetry: thermal.board_temperature
+      operator: '>'
+      value: 55.0
+      debounce_samples: 1
+    emits:
+      - thermal.board_temperature_high

--- a/examples/spacelab-inspired-communications-minislice/mission/modes.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/modes.yaml
@@ -1,0 +1,86 @@
+modes:
+  SAFE:
+    description: Protective mode with communications and data-handling activity reduced to essential operations.
+
+  STANDBY:
+    description: Low-activity mode used before nominal operations or after recovery.
+
+  NOMINAL:
+    description: Routine telemetry collection, beacon availability and command-handling readiness.
+    initial: true
+
+  CONTACT:
+    description: Ground contact is available and TT&C command reception/downlink preparation can occur.
+
+  DATA_REQUEST_HANDLING:
+    description: OBDH is validating, selecting and packaging stored frames requested by ground.
+
+  DOWNLINK:
+    description: TT&C/comms are using the available contact window to downlink prioritized mission data.
+
+  HIBERNATION:
+    description: Reduced-activity low-energy state where only essential wakeup and beacon context remain.
+
+  FAULT_RECOVERY:
+    description: Controlled recovery mode used after communications, command or storage-related warnings.
+
+mode_transitions:
+  - from: STANDBY
+    to: NOMINAL
+    reason: ground_authorized_nominal
+    description: Ground authorizes transition from standby to nominal operations.
+
+  - from: NOMINAL
+    to: CONTACT
+    reason: contact_window_started
+    description: A declared public-demo contact window becomes available.
+
+  - from: HIBERNATION
+    to: CONTACT
+    reason: contact_window_started
+    description: A declared public-demo contact window wakes the spacecraft into contact handling.
+
+  - from: CONTACT
+    to: DATA_REQUEST_HANDLING
+    reason: data_request_received
+    description: TT&C receives an abstract data request and forwards it to OBDH.
+
+  - from: DATA_REQUEST_HANDLING
+    to: DOWNLINK
+    reason: downlink_frames_packaged
+    description: OBDH has packaged selected stored frames for prioritized downlink.
+
+  - from: CONTACT
+    to: DOWNLINK
+    reason: beacon_and_housekeeping_only
+    description: Contact downlink starts without requested-data selection.
+
+  - from: DOWNLINK
+    to: NOMINAL
+    reason: contact_window_ended
+    description: Contact ends and the spacecraft returns to nominal operations with any pending frames retained.
+
+  - from: NOMINAL
+    to: HIBERNATION
+    reason: energy_saving_requested
+    description: Spacecraft enters a reduced-activity state between contact opportunities.
+
+  - from: NOMINAL
+    to: SAFE
+    reason: safe_mode_requested
+    description: Protective safe mode requested by command or recovery logic.
+
+  - from: CONTACT
+    to: SAFE
+    reason: command_authorization_failed
+    description: Command validation fails and the spacecraft transitions to a protective state if required.
+
+  - from: SAFE
+    to: FAULT_RECOVERY
+    reason: ground_clear_fault
+    description: Ground starts a controlled recovery sequence.
+
+  - from: FAULT_RECOVERY
+    to: STANDBY
+    reason: recovery_completed
+    description: Recovery completes and the spacecraft returns to standby.

--- a/examples/spacelab-inspired-communications-minislice/mission/packets.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/packets.yaml
@@ -1,0 +1,61 @@
+packets:
+  - id: periodic_beacon_packet
+    name: Periodic Beacon Packet
+    type: json
+    max_payload_bytes: 256
+    period: 60s
+    telemetry:
+      - obdh.uptime
+      - ttc.beacon_status
+      - eps.battery.state_of_charge
+      - thermal.board_temperature
+    description: >
+      Compact SpaceLab-inspired public-demo beacon packet. This is not an official
+      FloripaSat or GOLDS-UFSC beacon definition.
+
+  - id: critical_housekeeping_packet
+    name: Critical Housekeeping Packet
+    type: json
+    max_payload_bytes: 512
+    period: 30s
+    telemetry:
+      - obdh.uptime
+      - obdh.storage_used_bytes
+      - ttc.link_status
+      - eps.battery.state_of_charge
+      - thermal.board_temperature
+    description: Critical housekeeping packet prioritized before requested data frames.
+
+  - id: requested_telemetry_frame_batch
+    name: Requested Telemetry Frame Batch
+    type: json
+    max_payload_bytes: 2048
+    period: on_request
+    telemetry:
+      - requested_data.frames_selected
+      - requested_data.frames_pending
+      - data_storage.used_bytes
+    description: Abstract batch of requested stored telemetry frames selected by OBDH.
+
+  - id: downlink_summary_packet
+    name: Downlink Summary Packet
+    type: json
+    max_payload_bytes: 512
+    period: on_contact
+    telemetry:
+      - downlink.capacity_remaining_bytes
+      - ttc.downlink_status
+      - requested_data.frames_pending
+      - decoder.frames_received
+      - decoder.partial_completion_status
+    description: Contact summary packet used as evidence for partial requested-data completion.
+
+  - id: decoder_reception_packet
+    name: Decoder Reception Packet
+    type: json
+    max_payload_bytes: 512
+    period: on_contact
+    telemetry:
+      - decoder.frames_received
+      - decoder.partial_completion_status
+    description: Conceptual ground-side decoder reception evidence packet.

--- a/examples/spacelab-inspired-communications-minislice/mission/payloads.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/payloads.yaml
@@ -1,0 +1,1 @@
+payloads: []

--- a/examples/spacelab-inspired-communications-minislice/mission/policies.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/policies.yaml
@@ -1,0 +1,35 @@
+policies:
+  persistence:
+    allowed_values:
+      - none
+      - store
+      - downlink_only
+      - store_and_downlink
+
+  downlink_priority:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  command_risk:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical
+
+  event_severity:
+    allowed_values:
+      - info
+      - warning
+      - error
+      - critical
+
+  telemetry_criticality:
+    allowed_values:
+      - low
+      - medium
+      - high
+      - critical

--- a/examples/spacelab-inspired-communications-minislice/mission/spacecraft.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/spacecraft.yaml
@@ -1,0 +1,7 @@
+spacecraft:
+  id: spacelab-inspired-communications-minislice
+  name: SpaceLab-inspired Communications Minislice
+  class: cubesat
+  form_factor: 1U-inspired
+  mission_type: publicly_derived_conceptual_university_communications_demo
+  model_version: 0.4.0-demo

--- a/examples/spacelab-inspired-communications-minislice/mission/subsystems.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/subsystems.yaml
@@ -1,0 +1,84 @@
+subsystems:
+  - id: spacecraft_bus
+    name: Spacecraft Bus
+    type: bus
+    criticality: critical
+    description: Conceptual CubeSat bus context coordinating spacecraft-level operational state.
+
+  - id: obdh
+    name: Onboard Data Handling
+    type: core
+    criticality: critical
+    description: >
+      SpaceLab-inspired OBDH context for command routing, stored telemetry selection,
+      dataframe packaging, storage coordination and spacecraft mode control.
+
+  - id: ttc
+    name: Telemetry, Tracking and Telecommand
+    type: communication
+    criticality: critical
+    description: >
+      SpaceLab-inspired TT&C context for beacon transmission, telecommand reception,
+      command forwarding to OBDH and requested-data downlink.
+
+  - id: beacon_context
+    name: Beacon Context
+    type: communication
+    criticality: high
+    description: Conceptual periodic beacon context carrying basic satellite telemetry.
+
+  - id: data_storage
+    name: Non-Volatile Data Storage
+    type: storage
+    criticality: high
+    description: >
+      Conceptual onboard non-volatile storage context for retained telemetry frames,
+      requested data frames and scenario evidence products.
+
+  - id: comms
+    name: Communications Flow Context
+    type: communication
+    criticality: high
+    description: Contract-level contact, prioritization and constrained downlink context.
+
+  - id: rf
+    name: RF Link Context
+    type: communication
+    criticality: high
+    description: >
+      Abstract RF link state used only for public-demo downlink evidence. No real
+      frequency, callsign, TLE, ground station or link budget is modeled.
+
+  - id: transceiver
+    name: Transceiver Context
+    type: communication
+    criticality: high
+    description: Conceptual transceiver state for receive, transmit and standby behavior.
+
+  - id: ground_station_context
+    name: Ground Station Context
+    type: ground_context
+    criticality: medium
+    description: >
+      Abstract public-demo ground-contact context used only for contact and downlink
+      contract assumptions, not a real SpaceLab operational plan.
+
+  - id: decoder_context
+    name: Decoder Evidence Context
+    type: ground_context
+    criticality: medium
+    description: >
+      Conceptual ground-side decoder evidence context inspired by public SpaceLab
+      decoder documentation. It records received frames and partial completion only.
+
+  - id: eps
+    name: Electrical Power System
+    type: subsystem
+    criticality: critical
+    description: Conceptual EPS context exposing battery state of charge for communications availability.
+
+  - id: thermal
+    name: Board Thermal Context
+    type: subsystem
+    criticality: medium
+    description: Conceptual board-temperature context used as a simple communications-readiness warning source.

--- a/examples/spacelab-inspired-communications-minislice/mission/telemetry.yaml
+++ b/examples/spacelab-inspired-communications-minislice/mission/telemetry.yaml
@@ -1,0 +1,290 @@
+telemetry:
+  - id: obdh.uptime
+    name: OBDH Uptime
+    type: uint32
+    unit: s
+    source: obdh
+    sampling: 1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    quality:
+      required: true
+      default: good
+    description: OBDH uptime included in beacon, housekeeping and decoder evidence context.
+
+  - id: obdh.storage_used_bytes
+    name: OBDH Storage Used
+    type: uint32
+    unit: bytes
+    source: obdh
+    sampling: 0.1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 50000000
+      critical_high: 80000000
+    quality:
+      required: true
+      default: good
+    description: OBDH-visible stored-data occupancy.
+
+  - id: data_storage.used_bytes
+    name: Data Storage Used
+    type: uint32
+    unit: bytes
+    source: data_storage
+    sampling: 0.1Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 50000000
+      critical_high: 80000000
+    quality:
+      required: true
+      default: good
+    description: Generic non-volatile storage occupancy for retained telemetry, requested frames and evidence logs.
+
+  - id: ttc.link_status
+    name: TT&C Link Status
+    type: enum
+    unit: none
+    source: ttc
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - NO_CONTACT
+      - CONTACT_AVAILABLE
+      - DOWNLINK_ACTIVE
+    quality:
+      required: true
+      default: good
+    description: Abstract TT&C contact/downlink state for scenario evidence.
+
+  - id: ttc.beacon_status
+    name: TT&C Beacon Status
+    type: enum
+    unit: none
+    source: beacon_context
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    enum:
+      - IDLE
+      - AVAILABLE
+      - TRANSMITTED
+      - DEGRADED
+    quality:
+      required: true
+      default: good
+    description: Periodic beacon availability and transmission state.
+
+  - id: ttc.command_rx_status
+    name: TT&C Command Receive Status
+    type: enum
+    unit: none
+    source: ttc
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - IDLE
+      - RECEIVED
+      - ACCEPTED
+      - REJECTED
+    quality:
+      required: true
+      default: good
+    description: Abstract received-telecommand status used for data-request handling.
+
+  - id: ttc.downlink_status
+    name: TT&C Downlink Status
+    type: enum
+    unit: none
+    source: ttc
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - IDLE
+      - ACTIVE
+      - PARTIAL
+      - COMPLETE
+    quality:
+      required: true
+      default: good
+    description: Abstract TT&C downlink progress status.
+
+  - id: comms.contact_status
+    name: Contact Status
+    type: enum
+    unit: none
+    source: comms
+    sampling: on_change
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - NO_CONTACT
+      - ACTIVE_CONTACT
+      - CONTACT_ENDED
+    quality:
+      required: true
+      default: good
+    description: Contract-level contact state for the synthetic public-demo contact window.
+
+  - id: rf.downlink_status
+    name: RF Downlink Status
+    type: enum
+    unit: none
+    source: rf
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - IDLE
+      - ACTIVE
+      - PARTIAL
+      - COMPLETE
+    quality:
+      required: true
+      default: good
+    description: Abstract RF downlink status with no operational frequency or link budget.
+
+  - id: transceiver.status
+    name: Transceiver Status
+    type: enum
+    unit: none
+    source: transceiver
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: medium
+    enum:
+      - STANDBY
+      - RX_COMMAND
+      - TX_BEACON
+      - TX_DOWNLINK
+      - FAULT
+    quality:
+      required: true
+      default: good
+    description: Conceptual transceiver state during command reception, beacon and downlink.
+
+  - id: downlink.capacity_remaining_bytes
+    name: Downlink Capacity Remaining
+    type: uint32
+    unit: bytes
+    source: comms
+    sampling: on_change
+    criticality: medium
+    persistence: store
+    downlink_priority: medium
+    quality:
+      required: true
+      default: good
+    description: Contract-level remaining capacity after priority allocation.
+
+  - id: requested_data.frames_selected
+    name: Requested Data Frames Selected
+    type: uint16
+    unit: frames
+    source: obdh
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    quality:
+      required: true
+      default: good
+    description: Number of stored telemetry/data frames selected by OBDH for the current request.
+
+  - id: requested_data.frames_pending
+    name: Requested Data Frames Pending
+    type: uint16
+    unit: frames
+    source: data_storage
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 0
+    quality:
+      required: true
+      default: good
+    description: Requested frames remaining pending after the constrained contact window.
+
+  - id: decoder.frames_received
+    name: Decoder Frames Received
+    type: uint16
+    unit: frames
+    source: decoder_context
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    quality:
+      required: true
+      default: good
+    description: Conceptual ground-side decoder count of received frames.
+
+  - id: decoder.partial_completion_status
+    name: Decoder Partial Completion Status
+    type: enum
+    unit: none
+    source: decoder_context
+    sampling: on_change
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    enum:
+      - NOT_STARTED
+      - PARTIAL
+      - COMPLETE
+    quality:
+      required: true
+      default: good
+    description: Decoder-side evidence that the requested transfer completed only partially.
+
+  - id: eps.battery.state_of_charge
+    name: Battery State of Charge
+    type: float32
+    unit: percent
+    source: eps
+    sampling: 1Hz
+    criticality: high
+    persistence: store_and_downlink
+    downlink_priority: critical
+    limits:
+      warning_low: 30.0
+      critical_low: 15.0
+    quality:
+      required: true
+      default: good
+    description: Battery state of charge used to warn about communications availability constraints.
+
+  - id: thermal.board_temperature
+    name: Board Temperature
+    type: float32
+    unit: degC
+    source: thermal
+    sampling: 0.2Hz
+    criticality: medium
+    persistence: store_and_downlink
+    downlink_priority: high
+    limits:
+      warning_high: 55.0
+      critical_high: 70.0
+    quality:
+      required: true
+      default: good
+    description: Board-temperature context used as a simple TT&C/OBDH readiness warning source.

--- a/examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
+++ b/examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
@@ -1,0 +1,178 @@
+scenario:
+  id: ttc_data_request_constrained_downlink
+  name: TT&C data request constrained by downlink capacity
+  description: >
+    SpaceLab-inspired public communications minislice where a periodic beacon is
+    available, a ground contact starts, TT&C receives an abstract data-request
+    telecommand, OBDH selects and packages stored frames, and the constrained
+    contact downlinks beacon/housekeeping/evidence before leaving requested frames
+    partially pending onboard.
+mission:
+  path: ../mission
+initial_state:
+  mode: NOMINAL
+  telemetry:
+    obdh.uptime: 7200
+    obdh.storage_used_bytes: 42000
+    data_storage.used_bytes: 42000
+    ttc.link_status: NO_CONTACT
+    ttc.beacon_status: AVAILABLE
+    ttc.command_rx_status: IDLE
+    ttc.downlink_status: IDLE
+    comms.contact_status: NO_CONTACT
+    rf.downlink_status: IDLE
+    transceiver.status: STANDBY
+    downlink.capacity_remaining_bytes: 12000
+    requested_data.frames_selected: 0
+    requested_data.frames_pending: 0
+    decoder.frames_received: 0
+    decoder.partial_completion_status: NOT_STARTED
+    eps.battery.state_of_charge: 64.0
+    thermal.board_temperature: 32.0
+steps:
+  - t: 0
+    expect_mode: NOMINAL
+
+  - t: 5
+    event: ttc.beacon_transmitted
+
+  - t: 6
+    expect_event: ttc.beacon_transmitted
+
+  - t: 8
+    event: comms.contact_window_started
+
+  - t: 9
+    expect_event: comms.contact_window_started
+
+  - t: 10
+    inject:
+      comms.contact_status: ACTIVE_CONTACT
+      ttc.link_status: CONTACT_AVAILABLE
+      transceiver.status: RX_COMMAND
+
+  - t: 11
+    expect_telemetry:
+      comms.contact_status: ACTIVE_CONTACT
+      ttc.link_status: CONTACT_AVAILABLE
+      transceiver.status: RX_COMMAND
+
+  - t: 12
+    command: ttc.receive_data_request
+    args:
+      request_id: stored_frames_demo_request
+      requested_frame_count: 12
+    expect:
+      command_status: ACCEPTED
+
+  - t: 13
+    expect_event: ttc.telecommand_received
+
+  - t: 14
+    expect_event: obdh.data_request_accepted
+
+  - t: 15
+    expect_mode: DATA_REQUEST_HANDLING
+
+  - t: 16
+    expect_telemetry:
+      ttc.command_rx_status: ACCEPTED
+      transceiver.status: RX_COMMAND
+
+  - t: 18
+    command: obdh.select_requested_data
+    expect:
+      command_status: ACCEPTED
+
+  - t: 19
+    expect_event: obdh.data_frames_selected
+
+  - t: 20
+    expect_telemetry:
+      requested_data.frames_selected: 12
+      requested_data.frames_pending: 12
+      obdh.storage_used_bytes: 42000
+      data_storage.used_bytes: 42000
+
+  - t: 22
+    command: comms.set_downlink_priority
+    args:
+      policy: critical_first
+    expect:
+      command_status: ACCEPTED
+
+  - t: 23
+    expect_event: comms.downlink_priority_set
+
+  - t: 25
+    command: obdh.package_downlink_frames
+    expect:
+      command_status: ACCEPTED
+
+  - t: 26
+    expect_event: obdh.downlink_frames_packaged
+
+  - t: 27
+    expect_mode: DOWNLINK
+
+  - t: 29
+    command: comms.start_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 30
+    expect_event: comms.downlink_started
+
+  - t: 31
+    expect_event: comms.downlink_partial
+
+  - t: 32
+    expect_event: comms.downlink_capacity_insufficient
+
+  - t: 33
+    expect_event: requested_data.frames_pending
+
+  - t: 34
+    expect_event: decoder.frames_received
+
+  - t: 35
+    expect_event: decoder.partial_reception_recorded
+
+  - t: 36
+    expect_telemetry:
+      ttc.link_status: DOWNLINK_ACTIVE
+      ttc.beacon_status: TRANSMITTED
+      ttc.downlink_status: PARTIAL
+      comms.contact_status: ACTIVE_CONTACT
+      rf.downlink_status: PARTIAL
+      transceiver.status: TX_DOWNLINK
+      downlink.capacity_remaining_bytes: 0
+      requested_data.frames_selected: 12
+      requested_data.frames_pending: 8
+      decoder.frames_received: 4
+      decoder.partial_completion_status: PARTIAL
+
+  - t: 40
+    command: comms.end_downlink
+    expect:
+      command_status: ACCEPTED
+
+  - t: 41
+    expect_event: comms.contact_window_ended
+
+  - t: 42
+    expect_mode: NOMINAL
+
+  - t: 43
+    expect_telemetry:
+      ttc.link_status: NO_CONTACT
+      ttc.downlink_status: PARTIAL
+      comms.contact_status: CONTACT_ENDED
+      rf.downlink_status: PARTIAL
+      transceiver.status: STANDBY
+      requested_data.frames_pending: 8
+      decoder.partial_completion_status: PARTIAL
+
+  - t: 45
+    expect:
+      scenario_status: PASSED

--- a/examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
+++ b/examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
@@ -34,27 +34,24 @@ steps:
     expect_mode: NOMINAL
 
   - t: 5
-    event: ttc.beacon_transmitted
+    command: comms.start_contact
+    expect:
+      command_status: ACCEPTED
 
   - t: 6
+    expect_event: comms.contact_window_started
+
+  - t: 7
     expect_event: ttc.beacon_transmitted
 
   - t: 8
-    event: comms.contact_window_started
+    expect_mode: CONTACT
 
   - t: 9
-    expect_event: comms.contact_window_started
-
-  - t: 10
-    inject:
-      comms.contact_status: ACTIVE_CONTACT
-      ttc.link_status: CONTACT_AVAILABLE
-      transceiver.status: RX_COMMAND
-
-  - t: 11
     expect_telemetry:
       comms.contact_status: ACTIVE_CONTACT
       ttc.link_status: CONTACT_AVAILABLE
+      ttc.beacon_status: TRANSMITTED
       transceiver.status: RX_COMMAND
 
   - t: 12


### PR DESCRIPTION
## Summary

Adds `examples/spacelab-inspired-communications-minislice/`, a SpaceLab UFSC / FloripaSat-inspired public conceptual communications minislice for OrbitFabric.

The example focuses on a compact TT&C / OBDH data-flow contract:

- periodic beacon availability;
- synthetic ground contact;
- abstract data-request telecommand reception;
- OBDH requested-frame selection and packaging;
- beacon / critical housekeeping / evidence-first downlink;
- partial requested-frame downlink under constrained contact capacity;
- decoder-side evidence of received frames and partial completion.

## Scope

This is a publicly derived conceptual example. It is explicitly:

- not an official SpaceLab, FloripaSat or GOLDS-UFSC model;
- not endorsed by SpaceLab UFSC or UFSC;
- not a claim that SpaceLab uses OrbitFabric;
- not a collaboration announcement;
- not a conversion of FloripaSat architecture, firmware, packet formats or operational plans;
- not a replacement for SpaceLab decoder, transmitter, TT&C, OBDH, firmware or ground station software.

The example intentionally avoids real frequencies, callsigns, keys, TLEs, ground-station plans, operational schedules and sensitive operational details.

## Files added

- `examples/spacelab-inspired-communications-minislice/README.md`
- `examples/spacelab-inspired-communications-minislice/mission/*.yaml`
- `examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml`

## Validation

Validation performed locally:

```bash
orbitfabric lint examples/spacelab-inspired-communications-minislice/mission
orbitfabric gen docs examples/spacelab-inspired-communications-minislice/mission
orbitfabric sim examples/spacelab-inspired-communications-minislice/scenarios/ttc_data_request_constrained_downlink.yaml
ruff check .
pytest
mkdocs build --strict
```

Results:

- `lint`: passed with one expected warning;
- `gen docs`: passed;
- `sim`: passed;
- `ruff check .`: passed;
- `pytest`: passed;
- `mkdocs build --strict`: passed.

Expected lint warning:

```text
OF-DL-005 contacts.yaml spacelab_inspired_priority_downlink estimated eligible data product volume may exceed declared contact capacity
```

This warning is intentional. The example is designed to demonstrate constrained contact capacity, partial requested-frame downlink, onboard backlog and decoder evidence of partial completion.

## Notes

The intentional constrained-downlink condition is part of the example design: eligible data product volume exceeds the declared contact capacity so that requested frames remain partially pending onboard and decoder evidence records partial completion.