### PR TITLE
docs: define v0.5 commandability autonomy scope

### DIFF
--- a/docs/adr/ADR-0010-commandability-and-autonomy-contracts.md
+++ b/docs/adr/ADR-0010-commandability-and-autonomy-contracts.md
@@ -1,0 +1,378 @@
+# ADR-0010 — Commandability and Autonomy Contracts
+
+Status: Proposed  
+Date: 2026-05-07
+
+---
+
+## Context
+
+OrbitFabric is a model-first Mission Data Contract framework for small spacecraft.
+
+The v0.4.0 baseline introduced Contact Windows and Downlink Flow Contracts as declared assumptions for onboard-to-ground data flow reasoning.
+
+The current Mission Data Chain is:
+
+```text
+Payload Contract
+        -> Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+        -> Contact Window Assumption
+        -> Downlink Flow Contract
+```
+
+That chain describes what mission data exists, how it is intended to be retained, and under which declared contact/downlink assumptions it can become eligible for delivery.
+
+However, a mission contract also needs to describe whether the commands and autonomous actions that affect this chain are coherent.
+
+Examples:
+
+```text
+A payload acquisition command may be ground-dispatched only in selected modes.
+A recovery command may be auto-dispatched after a declared fault.
+A high-risk command may require an explicit confirmation intent.
+An autonomous action may expect events or telemetry effects to be declared.
+A command may require a contact assumption before it is considered commandable from ground.
+```
+
+These are Mission Data Contract concerns.
+
+They are not command uplink runtime, not command authentication, not command authorization, not an operator console, not an onboard scheduler, not a flight autonomy runtime and not a real FDIR implementation.
+
+---
+
+## Decision
+
+OrbitFabric will introduce Commandability and Autonomy Contracts as the next Mission Data Chain slice.
+
+The model will describe declared assumptions about command sources, command dispatch intent, commandability constraints, autonomous action assumptions and recovery intent so that OrbitFabric can reason about consistency before runtime skeletons, ground integration artifacts or end-to-end mission data flow evidence are introduced.
+
+The first implementation slice must be optional and narrow.
+
+The preferred model entry point is:
+
+```text
+mission/commandability.yaml
+```
+
+This name is intentional.
+
+It communicates that the domain describes whether commands are commandable under declared assumptions.
+
+It does not imply a mission operations system, command policy engine, security model, scheduler or autonomy runtime.
+
+The model may contain:
+
+```text
+command source assumptions
+commandability rules
+autonomous action contracts
+recovery intent declarations
+```
+
+These concepts are declarative.
+
+They do not execute commands, queue commands, authenticate users, schedule onboard actions, run autonomy logic or perform real safing.
+
+---
+
+## Naming Decision
+
+The selected first-slice file name is:
+
+```text
+mission/commandability.yaml
+```
+
+Rejected names:
+
+```text
+operations.yaml
+command_policy.yaml
+autonomy.yaml
+```
+
+Rationale:
+
+- `operations.yaml` is too broad and suggests mission operations procedures or an operator console.
+- `command_policy.yaml` suggests security, authorization or a runtime policy engine.
+- `autonomy.yaml` over-emphasizes autonomy and risks implying a flight autonomy runtime.
+
+A two-file split such as `commandability.yaml` plus `autonomy.yaml` is also deferred.
+
+The first slice should remain small enough to validate the concept without creating premature domain fragmentation.
+
+---
+
+## Terminology
+
+OrbitFabric must keep these concepts distinct.
+
+```text
+Command Source
+    A declared origin class for command dispatch intent.
+    Examples: ground, onboard, autonomous.
+
+Commandability Rule
+    A declared rule describing when a command is intended to be usable.
+    It complements the existing command definition without duplicating it.
+
+Autonomous Action Contract
+    A declared assumption that a command or action may be triggered by a modeled event, fault, telemetry condition or mode context.
+
+Recovery Intent
+    A declared recovery or safing-oriented intent that references existing commands, modes, faults or events.
+```
+
+A command source is not a user account.
+
+A commandability rule is not runtime authorization.
+
+An autonomous action contract is not autonomy software.
+
+A recovery intent is not FDIR implementation.
+
+---
+
+## Minimal Shape
+
+The first slice should use a shape similar to:
+
+```yaml
+commandability:
+  sources:
+    - id: ground_operator
+      type: ground
+      requires_contact: true
+      contact_profile: primary_ground_contact
+      description: Abstract ground-originated command source.
+
+    - id: onboard_autonomy
+      type: autonomous
+      requires_contact: false
+      description: Abstract onboard autonomous command source.
+
+  rules:
+    - id: payload_start_ground_rule
+      command: payload.start_acquisition
+      sources:
+        - ground_operator
+      allowed_modes:
+        - NOMINAL
+      confirmation: required
+      description: Payload acquisition may be commanded from ground in nominal mode.
+
+  autonomous_actions:
+    - id: stop_payload_on_battery_warning
+      trigger:
+        fault: eps.battery_warning
+      dispatches:
+        command: payload.stop_acquisition
+        source: onboard_autonomy
+      expected_events:
+        - payload.acquisition_stopped
+      description: Contract-level autonomous recovery assumption for battery warning.
+
+  recovery_intents:
+    - id: payload_battery_warning_recovery
+      fault: eps.battery_warning
+      target_mode: DEGRADED
+      commands:
+        - payload.stop_acquisition
+      description: Declared recovery intent for payload activity during battery warning.
+```
+
+This shape is a proposed v0.5.0 contract shape.
+
+It is not a frozen v1.0 schema.
+
+---
+
+## Relationship with Existing Commands
+
+The existing `commands.yaml` domain remains the source of truth for command identity and basic command definition.
+
+Commandability Contracts must not duplicate the command model.
+
+They should reference existing commands and add declared assumptions around:
+
+```text
+source
+mode availability refinement
+contact requirement
+confirmation intent
+autonomous dispatch intent
+recovery intent
+expected evidence
+```
+
+The existing command fields remain relevant:
+
+```text
+allowed_modes
+requires_ack
+timeout_ms
+risk
+emits
+expected_effects
+```
+
+The v0.5 model should cross-check commandability assumptions against those existing command fields.
+
+---
+
+## Initial Scope
+
+The first vertical slice should include:
+
+```text
+optional commandability.yaml loading
+typed commandability model objects
+command source identity validation
+commandability rule identity validation
+autonomous action identity validation
+recovery intent identity validation
+reference validation to existing commands
+reference validation to existing modes
+reference validation to existing events, faults and telemetry where used
+optional reference validation to contact profiles when ground source requires contact
+minimal semantic lint rules
+generated commandability documentation
+one synthetic demo commandability/autonomy slice
+```
+
+The slice should prove this relationship:
+
+```text
+Command Definition
+        -> Command Source Assumption
+        -> Commandability Rule
+        -> Autonomous Action Assumption
+        -> Recovery Intent
+        -> Lintable Consistency
+        -> Generated Documentation
+```
+
+---
+
+## Non-Goals
+
+This decision must not introduce:
+
+```text
+real command authentication
+real command authorization
+user roles or permissions
+encryption
+key management
+live uplink
+live command routing
+real command queue
+operator console
+mission control system
+Yamcs runtime integration
+OpenC3 runtime integration
+flight autonomy runtime
+onboard scheduler
+onboard command dispatcher
+real FDIR implementation
+real safing logic
+runtime skeleton generation
+ground export generation
+private mission operations procedures
+```
+
+These are not missing pieces of v0.5.0.
+
+They are intentionally outside the scope of this ADR.
+
+---
+
+## Linting Direction
+
+Commandability and Autonomy Contracts must be lintable from the beginning.
+
+Initial linting direction should include:
+
+```text
+ERROR: commandability rule references an unknown command.
+ERROR: commandability rule references an unknown mode.
+ERROR: commandability rule references an unknown source.
+WARNING: ground command source requires contact but no contact profile is referenced.
+ERROR: ground command source references an unknown contact profile.
+ERROR: autonomous action dispatches an unknown command.
+ERROR: autonomous action references an unknown source.
+ERROR: autonomous action trigger references an unknown event, fault or telemetry item.
+ERROR: recovery intent references an unknown command.
+ERROR: recovery intent references an unknown fault, event or mode.
+WARNING: high-risk command lacks explicit confirmation intent.
+WARNING: autonomous recovery command lacks expected events or effects.
+```
+
+The principle is fixed:
+
+> If command use or autonomous behavior can become operationally ambiguous, the ambiguity must be visible before runtime or ground artifacts are generated.
+
+---
+
+## Documentation Direction
+
+Generated documentation should expose commandability and autonomy assumptions from the validated Mission Model.
+
+The expected generated file is:
+
+```text
+generated/docs/commandability.md
+```
+
+The generated page should make clear that sources, commandability rules, autonomous actions and recovery intents are contract assumptions only.
+
+---
+
+## Consequences
+
+This decision extends OrbitFabric from declared onboard-to-ground data flow reasoning toward declared command and recovery reasoning.
+
+It makes the next Mission Data Chain step explicit:
+
+```text
+contact/downlink assumptions
+        -> command source assumptions
+        -> commandability rules
+        -> autonomous action assumptions
+        -> recovery intent
+        -> future end-to-end mission data flow evidence
+```
+
+This strengthens later milestones.
+
+End-to-End Mission Data Flow Evidence will be able to reason about whether a scenario is not only data-flow coherent, but also commandability coherent.
+
+Runtime skeletons and ground integration artifacts will eventually be derived from a stronger model.
+
+---
+
+## Acceptance Criteria for This Decision
+
+This ADR is satisfied when:
+
+- the scope of Commandability and Autonomy Contracts is documented;
+- `mission/commandability.yaml` is selected as the first-slice model entry point;
+- command sources, commandability rules, autonomous actions and recovery intents are defined as contract assumptions;
+- non-goals are explicit;
+- the model remains optional;
+- commandability concepts are connected to existing commands, modes, events, faults, telemetry and contact assumptions where appropriate;
+- initial linting direction is documented;
+- generated documentation direction is documented;
+- implementation remains narrow, synthetic and clean-room.
+
+---
+
+## Final Position
+
+OrbitFabric must not jump from contact/downlink contracts directly to runtime or ground integration.
+
+The next correct step is to model the commandability and autonomy assumptions used to reason about the mission contract.
+
+That model must stay declarative.

--- a/docs/reference/commandability-contract-model.md
+++ b/docs/reference/commandability-contract-model.md
@@ -1,0 +1,378 @@
+# Commandability and Autonomy Contract Model
+
+Status: Proposed for OrbitFabric v0.5.0  
+Scope: Commandability and Autonomy Contract definition
+
+---
+
+## Purpose
+
+The Commandability and Autonomy Contract Model extends OrbitFabric with an optional model domain for declared commandability and autonomy assumptions.
+
+Its purpose is to answer a contract-level question:
+
+> Given the declared commands, modes, contact/downlink assumptions, mission conditions and recovery expectations, is the intended use of commands and autonomous actions coherent?
+
+The model does not execute commands.
+
+It does not authenticate operators.
+
+It does not authorize commands.
+
+It does not implement live uplink.
+
+It does not implement onboard autonomy.
+
+It does not implement a real FDIR system.
+
+---
+
+## Relationship with Commands
+
+The existing Command model describes command identity and basic command definition.
+
+A command may already define:
+
+```text
+command id
+target subsystem
+arguments
+allowed modes
+preconditions
+ack requirement
+timeout
+risk
+emitted events
+expected effects
+```
+
+The Commandability and Autonomy Contract Model describes the assumptions used to reason about how commands are intended to be dispatched, constrained and used in recovery or autonomous contexts.
+
+The relationship is:
+
+```text
+Command Definition
+        -> Command Source Assumption
+        -> Commandability Rule
+        -> Autonomous Action Assumption
+        -> Recovery Intent
+```
+
+This is declarative.
+
+It does not imply runtime dispatch, onboard scheduling, operator workflow or live command routing.
+
+---
+
+## Relationship with Contact and Downlink Contracts
+
+Contact and Downlink Contracts describe declared assumptions about contact opportunities and data delivery paths.
+
+Commandability Contracts may reference contact assumptions only where this is useful for contract-level consistency.
+
+For example, a ground command source may declare:
+
+```text
+requires_contact: true
+contact_profile: primary_ground_contact
+```
+
+This means only that the command source depends on a declared contact assumption.
+
+It does not create an uplink runtime.
+
+It does not turn OrbitFabric into a contact scheduler.
+
+It does not require RF simulation.
+
+---
+
+## What the Model May Describe
+
+A commandability/autonomy contract may describe:
+
+```text
+command source identity
+command source type
+whether a source requires contact
+optional contact profile reference
+commandability rule identity
+referenced command
+allowed source assumptions
+mode availability refinement
+confirmation intent
+autonomous trigger assumption
+autonomously dispatched command assumption
+expected event evidence
+expected telemetry or mode effects
+recovery intent
+safing-oriented target mode assumption
+```
+
+These fields exist to support validation, linting and generated documentation.
+
+---
+
+## What the Model Must Not Describe
+
+A commandability/autonomy contract must not describe:
+
+```text
+real command authentication
+real command authorization
+operator accounts
+user roles
+cryptographic keys
+encryption
+live uplink
+live command routing
+real command queue
+operator console
+mission control system
+flight autonomy runtime
+onboard scheduler
+onboard command dispatcher
+real FDIR implementation
+real safing logic
+Yamcs/OpenC3 runtime services
+runtime skeleton generation
+ground export artifacts
+```
+
+Those are intentionally outside the v0.5.0 scope.
+
+---
+
+## YAML Shape
+
+Commandability and autonomy assumptions are expected to be defined in the optional file:
+
+```text
+mission/commandability.yaml
+```
+
+Proposed shape:
+
+```yaml
+commandability:
+  sources:
+    - id: ground_operator
+      type: ground
+      requires_contact: true
+      contact_profile: primary_ground_contact
+      description: Abstract ground-originated command source.
+
+    - id: onboard_autonomy
+      type: autonomous
+      requires_contact: false
+      description: Abstract onboard autonomous command source.
+
+  rules:
+    - id: payload_start_ground_rule
+      command: payload.start_acquisition
+      sources:
+        - ground_operator
+      allowed_modes:
+        - NOMINAL
+      confirmation: required
+      description: Payload acquisition may be commanded from ground in nominal mode.
+
+  autonomous_actions:
+    - id: stop_payload_on_battery_warning
+      trigger:
+        fault: eps.battery_warning
+      dispatches:
+        command: payload.stop_acquisition
+        source: onboard_autonomy
+      expected_events:
+        - payload.acquisition_stopped
+      description: Contract-level autonomous recovery assumption for battery warning.
+
+  recovery_intents:
+    - id: payload_battery_warning_recovery
+      fault: eps.battery_warning
+      target_mode: DEGRADED
+      commands:
+        - payload.stop_acquisition
+      description: Declared recovery intent for payload activity during battery warning.
+```
+
+This shape is intentionally minimal.
+
+OrbitFabric is still pre-1.0 and the schema may evolve before stabilization.
+
+---
+
+## Command Sources
+
+A command source describes an abstract source class for command dispatch intent.
+
+Examples:
+
+```text
+ground_operator
+onboard_autonomy
+scenario_driver
+maintenance_session
+```
+
+A command source may define:
+
+```text
+id
+type
+requires_contact
+optional contact profile reference
+description
+```
+
+A command source is not a user account.
+
+It is not an authorization role.
+
+It is not a transport endpoint.
+
+---
+
+## Commandability Rules
+
+A commandability rule describes when a command is intended to be usable under declared assumptions.
+
+It may reference:
+
+```text
+command
+sources
+allowed modes
+confirmation intent
+timeout expectation
+expected evidence
+```
+
+This should complement, not replace, the existing command definition.
+
+If the existing command declares `allowed_modes`, the commandability rule should be consistent with that declaration.
+
+---
+
+## Autonomous Action Contracts
+
+An autonomous action contract describes a declared assumption that an event, fault, telemetry condition or mode context may lead to an autonomous command dispatch or recovery-oriented action.
+
+It may reference:
+
+```text
+trigger event
+trigger fault
+trigger telemetry item
+dispatched command
+source
+expected events
+expected effects
+```
+
+This is not autonomy software.
+
+It is contract-level documentation and lintable intent.
+
+---
+
+## Recovery Intents
+
+A recovery intent describes a declared recovery or safing-oriented response.
+
+It may reference:
+
+```text
+fault
+event
+target mode
+commands
+expected evidence
+```
+
+A recovery intent is not FDIR implementation.
+
+It exists to make recovery assumptions explicit before future scenario evidence and runtime skeletons consume them.
+
+---
+
+## Initial Lint Direction
+
+Initial lint rules should focus on reference integrity and obvious consistency issues.
+
+Expected rule direction:
+
+```text
+ERROR: commandability rule references an unknown command.
+ERROR: commandability rule references an unknown mode.
+ERROR: commandability rule references an unknown source.
+WARNING: ground command source requires contact but no contact profile is referenced.
+ERROR: ground command source references an unknown contact profile.
+ERROR: autonomous action dispatches an unknown command.
+ERROR: autonomous action references an unknown source.
+ERROR: autonomous action trigger references an unknown event, fault or telemetry item.
+ERROR: recovery intent references an unknown command.
+ERROR: recovery intent references an unknown fault, event or mode.
+WARNING: high-risk command lacks explicit confirmation intent.
+WARNING: autonomous recovery command lacks expected events or effects.
+```
+
+Warnings should expose engineering ambiguity without pretending to solve command routing, scheduling or autonomy execution.
+
+---
+
+## Generated Documentation
+
+When commandability/autonomy contracts are present, OrbitFabric should generate Markdown documentation from the validated Mission Model.
+
+Expected generated output:
+
+```text
+generated/docs/commandability.md
+```
+
+The generated page should expose:
+
+```text
+command sources
+commandability rules
+autonomous action assumptions
+recovery intents
+referenced commands
+referenced modes
+referenced events, faults and telemetry
+```
+
+Generated documentation must state that these are contract assumptions, not runtime behavior.
+
+---
+
+## Current Boundary
+
+The v0.5.0 model must remain narrow.
+
+It should strengthen the Mission Data Chain without introducing command runtime or autonomy runtime behavior.
+
+The correct v0.5.0 outcome is:
+
+```text
+Command Definition
+        -> Commandability Contract
+        -> Autonomy/Recovery Contract Assumption
+        -> Lintable Consistency
+        -> Generated Documentation
+```
+
+The incorrect v0.5.0 outcome is:
+
+```text
+command uplink runtime
+operator console
+scheduler
+command dispatcher
+autonomy runtime
+real FDIR system
+```
+
+That boundary is strict.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Payload Contract Model: reference/payload-contract-model.md
       - Data Product Contract Model: reference/data-product-contract-model.md
       - Contact and Downlink Contract Model: reference/contact-downlink-contract-model.md
+      - Commandability and Autonomy Contract Model: reference/commandability-contract-model.md
   - Releases:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
@@ -44,6 +45,7 @@ nav:
       - ADR-0007 Mission Data Chain Before Runtime: adr/ADR-0007-mission-data-chain-before-runtime.md
       - ADR-0008 Data Product and Storage Contracts: adr/ADR-0008-data-product-and-storage-contracts.md
       - ADR-0009 Contact Windows and Downlink Flow Contracts: adr/ADR-0009-contact-windows-and-downlink-flow-contracts.md
+      - ADR-0010 Commandability and Autonomy Contracts: adr/ADR-0010-commandability-and-autonomy-contracts.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

This PR starts the `v0.5 — Commandability and Autonomy Contracts` milestone with a documentation-first scope definition.

It adds:

- `ADR-0010 — Commandability and Autonomy Contracts`
- initial `Commandability and Autonomy Contract Model` reference documentation
- MkDocs navigation entries for the new ADR and reference page

## Architectural position

The selected first-slice model entry point is:

```text
mission/commandability.yaml
```

The scope remains declarative and contract-level only.

This PR explicitly keeps v0.5 away from:

- real command authentication or authorization
- live uplink
- command queues
- operator consoles
- onboard schedulers
- onboard command dispatchers
- flight autonomy runtime
- real FDIR or safing logic
- runtime skeleton generation
- ground export generation

## Non-code PR

This PR intentionally does not add:

- model classes
- loader support
- lint rules
- tests
- generated docs implementation
- demo mission changes

Those belong to later PRs.

## Validation

No local test execution was performed through this GitHub connector.

Expected validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```
