### PR TITLE
model: add optional commandability contract domain

### DIFF
--- a/src/orbitfabric/model/loader.py
+++ b/src/orbitfabric/model/loader.py
@@ -26,6 +26,7 @@ OPTIONAL_FILES: dict[str, tuple[str, ...]] = {
     "payloads.yaml": ("payloads",),
     "data_products.yaml": ("data_products",),
     "contacts.yaml": ("contacts",),
+    "commandability.yaml": ("commandability",),
 }
 
 
@@ -291,6 +292,34 @@ class MissionModelLoader:
                 domain="downlink_flows",
                 file="contacts.yaml",
                 values=[item.id for item in model.contacts.downlink_flows],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="command_sources",
+                file="commandability.yaml",
+                values=[item.id for item in model.commandability.sources],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="commandability_rules",
+                file="commandability.yaml",
+                values=[item.id for item in model.commandability.rules],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="autonomous_actions",
+                file="commandability.yaml",
+                values=[item.id for item in model.commandability.autonomous_actions],
+            )
+        )
+        diagnostics.extend(
+            self._duplicates(
+                domain="recovery_intents",
+                file="commandability.yaml",
+                values=[item.id for item in model.commandability.recovery_intents],
             )
         )
         diagnostics.extend(

--- a/src/orbitfabric/model/mission.py
+++ b/src/orbitfabric/model/mission.py
@@ -54,6 +54,8 @@ DownlinkFlowQueuePolicy = Literal[
     "manual_selection",
     "critical_first",
 ]
+CommandSourceType = Literal["ground", "onboard", "autonomous"]
+CommandConfirmationIntent = Literal["none", "hinted", "required"]
 
 
 class StrictModel(BaseModel):
@@ -282,6 +284,65 @@ class ContactContracts(StrictModel):
     downlink_flows: list[DownlinkFlowContract] = Field(default_factory=list)
 
 
+class CommandSource(StrictModel):
+    id: str
+    type: CommandSourceType
+    requires_contact: bool = False
+    contact_profile: str | None = None
+    description: str | None = None
+
+
+class CommandabilityRule(StrictModel):
+    id: str
+    command: str
+    sources: list[str] = Field(default_factory=list)
+    allowed_modes: list[str] = Field(default_factory=list)
+    confirmation: CommandConfirmationIntent | None = None
+    timeout_ms: int | None = Field(default=None, gt=0)
+    expected_events: list[str] = Field(default_factory=list)
+    expected_effects: dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+
+
+class AutonomousActionTrigger(StrictModel):
+    event: str | None = None
+    fault: str | None = None
+    telemetry: str | None = None
+    mode: str | None = None
+
+
+class AutonomousActionDispatch(StrictModel):
+    command: str
+    source: str
+
+
+class AutonomousActionContract(StrictModel):
+    id: str
+    trigger: AutonomousActionTrigger
+    dispatches: AutonomousActionDispatch
+    expected_events: list[str] = Field(default_factory=list)
+    expected_effects: dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+
+
+class RecoveryIntent(StrictModel):
+    id: str
+    fault: str | None = None
+    event: str | None = None
+    target_mode: str | None = None
+    commands: list[str] = Field(default_factory=list)
+    expected_events: list[str] = Field(default_factory=list)
+    expected_effects: dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+
+
+class CommandabilityContracts(StrictModel):
+    sources: list[CommandSource] = Field(default_factory=list)
+    rules: list[CommandabilityRule] = Field(default_factory=list)
+    autonomous_actions: list[AutonomousActionContract] = Field(default_factory=list)
+    recovery_intents: list[RecoveryIntent] = Field(default_factory=list)
+
+
 class AllowedValues(StrictModel):
     allowed_values: list[str]
 
@@ -308,6 +369,7 @@ class MissionModel(StrictModel):
     payloads: list[PayloadContract] = Field(default_factory=list)
     data_products: list[DataProductContract] = Field(default_factory=list)
     contacts: ContactContracts = Field(default_factory=ContactContracts)
+    commandability: CommandabilityContracts = Field(default_factory=CommandabilityContracts)
 
     @property
     def subsystem_ids(self) -> set[str]:
@@ -356,6 +418,22 @@ class MissionModel(StrictModel):
     @property
     def downlink_flow_ids(self) -> set[str]:
         return {item.id for item in self.contacts.downlink_flows}
+
+    @property
+    def command_source_ids(self) -> set[str]:
+        return {item.id for item in self.commandability.sources}
+
+    @property
+    def commandability_rule_ids(self) -> set[str]:
+        return {item.id for item in self.commandability.rules}
+
+    @property
+    def autonomous_action_ids(self) -> set[str]:
+        return {item.id for item in self.commandability.autonomous_actions}
+
+    @property
+    def recovery_intent_ids(self) -> set[str]:
+        return {item.id for item in self.commandability.recovery_intents}
 
     @property
     def mode_ids(self) -> set[str]:

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -52,6 +52,50 @@ VALID_CONTACTS_YAML = """contacts:
       description: Synthetic science downlink flow used to validate contact contracts.
 """
 
+VALID_COMMANDABILITY_YAML = """commandability:
+  sources:
+    - id: ground_operator
+      type: ground
+      requires_contact: true
+      contact_profile: primary_ground_contact
+      description: Abstract ground-originated command source.
+    - id: onboard_autonomy
+      type: autonomous
+      requires_contact: false
+      description: Abstract onboard autonomous command source.
+  rules:
+    - id: payload_start_ground_rule
+      command: payload.start_acquisition
+      sources:
+        - ground_operator
+      allowed_modes:
+        - NOMINAL
+      confirmation: required
+      timeout_ms: 5000
+      expected_events:
+        - payload.acquisition_started
+      description: Payload acquisition may be commanded from ground in nominal mode.
+  autonomous_actions:
+    - id: stop_payload_on_battery_warning
+      trigger:
+        fault: eps.battery_warning
+      dispatches:
+        command: payload.stop_acquisition
+        source: onboard_autonomy
+      expected_events:
+        - payload.acquisition_stopped
+      description: Contract-level autonomous recovery assumption for battery warning.
+  recovery_intents:
+    - id: payload_battery_warning_recovery
+      fault: eps.battery_warning
+      target_mode: DEGRADED
+      commands:
+        - payload.stop_acquisition
+      expected_events:
+        - payload.acquisition_stopped
+      description: Declared recovery intent for payload activity during battery warning.
+"""
+
 
 def copy_demo_mission(tmp_path: Path) -> Path:
     mission_dir = tmp_path / "mission"
@@ -82,6 +126,10 @@ def test_load_demo_mission() -> None:
     assert len(model.contacts.link_profiles) == 1
     assert len(model.contacts.contact_windows) == 1
     assert len(model.contacts.downlink_flows) == 1
+    assert model.commandability.sources == []
+    assert model.commandability.rules == []
+    assert model.commandability.autonomous_actions == []
+    assert model.commandability.recovery_intents == []
 
 
 def test_load_demo_payload_contract() -> None:
@@ -379,6 +427,113 @@ def test_duplicate_contact_profile_id_fails(tmp_path: Path) -> None:
         and diagnostic.file == "contacts.yaml"
         and diagnostic.domain == "contact_profiles"
         and diagnostic.object_id == "primary_ground_contact"
+        for diagnostic in diagnostics
+    )
+
+
+def test_optional_commandability_file_can_be_absent(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        if source_file.name == "commandability.yaml":
+            continue
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert model.commandability.sources == []
+    assert model.commandability.rules == []
+    assert model.commandability.autonomous_actions == []
+    assert model.commandability.recovery_intents == []
+
+
+def test_load_valid_commandability_contracts(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "commandability.yaml").write_text(
+        VALID_COMMANDABILITY_YAML,
+        encoding="utf-8",
+    )
+
+    model = MissionModelLoader().load(mission_dir)
+
+    assert len(model.commandability.sources) == 2
+    assert len(model.commandability.rules) == 1
+    assert len(model.commandability.autonomous_actions) == 1
+    assert len(model.commandability.recovery_intents) == 1
+
+    source = model.commandability.sources[0]
+    rule = model.commandability.rules[0]
+    action = model.commandability.autonomous_actions[0]
+    recovery = model.commandability.recovery_intents[0]
+
+    assert source.id == "ground_operator"
+    assert source.type == "ground"
+    assert source.requires_contact is True
+    assert source.contact_profile == "primary_ground_contact"
+    assert rule.id == "payload_start_ground_rule"
+    assert rule.command == "payload.start_acquisition"
+    assert rule.sources == ["ground_operator"]
+    assert rule.allowed_modes == ["NOMINAL"]
+    assert rule.confirmation == "required"
+    assert rule.timeout_ms == 5000
+    assert rule.expected_events == ["payload.acquisition_started"]
+    assert action.id == "stop_payload_on_battery_warning"
+    assert action.trigger.fault == "eps.battery_warning"
+    assert action.dispatches.command == "payload.stop_acquisition"
+    assert action.dispatches.source == "onboard_autonomy"
+    assert action.expected_events == ["payload.acquisition_stopped"]
+    assert recovery.id == "payload_battery_warning_recovery"
+    assert recovery.fault == "eps.battery_warning"
+    assert recovery.target_mode == "DEGRADED"
+    assert recovery.commands == ["payload.stop_acquisition"]
+
+    assert model.command_source_ids == {"ground_operator", "onboard_autonomy"}
+    assert model.commandability_rule_ids == {"payload_start_ground_rule"}
+    assert model.autonomous_action_ids == {"stop_payload_on_battery_warning"}
+    assert model.recovery_intent_ids == {"payload_battery_warning_recovery"}
+
+
+def test_invalid_commandability_top_level_key_fails(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "commandability.yaml").write_text(
+        "command_policy: []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissionModelError) as exc_info:
+        MissionModelLoader().load(mission_dir)
+
+    codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
+    assert "OF-STR-001" in codes
+    assert "OF-STR-002" in codes
+
+
+def test_duplicate_command_source_id_fails(tmp_path: Path) -> None:
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "commandability.yaml").write_text(
+        "commandability:\n"
+        "  sources:\n"
+        "    - id: ground_operator\n"
+        "      type: ground\n"
+        "    - id: ground_operator\n"
+        "      type: onboard\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MissionModelError) as exc_info:
+        MissionModelLoader().load(mission_dir)
+
+    diagnostics = exc_info.value.diagnostics
+
+    assert any(
+        diagnostic.code == "OF-ID-001"
+        and diagnostic.file == "commandability.yaml"
+        and diagnostic.domain == "command_sources"
+        and diagnostic.object_id == "ground_operator"
         for diagnostic in diagnostics
     )
 


### PR DESCRIPTION
## Summary

This PR implements the minimal model/loader slice for `v0.5 — Commandability and Autonomy Contracts`.

It adds an optional Mission Model domain:

```text
mission/commandability.yaml
```

The domain is loaded under the top-level key:

```text
commandability
```

## Added model objects

- `CommandSource`
- `CommandabilityRule`
- `AutonomousActionTrigger`
- `AutonomousActionDispatch`
- `AutonomousActionContract`
- `RecoveryIntent`
- `CommandabilityContracts`

## Added structural support

- optional `commandability.yaml` loader support
- default empty `MissionModel.commandability`
- ID helper sets:
  - `command_source_ids`
  - `commandability_rule_ids`
  - `autonomous_action_ids`
  - `recovery_intent_ids`
- duplicate ID checks for:
  - command sources
  - commandability rules
  - autonomous actions
  - recovery intents

## Tests

Adds model loader tests for:

- optional file absence
- valid commandability model loading
- invalid top-level key
- duplicate command source IDs

## Scope boundary

This PR intentionally does not add:

- semantic lint rules
- generated docs
- demo mission updates
- scenario behavior
- runtime behavior
- command queues
- command auth/authz
- uplink handling
- autonomy runtime
- real FDIR/safing logic

Those belong to later PRs.

## Validation

No local test execution was performed through this GitHub connector.

Expected validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```
