### PR TITLE
lint: add commandability consistency rules

### DIFF
--- a/src/orbitfabric/lint/engine.py
+++ b/src/orbitfabric/lint/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from orbitfabric.lint.finding import LintReport
+from orbitfabric.lint.rules_commandability import check_commandability
 from orbitfabric.lint.rules_commands import check_commands
 from orbitfabric.lint.rules_contacts import check_contacts
 from orbitfabric.lint.rules_data_products import check_data_products
@@ -24,6 +25,7 @@ class LintEngine:
         findings.extend(check_payloads(model))
         findings.extend(check_data_products(model))
         findings.extend(check_contacts(model))
+        findings.extend(check_commandability(model))
         findings.extend(check_telemetry(model))
         findings.extend(check_commands(model))
         findings.extend(check_events(model))

--- a/src/orbitfabric/lint/rules_commandability.py
+++ b/src/orbitfabric/lint/rules_commandability.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from orbitfabric.lint.finding import LintFinding
 from orbitfabric.model.mission import (
     AutonomousActionContract,
-    CommandSource,
     CommandabilityRule,
+    CommandSource,
     MissionModel,
     RecoveryIntent,
 )
@@ -53,7 +53,10 @@ def _check_command_source(
             )
         )
 
-    if source.contact_profile is not None and source.contact_profile not in model.contact_profile_ids:
+    if (
+        source.contact_profile is not None
+        and source.contact_profile not in model.contact_profile_ids
+    ):
         findings.append(
             LintFinding(
                 severity="ERROR",
@@ -65,7 +68,10 @@ def _check_command_source(
                     "command source references unknown contact profile "
                     f"'{source.contact_profile}'"
                 ),
-                suggestion="Add the contact profile to contacts.yaml or fix source.contact_profile.",
+                suggestion=(
+                    "Add the contact profile to contacts.yaml or fix "
+                    "source.contact_profile."
+                ),
             )
         )
 
@@ -207,7 +213,10 @@ def _check_autonomous_action(
                 domain="autonomous_actions",
                 object_id=action.id,
                 message="autonomous action lacks expected events or effects",
-                suggestion="Add expected_events or expected_effects to make the assumption testable.",
+                suggestion=(
+                    "Add expected_events or expected_effects to make the "
+                    "assumption testable."
+                ),
             )
         )
 
@@ -278,12 +287,27 @@ def _check_recovery_intent(
         )
 
     if recovery_intent.fault is not None and recovery_intent.fault not in model.fault_ids:
-        findings.append(_unknown_recovery_reference(recovery_intent, "fault", recovery_intent.fault))
+        findings.append(
+            _unknown_recovery_reference(
+                recovery_intent,
+                "fault",
+                recovery_intent.fault,
+            )
+        )
 
     if recovery_intent.event is not None and recovery_intent.event not in model.event_ids:
-        findings.append(_unknown_recovery_reference(recovery_intent, "event", recovery_intent.event))
+        findings.append(
+            _unknown_recovery_reference(
+                recovery_intent,
+                "event",
+                recovery_intent.event,
+            )
+        )
 
-    if recovery_intent.target_mode is not None and recovery_intent.target_mode not in model.mode_ids:
+    if (
+        recovery_intent.target_mode is not None
+        and recovery_intent.target_mode not in model.mode_ids
+    ):
         findings.append(
             _unknown_recovery_reference(recovery_intent, "mode", recovery_intent.target_mode)
         )
@@ -327,7 +351,9 @@ def _check_high_risk_commands_have_confirmation_intent(
     model: MissionModel,
 ) -> list[LintFinding]:
     commandability_by_command = {
-        rule.command: rule for rule in model.commandability.rules if rule.command in model.command_ids
+        rule.command: rule
+        for rule in model.commandability.rules
+        if rule.command in model.command_ids
     }
     findings: list[LintFinding] = []
 

--- a/src/orbitfabric/lint/rules_commandability.py
+++ b/src/orbitfabric/lint/rules_commandability.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from orbitfabric.lint.finding import LintFinding
+from orbitfabric.model.mission import (
+    AutonomousActionContract,
+    CommandSource,
+    CommandabilityRule,
+    MissionModel,
+    RecoveryIntent,
+)
+
+HIGH_RISK_COMMAND_LEVELS = {"high", "critical"}
+
+
+def check_commandability(model: MissionModel) -> list[LintFinding]:
+    """Check Commandability and Autonomy Contract consistency."""
+    findings: list[LintFinding] = []
+
+    for source in model.commandability.sources:
+        findings.extend(_check_command_source(model, source))
+
+    for rule in model.commandability.rules:
+        findings.extend(_check_commandability_rule(model, rule))
+
+    for action in model.commandability.autonomous_actions:
+        findings.extend(_check_autonomous_action(model, action))
+
+    for recovery_intent in model.commandability.recovery_intents:
+        findings.extend(_check_recovery_intent(model, recovery_intent))
+
+    if _has_commandability_domain_content(model):
+        findings.extend(_check_high_risk_commands_have_confirmation_intent(model))
+
+    return findings
+
+
+def _check_command_source(
+    model: MissionModel,
+    source: CommandSource,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if source.type == "ground" and source.requires_contact and source.contact_profile is None:
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-CAB-004",
+                file="commandability.yaml",
+                domain="command_sources",
+                object_id=source.id,
+                message="ground command source requires contact but has no contact profile",
+                suggestion="Set contact_profile or set requires_contact to false.",
+            )
+        )
+
+    if source.contact_profile is not None and source.contact_profile not in model.contact_profile_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CAB-005",
+                file="commandability.yaml",
+                domain="command_sources",
+                object_id=source.id,
+                message=(
+                    "command source references unknown contact profile "
+                    f"'{source.contact_profile}'"
+                ),
+                suggestion="Add the contact profile to contacts.yaml or fix source.contact_profile.",
+            )
+        )
+
+    return findings
+
+
+def _check_commandability_rule(
+    model: MissionModel,
+    rule: CommandabilityRule,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if rule.command not in model.command_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CAB-001",
+                file="commandability.yaml",
+                domain="commandability_rules",
+                object_id=rule.id,
+                message=f"commandability rule references unknown command '{rule.command}'",
+                suggestion="Add the command to commands.yaml or fix rule.command.",
+            )
+        )
+
+    for mode_id in rule.allowed_modes:
+        if mode_id in model.mode_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CAB-002",
+                file="commandability.yaml",
+                domain="commandability_rules",
+                object_id=rule.id,
+                message=f"commandability rule references unknown mode '{mode_id}'",
+                suggestion="Add the mode to modes.yaml or fix rule.allowed_modes.",
+            )
+        )
+
+    for source_id in rule.sources:
+        if source_id in model.command_source_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CAB-003",
+                file="commandability.yaml",
+                domain="commandability_rules",
+                object_id=rule.id,
+                message=f"commandability rule references unknown source '{source_id}'",
+                suggestion="Add the source to commandability.sources or fix rule.sources.",
+            )
+        )
+
+    for event_id in rule.expected_events:
+        if event_id in model.event_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-CAB-006",
+                file="commandability.yaml",
+                domain="commandability_rules",
+                object_id=rule.id,
+                message=f"commandability rule references unknown expected event '{event_id}'",
+                suggestion="Add the event to events.yaml or fix rule.expected_events.",
+            )
+        )
+
+    return findings
+
+
+def _check_autonomous_action(
+    model: MissionModel,
+    action: AutonomousActionContract,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    if action.dispatches.command not in model.command_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-AUT-001",
+                file="commandability.yaml",
+                domain="autonomous_actions",
+                object_id=action.id,
+                message=(
+                    "autonomous action dispatches unknown command "
+                    f"'{action.dispatches.command}'"
+                ),
+                suggestion="Add the command to commands.yaml or fix dispatches.command.",
+            )
+        )
+
+    if action.dispatches.source not in model.command_source_ids:
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-AUT-002",
+                file="commandability.yaml",
+                domain="autonomous_actions",
+                object_id=action.id,
+                message=(
+                    "autonomous action references unknown source "
+                    f"'{action.dispatches.source}'"
+                ),
+                suggestion="Add the source to commandability.sources or fix dispatches.source.",
+            )
+        )
+
+    findings.extend(_check_autonomous_trigger_references(model, action))
+
+    for event_id in action.expected_events:
+        if event_id in model.event_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-AUT-004",
+                file="commandability.yaml",
+                domain="autonomous_actions",
+                object_id=action.id,
+                message=f"autonomous action references unknown expected event '{event_id}'",
+                suggestion="Add the event to events.yaml or fix expected_events.",
+            )
+        )
+
+    if not action.expected_events and not action.expected_effects:
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-AUT-005",
+                file="commandability.yaml",
+                domain="autonomous_actions",
+                object_id=action.id,
+                message="autonomous action lacks expected events or effects",
+                suggestion="Add expected_events or expected_effects to make the assumption testable.",
+            )
+        )
+
+    return findings
+
+
+def _check_autonomous_trigger_references(
+    model: MissionModel,
+    action: AutonomousActionContract,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+    trigger = action.trigger
+
+    if trigger.event is not None and trigger.event not in model.event_ids:
+        findings.append(_unknown_trigger_finding(action, "event", trigger.event))
+
+    if trigger.fault is not None and trigger.fault not in model.fault_ids:
+        findings.append(_unknown_trigger_finding(action, "fault", trigger.fault))
+
+    if trigger.telemetry is not None and trigger.telemetry not in model.telemetry_ids:
+        findings.append(_unknown_trigger_finding(action, "telemetry", trigger.telemetry))
+
+    if trigger.mode is not None and trigger.mode not in model.mode_ids:
+        findings.append(_unknown_trigger_finding(action, "mode", trigger.mode))
+
+    return findings
+
+
+def _unknown_trigger_finding(
+    action: AutonomousActionContract,
+    trigger_kind: str,
+    trigger_value: str,
+) -> LintFinding:
+    return LintFinding(
+        severity="ERROR",
+        code="OF-AUT-003",
+        file="commandability.yaml",
+        domain="autonomous_actions",
+        object_id=action.id,
+        message=(
+            "autonomous action trigger references unknown "
+            f"{trigger_kind} '{trigger_value}'"
+        ),
+        suggestion=f"Add the {trigger_kind} to the Mission Model or fix action.trigger.",
+    )
+
+
+def _check_recovery_intent(
+    model: MissionModel,
+    recovery_intent: RecoveryIntent,
+) -> list[LintFinding]:
+    findings: list[LintFinding] = []
+
+    for command_id in recovery_intent.commands:
+        if command_id in model.command_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-REC-001",
+                file="commandability.yaml",
+                domain="recovery_intents",
+                object_id=recovery_intent.id,
+                message=f"recovery intent references unknown command '{command_id}'",
+                suggestion="Add the command to commands.yaml or fix recovery_intent.commands.",
+            )
+        )
+
+    if recovery_intent.fault is not None and recovery_intent.fault not in model.fault_ids:
+        findings.append(_unknown_recovery_reference(recovery_intent, "fault", recovery_intent.fault))
+
+    if recovery_intent.event is not None and recovery_intent.event not in model.event_ids:
+        findings.append(_unknown_recovery_reference(recovery_intent, "event", recovery_intent.event))
+
+    if recovery_intent.target_mode is not None and recovery_intent.target_mode not in model.mode_ids:
+        findings.append(
+            _unknown_recovery_reference(recovery_intent, "mode", recovery_intent.target_mode)
+        )
+
+    for event_id in recovery_intent.expected_events:
+        if event_id in model.event_ids:
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="ERROR",
+                code="OF-REC-003",
+                file="commandability.yaml",
+                domain="recovery_intents",
+                object_id=recovery_intent.id,
+                message=f"recovery intent references unknown expected event '{event_id}'",
+                suggestion="Add the event to events.yaml or fix recovery_intent.expected_events.",
+            )
+        )
+
+    return findings
+
+
+def _unknown_recovery_reference(
+    recovery_intent: RecoveryIntent,
+    reference_kind: str,
+    reference_value: str,
+) -> LintFinding:
+    return LintFinding(
+        severity="ERROR",
+        code="OF-REC-002",
+        file="commandability.yaml",
+        domain="recovery_intents",
+        object_id=recovery_intent.id,
+        message=f"recovery intent references unknown {reference_kind} '{reference_value}'",
+        suggestion=f"Add the {reference_kind} to the Mission Model or fix recovery_intent.",
+    )
+
+
+def _check_high_risk_commands_have_confirmation_intent(
+    model: MissionModel,
+) -> list[LintFinding]:
+    commandability_by_command = {
+        rule.command: rule for rule in model.commandability.rules if rule.command in model.command_ids
+    }
+    findings: list[LintFinding] = []
+
+    for command in model.commands:
+        if command.risk not in HIGH_RISK_COMMAND_LEVELS:
+            continue
+
+        rule = commandability_by_command.get(command.id)
+        if rule is not None and rule.confirmation == "required":
+            continue
+
+        findings.append(
+            LintFinding(
+                severity="WARNING",
+                code="OF-CAB-007",
+                file="commandability.yaml",
+                domain="commandability_rules",
+                object_id=command.id,
+                message="high-risk command lacks explicit required confirmation intent",
+                suggestion=(
+                    "Add a commandability rule with confirmation: required, or lower "
+                    "the command risk if appropriate."
+                ),
+            )
+        )
+
+    return findings
+
+
+def _has_commandability_domain_content(model: MissionModel) -> bool:
+    return any(
+        (
+            model.commandability.sources,
+            model.commandability.rules,
+            model.commandability.autonomous_actions,
+            model.commandability.recovery_intents,
+        )
+    )

--- a/src/orbitfabric/lint/rules_commandability.py
+++ b/src/orbitfabric/lint/rules_commandability.py
@@ -9,7 +9,7 @@ from orbitfabric.model.mission import (
     RecoveryIntent,
 )
 
-HIGH_RISK_COMMAND_LEVELS = {"high", "critical"}
+RISKY_COMMAND_LEVELS = {"medium", "high", "critical"}
 
 
 def check_commandability(model: MissionModel) -> list[LintFinding]:
@@ -29,7 +29,7 @@ def check_commandability(model: MissionModel) -> list[LintFinding]:
         findings.extend(_check_recovery_intent(model, recovery_intent))
 
     if _has_commandability_domain_content(model):
-        findings.extend(_check_high_risk_commands_have_confirmation_intent(model))
+        findings.extend(_check_risky_commands_have_confirmation_intent(model))
 
     return findings
 
@@ -347,7 +347,7 @@ def _unknown_recovery_reference(
     )
 
 
-def _check_high_risk_commands_have_confirmation_intent(
+def _check_risky_commands_have_confirmation_intent(
     model: MissionModel,
 ) -> list[LintFinding]:
     commandability_by_command = {
@@ -358,7 +358,7 @@ def _check_high_risk_commands_have_confirmation_intent(
     findings: list[LintFinding] = []
 
     for command in model.commands:
-        if command.risk not in HIGH_RISK_COMMAND_LEVELS:
+        if command.risk not in RISKY_COMMAND_LEVELS:
             continue
 
         rule = commandability_by_command.get(command.id)
@@ -372,7 +372,7 @@ def _check_high_risk_commands_have_confirmation_intent(
                 file="commandability.yaml",
                 domain="commandability_rules",
                 object_id=command.id,
-                message="high-risk command lacks explicit required confirmation intent",
+                message="risky command lacks explicit required confirmation intent",
                 suggestion=(
                     "Add a commandability rule with confirmation: required, or lower "
                     "the command risk if appropriate."

--- a/tests/test_lint_commandability.py
+++ b/tests/test_lint_commandability.py
@@ -32,7 +32,7 @@ VALID_COMMANDABILITY_YAML = """commandability:
   autonomous_actions:
     - id: stop_payload_on_battery_warning
       trigger:
-        fault: eps.battery_warning
+        fault: eps.battery_low_fault
       dispatches:
         command: payload.stop_acquisition
         source: onboard_autonomy
@@ -41,7 +41,7 @@ VALID_COMMANDABILITY_YAML = """commandability:
       description: Contract-level autonomous recovery assumption for battery warning.
   recovery_intents:
     - id: payload_battery_warning_recovery
-      fault: eps.battery_warning
+      fault: eps.battery_low_fault
       target_mode: DEGRADED
       commands:
         - payload.stop_acquisition
@@ -155,7 +155,7 @@ def test_commandability_rule_unknown_expected_event_is_reported(tmp_path: Path) 
     assert "OF-CAB-006" in lint_codes(model)
 
 
-def test_high_risk_command_without_required_confirmation_is_warning(tmp_path: Path) -> None:
+def test_risky_command_without_required_confirmation_is_warning(tmp_path: Path) -> None:
     model = load_model_with_commandability(
         tmp_path,
         VALID_COMMANDABILITY_YAML.replace("confirmation: required", "confirmation: hinted"),
@@ -188,7 +188,7 @@ def test_autonomous_action_unknown_source_is_reported(tmp_path: Path) -> None:
 def test_autonomous_action_unknown_trigger_is_reported(tmp_path: Path) -> None:
     model = load_model_with_commandability(
         tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("fault: eps.battery_warning", "fault: eps.unknown_fault"),
+        VALID_COMMANDABILITY_YAML.replace("fault: eps.battery_low_fault", "fault: eps.unknown_fault"),
     )
 
     assert "OF-AUT-003" in lint_codes(model)
@@ -237,7 +237,7 @@ def test_recovery_intent_unknown_reference_is_reported(tmp_path: Path) -> None:
     model = load_model_with_commandability(
         tmp_path,
         VALID_COMMANDABILITY_YAML.replace(
-            "fault: eps.battery_warning",
+            "fault: eps.battery_low_fault",
             "fault: eps.unknown_recovery_fault",
             2,
         ),

--- a/tests/test_lint_commandability.py
+++ b/tests/test_lint_commandability.py
@@ -154,7 +154,10 @@ def test_autonomous_action_unknown_command_is_reported(tmp_path: Path) -> None:
 
 
 def test_autonomous_action_unknown_source_is_reported(tmp_path: Path) -> None:
-    mutated = VALID_COMMANDABILITY_YAML.replace("source: onboard_autonomy", "source: missing_source")
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "source: onboard_autonomy",
+        "source: missing_source",
+    )
 
     assert "OF-AUT-002" in lint_codes(mutated, tmp_path)
 

--- a/tests/test_lint_commandability.py
+++ b/tests/test_lint_commandability.py
@@ -70,7 +70,8 @@ def load_model_with_commandability(tmp_path: Path, commandability_yaml: str):
     return MissionModelLoader().load(mission_dir)
 
 
-def lint_codes(model) -> set[str]:
+def lint_codes(commandability_yaml: str, tmp_path: Path) -> set[str]:
+    model = load_model_with_commandability(tmp_path, commandability_yaml)
     return {finding.code for finding in LintEngine().run(model).findings}
 
 
@@ -88,172 +89,130 @@ def test_valid_commandability_contract_has_no_commandability_findings(tmp_path: 
 
 
 def test_commandability_rule_unknown_command_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "command: payload.start_acquisition",
-            "command: payload.unknown_command",
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "command: payload.start_acquisition",
+        "command: payload.unknown_command",
     )
 
-    assert "OF-CAB-001" in lint_codes(model)
+    assert "OF-CAB-001" in lint_codes(mutated, tmp_path)
 
 
 def test_commandability_rule_unknown_mode_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("- NOMINAL", "- UNKNOWN_MODE", 1),
-    )
+    mutated = VALID_COMMANDABILITY_YAML.replace("- NOMINAL", "- UNKNOWN_MODE", 1)
 
-    assert "OF-CAB-002" in lint_codes(model)
+    assert "OF-CAB-002" in lint_codes(mutated, tmp_path)
 
 
 def test_commandability_rule_unknown_source_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("- ground_operator", "- missing_source", 1),
-    )
+    mutated = VALID_COMMANDABILITY_YAML.replace("- ground_operator", "- missing_source", 1)
 
-    assert "OF-CAB-003" in lint_codes(model)
+    assert "OF-CAB-003" in lint_codes(mutated, tmp_path)
 
 
 def test_ground_source_requires_contact_without_profile_is_warning(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "      contact_profile: primary_ground_contact\n",
-            "",
-            1,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "      contact_profile: primary_ground_contact\n",
+        "",
+        1,
     )
 
-    assert "OF-CAB-004" in lint_codes(model)
+    assert "OF-CAB-004" in lint_codes(mutated, tmp_path)
 
 
 def test_ground_source_unknown_contact_profile_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "contact_profile: primary_ground_contact",
-            "contact_profile: missing_contact_profile",
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "contact_profile: primary_ground_contact",
+        "contact_profile: missing_contact_profile",
     )
 
-    assert "OF-CAB-005" in lint_codes(model)
+    assert "OF-CAB-005" in lint_codes(mutated, tmp_path)
 
 
 def test_commandability_rule_unknown_expected_event_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "- payload.acquisition_started",
-            "- payload.unknown_event",
-            1,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "- payload.acquisition_started",
+        "- payload.unknown_event",
+        1,
     )
 
-    assert "OF-CAB-006" in lint_codes(model)
+    assert "OF-CAB-006" in lint_codes(mutated, tmp_path)
 
 
 def test_risky_command_without_required_confirmation_is_warning(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("confirmation: required", "confirmation: hinted"),
-    )
+    mutated = VALID_COMMANDABILITY_YAML.replace("confirmation: required", "confirmation: hinted")
 
-    assert "OF-CAB-007" in lint_codes(model)
+    assert "OF-CAB-007" in lint_codes(mutated, tmp_path)
 
 
 def test_autonomous_action_unknown_command_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "command: payload.stop_acquisition",
-            "command: payload.unknown_stop",
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "command: payload.stop_acquisition",
+        "command: payload.unknown_stop",
     )
 
-    assert "OF-AUT-001" in lint_codes(model)
+    assert "OF-AUT-001" in lint_codes(mutated, tmp_path)
 
 
 def test_autonomous_action_unknown_source_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("source: onboard_autonomy", "source: missing_source"),
-    )
+    mutated = VALID_COMMANDABILITY_YAML.replace("source: onboard_autonomy", "source: missing_source")
 
-    assert "OF-AUT-002" in lint_codes(model)
+    assert "OF-AUT-002" in lint_codes(mutated, tmp_path)
 
 
 def test_autonomous_action_unknown_trigger_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace("fault: eps.battery_low_fault", "fault: eps.unknown_fault"),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "fault: eps.battery_low_fault",
+        "fault: eps.unknown_fault",
     )
 
-    assert "OF-AUT-003" in lint_codes(model)
+    assert "OF-AUT-003" in lint_codes(mutated, tmp_path)
 
 
 def test_autonomous_action_unknown_expected_event_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "- payload.acquisition_stopped",
-            "- payload.unknown_stop_event",
-            1,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "- payload.acquisition_stopped",
+        "- payload.unknown_stop_event",
+        1,
     )
 
-    assert "OF-AUT-004" in lint_codes(model)
+    assert "OF-AUT-004" in lint_codes(mutated, tmp_path)
 
 
 def test_autonomous_action_without_expected_evidence_is_warning(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "      expected_events:\n        - payload.acquisition_stopped\n",
-            "",
-            1,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "      expected_events:\n        - payload.acquisition_stopped\n",
+        "",
+        1,
     )
 
-    assert "OF-AUT-005" in lint_codes(model)
+    assert "OF-AUT-005" in lint_codes(mutated, tmp_path)
 
 
 def test_recovery_intent_unknown_command_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "- payload.stop_acquisition",
-            "- payload.unknown_recovery_command",
-            2,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "- payload.stop_acquisition",
+        "- payload.unknown_recovery_command",
+        2,
     )
 
-    assert "OF-REC-001" in lint_codes(model)
+    assert "OF-REC-001" in lint_codes(mutated, tmp_path)
 
 
 def test_recovery_intent_unknown_reference_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "fault: eps.battery_low_fault",
-            "fault: eps.unknown_recovery_fault",
-            2,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "fault: eps.battery_low_fault",
+        "fault: eps.unknown_recovery_fault",
+        2,
     )
 
-    assert "OF-REC-002" in lint_codes(model)
+    assert "OF-REC-002" in lint_codes(mutated, tmp_path)
 
 
 def test_recovery_intent_unknown_expected_event_is_reported(tmp_path: Path) -> None:
-    model = load_model_with_commandability(
-        tmp_path,
-        VALID_COMMANDABILITY_YAML.replace(
-            "- payload.acquisition_stopped",
-            "- payload.unknown_recovery_event",
-            2,
-        ),
+    mutated = VALID_COMMANDABILITY_YAML.replace(
+        "- payload.acquisition_stopped",
+        "- payload.unknown_recovery_event",
+        2,
     )
 
-    assert "OF-REC-003" in lint_codes(model)
+    assert "OF-REC-003" in lint_codes(mutated, tmp_path)

--- a/tests/test_lint_commandability.py
+++ b/tests/test_lint_commandability.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.lint.engine import LintEngine
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+VALID_COMMANDABILITY_YAML = """commandability:
+  sources:
+    - id: ground_operator
+      type: ground
+      requires_contact: true
+      contact_profile: primary_ground_contact
+      description: Abstract ground-originated command source.
+    - id: onboard_autonomy
+      type: autonomous
+      requires_contact: false
+      description: Abstract onboard autonomous command source.
+  rules:
+    - id: payload_start_ground_rule
+      command: payload.start_acquisition
+      sources:
+        - ground_operator
+      allowed_modes:
+        - NOMINAL
+      confirmation: required
+      expected_events:
+        - payload.acquisition_started
+      description: Payload acquisition may be commanded from ground in nominal mode.
+  autonomous_actions:
+    - id: stop_payload_on_battery_warning
+      trigger:
+        fault: eps.battery_warning
+      dispatches:
+        command: payload.stop_acquisition
+        source: onboard_autonomy
+      expected_events:
+        - payload.acquisition_stopped
+      description: Contract-level autonomous recovery assumption for battery warning.
+  recovery_intents:
+    - id: payload_battery_warning_recovery
+      fault: eps.battery_warning
+      target_mode: DEGRADED
+      commands:
+        - payload.stop_acquisition
+      expected_events:
+        - payload.acquisition_stopped
+      description: Declared recovery intent for payload activity during battery warning.
+"""
+
+
+def copy_demo_mission(tmp_path: Path) -> Path:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    return mission_dir
+
+
+def load_model_with_commandability(tmp_path: Path, commandability_yaml: str):
+    mission_dir = copy_demo_mission(tmp_path)
+    (mission_dir / "commandability.yaml").write_text(commandability_yaml, encoding="utf-8")
+    return MissionModelLoader().load(mission_dir)
+
+
+def lint_codes(model) -> set[str]:
+    return {finding.code for finding in LintEngine().run(model).findings}
+
+
+def test_valid_commandability_contract_has_no_commandability_findings(tmp_path: Path) -> None:
+    model = load_model_with_commandability(tmp_path, VALID_COMMANDABILITY_YAML)
+    report = LintEngine().run(model)
+
+    commandability_codes = {
+        finding.code
+        for finding in report.findings
+        if finding.file == "commandability.yaml"
+    }
+
+    assert commandability_codes == set()
+
+
+def test_commandability_rule_unknown_command_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "command: payload.start_acquisition",
+            "command: payload.unknown_command",
+        ),
+    )
+
+    assert "OF-CAB-001" in lint_codes(model)
+
+
+def test_commandability_rule_unknown_mode_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace("- NOMINAL", "- UNKNOWN_MODE", 1),
+    )
+
+    assert "OF-CAB-002" in lint_codes(model)
+
+
+def test_commandability_rule_unknown_source_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace("- ground_operator", "- missing_source", 1),
+    )
+
+    assert "OF-CAB-003" in lint_codes(model)
+
+
+def test_ground_source_requires_contact_without_profile_is_warning(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "      contact_profile: primary_ground_contact\n",
+            "",
+            1,
+        ),
+    )
+
+    assert "OF-CAB-004" in lint_codes(model)
+
+
+def test_ground_source_unknown_contact_profile_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "contact_profile: primary_ground_contact",
+            "contact_profile: missing_contact_profile",
+        ),
+    )
+
+    assert "OF-CAB-005" in lint_codes(model)
+
+
+def test_commandability_rule_unknown_expected_event_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "- payload.acquisition_started",
+            "- payload.unknown_event",
+            1,
+        ),
+    )
+
+    assert "OF-CAB-006" in lint_codes(model)
+
+
+def test_high_risk_command_without_required_confirmation_is_warning(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace("confirmation: required", "confirmation: hinted"),
+    )
+
+    assert "OF-CAB-007" in lint_codes(model)
+
+
+def test_autonomous_action_unknown_command_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "command: payload.stop_acquisition",
+            "command: payload.unknown_stop",
+        ),
+    )
+
+    assert "OF-AUT-001" in lint_codes(model)
+
+
+def test_autonomous_action_unknown_source_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace("source: onboard_autonomy", "source: missing_source"),
+    )
+
+    assert "OF-AUT-002" in lint_codes(model)
+
+
+def test_autonomous_action_unknown_trigger_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace("fault: eps.battery_warning", "fault: eps.unknown_fault"),
+    )
+
+    assert "OF-AUT-003" in lint_codes(model)
+
+
+def test_autonomous_action_unknown_expected_event_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "- payload.acquisition_stopped",
+            "- payload.unknown_stop_event",
+            1,
+        ),
+    )
+
+    assert "OF-AUT-004" in lint_codes(model)
+
+
+def test_autonomous_action_without_expected_evidence_is_warning(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "      expected_events:\n        - payload.acquisition_stopped\n",
+            "",
+            1,
+        ),
+    )
+
+    assert "OF-AUT-005" in lint_codes(model)
+
+
+def test_recovery_intent_unknown_command_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "- payload.stop_acquisition",
+            "- payload.unknown_recovery_command",
+            2,
+        ),
+    )
+
+    assert "OF-REC-001" in lint_codes(model)
+
+
+def test_recovery_intent_unknown_reference_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "fault: eps.battery_warning",
+            "fault: eps.unknown_recovery_fault",
+            2,
+        ),
+    )
+
+    assert "OF-REC-002" in lint_codes(model)
+
+
+def test_recovery_intent_unknown_expected_event_is_reported(tmp_path: Path) -> None:
+    model = load_model_with_commandability(
+        tmp_path,
+        VALID_COMMANDABILITY_YAML.replace(
+            "- payload.acquisition_stopped",
+            "- payload.unknown_recovery_event",
+            2,
+        ),
+    )
+
+    assert "OF-REC-003" in lint_codes(model)


### PR DESCRIPTION
## Summary

This PR adds the first semantic lint slice for `v0.5 — Commandability and Autonomy Contracts`.

It introduces a dedicated lint rule family for contract-level commandability assumptions:

- `OF-CAB-*` — commandability rules and command sources
- `OF-AUT-*` — autonomous action assumptions
- `OF-REC-*` — recovery intent assumptions

## Added

- new `src/orbitfabric/lint/rules_commandability.py`
- lint engine integration
- dedicated commandability lint tests

## Implemented checks

Commandability:

- `OF-CAB-001` commandability rule references unknown command
- `OF-CAB-002` commandability rule references unknown mode
- `OF-CAB-003` commandability rule references unknown source
- `OF-CAB-004` ground source requires contact but has no contact profile
- `OF-CAB-005` command source references unknown contact profile
- `OF-CAB-006` commandability rule references unknown expected event
- `OF-CAB-007` high-risk command lacks explicit required confirmation intent

Autonomy:

- `OF-AUT-001` autonomous action dispatches unknown command
- `OF-AUT-002` autonomous action references unknown source
- `OF-AUT-003` autonomous action trigger references unknown event/fault/telemetry/mode
- `OF-AUT-004` autonomous action references unknown expected event
- `OF-AUT-005` autonomous action lacks expected events or effects

Recovery:

- `OF-REC-001` recovery intent references unknown command
- `OF-REC-002` recovery intent references unknown fault/event/mode
- `OF-REC-003` recovery intent references unknown expected event

## Scope boundary

This PR intentionally does not add:

- generated commandability documentation
- demo mission `commandability.yaml`
- scenario behavior
- command runtime behavior
- command queues
- command authentication/authorization
- live uplink
- onboard scheduler
- autonomy runtime
- real FDIR or safing logic

Those belong to later milestones or later PRs.

## Validation

No local test execution was performed through this GitHub connector.

Expected validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```
