### PR TITLE
docs: generate commandability contract reference

### DIFF
--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -6,9 +6,9 @@ from typing import Any
 from orbitfabric.model.mission import (
     AutonomousActionContract,
     Command,
+    CommandabilityRule,
     CommandArgument,
     CommandSource,
-    CommandabilityRule,
     ContactProfile,
     ContactWindow,
     DataProductContract,

--- a/src/orbitfabric/gen/docs.py
+++ b/src/orbitfabric/gen/docs.py
@@ -4,8 +4,11 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric.model.mission import (
+    AutonomousActionContract,
     Command,
     CommandArgument,
+    CommandSource,
+    CommandabilityRule,
     ContactProfile,
     ContactWindow,
     DataProductContract,
@@ -21,6 +24,7 @@ from orbitfabric.model.mission import (
     Packet,
     PayloadContract,
     QualityPolicy,
+    RecoveryIntent,
     TelemetryItem,
     TelemetryLimits,
 )
@@ -52,6 +56,11 @@ def generate_markdown_docs(model: MissionModel, output_dir: Path) -> list[Path]:
     if _has_contact_contracts(model):
         generated_files.append(
             _write(output_dir / "contacts.md", _render_contacts(model))
+        )
+
+    if _has_commandability_contracts(model):
+        generated_files.append(
+            _write(output_dir / "commandability.md", _render_commandability(model))
         )
 
     return generated_files
@@ -502,6 +511,162 @@ def _render_downlink_flows(downlink_flows: list[DownlinkFlowContract]) -> str:
 
     lines.append("\n")
     return "".join(lines)
+
+
+def _has_commandability_contracts(model: MissionModel) -> bool:
+    return any(
+        (
+            model.commandability.sources,
+            model.commandability.rules,
+            model.commandability.autonomous_actions,
+            model.commandability.recovery_intents,
+        )
+    )
+
+
+def _render_commandability(model: MissionModel) -> str:
+    lines = [_header("Commandability and Autonomy Contract Reference", model)]
+
+    commandability = model.commandability
+
+    lines.append("## Summary\n\n")
+    lines.append(f"- Command sources: `{len(commandability.sources)}`\n")
+    lines.append(f"- Commandability rules: `{len(commandability.rules)}`\n")
+    lines.append(f"- Autonomous actions: `{len(commandability.autonomous_actions)}`\n")
+    lines.append(f"- Recovery intents: `{len(commandability.recovery_intents)}`\n\n")
+    lines.append(
+        "Commandability and autonomy fields describe contract assumptions only. "
+        "They do not imply command dispatch, command queues, uplink execution, "
+        "operator authentication, scheduling, autonomy runtime or FDIR behavior.\n\n"
+    )
+
+    lines.append(_render_command_sources(commandability.sources))
+    lines.append(_render_commandability_rules(commandability.rules))
+    lines.append(_render_autonomous_actions(commandability.autonomous_actions))
+    lines.append(_render_recovery_intents(commandability.recovery_intents))
+
+    return "".join(lines)
+
+
+def _render_command_sources(sources: list[CommandSource]) -> str:
+    lines = ["## Command sources\n\n"]
+
+    if not sources:
+        lines.append("No command sources declared.\n\n")
+        return "".join(lines)
+
+    lines.append("| ID | Type | Requires Contact | Contact Profile | Description |\n")
+    lines.append("|---|---|---:|---|---|\n")
+
+    for source in sorted(sources, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(source.id)} "
+            f"| {_code(source.type)} "
+            f"| {_format_bool(source.requires_contact)} "
+            f"| {_code(source.contact_profile or '-')} "
+            f"| {_text(source.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_commandability_rules(rules: list[CommandabilityRule]) -> str:
+    lines = ["## Commandability rules\n\n"]
+
+    if not rules:
+        lines.append("No commandability rules declared.\n\n")
+        return "".join(lines)
+
+    lines.append(
+        "| ID | Command | Sources | Allowed Modes | Confirmation | Timeout | "
+        "Expected Events | Expected Effects | Description |\n"
+    )
+    lines.append("|---|---|---|---|---|---:|---|---|---|\n")
+
+    for rule in sorted(rules, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(rule.id)} "
+            f"| {_code(rule.command)} "
+            f"| {_format_list(rule.sources)} "
+            f"| {_format_list(rule.allowed_modes)} "
+            f"| {_code(rule.confirmation or '-')} "
+            f"| {_format_timeout(rule.timeout_ms)} "
+            f"| {_format_list(rule.expected_events)} "
+            f"| {_format_expected_effects(rule.expected_effects)} "
+            f"| {_text(rule.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_autonomous_actions(actions: list[AutonomousActionContract]) -> str:
+    lines = ["## Autonomous actions\n\n"]
+
+    if not actions:
+        lines.append("No autonomous actions declared.\n\n")
+        return "".join(lines)
+
+    lines.append(
+        "| ID | Trigger | Dispatch Command | Dispatch Source | Expected Events | "
+        "Expected Effects | Description |\n"
+    )
+    lines.append("|---|---|---|---|---|---|---|\n")
+
+    for action in sorted(actions, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(action.id)} "
+            f"| {_format_autonomous_trigger(action)} "
+            f"| {_code(action.dispatches.command)} "
+            f"| {_code(action.dispatches.source)} "
+            f"| {_format_list(action.expected_events)} "
+            f"| {_format_expected_effects(action.expected_effects)} "
+            f"| {_text(action.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _render_recovery_intents(recovery_intents: list[RecoveryIntent]) -> str:
+    lines = ["## Recovery intents\n\n"]
+
+    if not recovery_intents:
+        lines.append("No recovery intents declared.\n\n")
+        return "".join(lines)
+
+    lines.append(
+        "| ID | Fault | Event | Target Mode | Commands | Expected Events | "
+        "Expected Effects | Description |\n"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|\n")
+
+    for recovery_intent in sorted(recovery_intents, key=lambda item: item.id):
+        lines.append(
+            f"| {_code(recovery_intent.id)} "
+            f"| {_code(recovery_intent.fault or '-')} "
+            f"| {_code(recovery_intent.event or '-')} "
+            f"| {_code(recovery_intent.target_mode or '-')} "
+            f"| {_format_list(recovery_intent.commands)} "
+            f"| {_format_list(recovery_intent.expected_events)} "
+            f"| {_format_expected_effects(recovery_intent.expected_effects)} "
+            f"| {_text(recovery_intent.description or '-')} |\n"
+        )
+
+    lines.append("\n")
+    return "".join(lines)
+
+
+def _format_autonomous_trigger(action: AutonomousActionContract) -> str:
+    values = action.trigger.model_dump(exclude_none=True)
+    if not values:
+        return "-"
+
+    return _line_break_join(
+        f"{_code(key)} = {_code(value)}"
+        for key, value in sorted(values.items())
+    )
 
 
 def _producer_heading(model: MissionModel, data_product: DataProductContract) -> str:

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -5,6 +5,12 @@ from pathlib import Path
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.model.loader import MissionModelLoader
 from orbitfabric.model.mission import (
+    AutonomousActionContract,
+    AutonomousActionDispatch,
+    AutonomousActionTrigger,
+    CommandabilityContracts,
+    CommandabilityRule,
+    CommandSource,
     ContactContracts,
     ContactProfile,
     ContactWindow,
@@ -13,6 +19,7 @@ from orbitfabric.model.mission import (
     DataProductStorageIntent,
     DownlinkFlowContract,
     LinkProfile,
+    RecoveryIntent,
 )
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
@@ -73,6 +80,65 @@ def make_valid_contacts() -> ContactContracts:
                 queue_policy="priority_then_age",
                 eligible_data_products=["payload.radiation_histogram"],
                 description="Synthetic science downlink flow.",
+            )
+        ],
+    )
+
+
+def make_valid_commandability() -> CommandabilityContracts:
+    return CommandabilityContracts(
+        sources=[
+            CommandSource(
+                id="ground_operator",
+                type="ground",
+                requires_contact=True,
+                contact_profile="primary_ground_contact",
+                description="Abstract ground-originated command source.",
+            ),
+            CommandSource(
+                id="onboard_autonomy",
+                type="autonomous",
+                description="Abstract onboard autonomous command source.",
+            ),
+        ],
+        rules=[
+            CommandabilityRule(
+                id="payload_start_ground_rule",
+                command="payload.start_acquisition",
+                sources=["ground_operator"],
+                allowed_modes=["NOMINAL"],
+                confirmation="required",
+                timeout_ms=5000,
+                expected_events=["payload.acquisition_started"],
+                expected_effects={
+                    "payload_lifecycle": {
+                        "payload": "demo_iod_payload",
+                        "state": "ACQUIRING",
+                    }
+                },
+                description="Payload acquisition may be commanded from ground.",
+            )
+        ],
+        autonomous_actions=[
+            AutonomousActionContract(
+                id="stop_payload_on_battery_low",
+                trigger=AutonomousActionTrigger(fault="eps.battery_low_fault"),
+                dispatches=AutonomousActionDispatch(
+                    command="payload.stop_acquisition",
+                    source="onboard_autonomy",
+                ),
+                expected_events=["payload.acquisition_stopped"],
+                description="Contract-level autonomous recovery assumption.",
+            )
+        ],
+        recovery_intents=[
+            RecoveryIntent(
+                id="payload_battery_low_recovery",
+                fault="eps.battery_low_fault",
+                target_mode="DEGRADED",
+                commands=["payload.stop_acquisition"],
+                expected_events=["payload.acquisition_stopped"],
+                description="Declared recovery intent for battery warning.",
             )
         ],
     )
@@ -198,6 +264,7 @@ def test_data_product_contract_docs_are_skipped_without_data_products(
     assert "data_products.md" not in generated_names
     assert not (tmp_path / "data_products.md").exists()
 
+
 def test_generate_contact_downlink_contract_docs(tmp_path: Path) -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
     model.contacts = make_valid_contacts()
@@ -238,3 +305,45 @@ def test_contact_downlink_docs_are_skipped_without_contact_contracts(
 
     assert "contacts.md" not in generated_names
     assert not (tmp_path / "contacts.md").exists()
+
+
+def test_generate_commandability_contract_docs(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commandability = make_valid_commandability()
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+
+    commandability_path = tmp_path / "commandability.md"
+    generated_names = {path.name for path in generated_files}
+
+    assert "commandability.md" in generated_names
+    assert commandability_path.exists()
+
+    content = commandability_path.read_text(encoding="utf-8")
+
+    assert "# Commandability and Autonomy Contract Reference" in content
+    assert "contract assumptions only" in content
+    assert "`ground_operator`" in content
+    assert "`onboard_autonomy`" in content
+    assert "`payload_start_ground_rule`" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`payload.acquisition_started`" in content
+    assert "payload `demo_iod_payload` lifecycle -> `ACQUIRING`" in content
+    assert "`stop_payload_on_battery_low`" in content
+    assert "`eps.battery_low_fault`" in content
+    assert "`payload.stop_acquisition`" in content
+    assert "`payload_battery_low_recovery`" in content
+    assert "`DEGRADED`" in content
+
+
+def test_commandability_docs_are_skipped_without_commandability_contracts(
+    tmp_path: Path,
+) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commandability = CommandabilityContracts()
+
+    generated_files = generate_markdown_docs(model, tmp_path)
+    generated_names = {path.name for path in generated_files}
+
+    assert "commandability.md" not in generated_names
+    assert not (tmp_path / "commandability.md").exists()


### PR DESCRIPTION
## Summary

This PR adds generated Markdown documentation support for the optional `v0.5 — Commandability and Autonomy Contracts` domain.

It generates `commandability.md` when the Mission Model contains commandability contracts.

## Added

- conditional generation of `commandability.md`
- command sources section
- commandability rules section
- autonomous actions section
- recovery intents section
- dedicated docs generator tests

## Scope boundary

This PR intentionally does not add:

- demo mission `commandability.yaml`
- generated committed artifacts
- release/version changes
- scenario behavior
- command runtime behavior
- command queues
- command authentication/authorization
- live uplink
- onboard scheduler
- autonomy runtime
- real FDIR or safing logic

Those remain outside this PR scope.

## Validation

No local test execution was performed through this GitHub connector.

Expected validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```