### PR TITLE
docs: align v0.5 commandability documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,25 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ## [Unreleased]
 
+### Added
+
+- Added the Commandability and Autonomy Contract Model as an optional mission model domain.
+- Added optional `mission/commandability.yaml` loading.
+- Added command sources.
+- Added commandability rules.
+- Added autonomous action contracts.
+- Added recovery intents.
+- Added semantic lint rules for commandability/autonomy consistency.
+- Added `OF-CAB-*`, `OF-AUT-*` and `OF-REC-*` lint rule families.
+- Added generated Commandability and Autonomy Contract documentation.
+- Added generated `commandability.md` documentation output.
+- Added one synthetic commandability/autonomy slice to the `demo-3u` mission.
+
 ### Changed
 
-- Next development focus: `v0.5 — Commandability and Autonomy Contracts`.
+- Extended the synthetic `demo-3u` mission with contract-level commandability and recovery assumptions.
+- Extended generated mission documentation to include commandability/autonomy references when commandability contracts are present.
+- Extended the Mission Data Chain from contact/downlink assumptions to commandability, autonomy and recovery assumptions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets, payload contracts, data products and operational scenarios once.
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts and operational scenarios once.
 Validate them, document them, and execute deterministic mission scenarios from the same source of truth.
 
 </div>
@@ -40,14 +40,17 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is currently at `v0.4.0 — Contact Windows and Downlink Flow Contracts`.
+OrbitFabric's current development baseline includes `v0.5 — Commandability and Autonomy Contracts`.
+
+The package/CLI version remains `0.4.0` until the next release tag.
 
 The current repository includes:
 
 - the `v0.2.1 — Payload Contract Model` vertical slice;
 - the `v0.2.3 — Mission Data Chain Roadmap Alignment` direction;
 - the `v0.3.0 — Data Product and Storage Contracts` vertical slice;
-- the `v0.4.0 — Contact Windows and Downlink Flow Contracts` vertical slice.
+- the `v0.4.0 — Contact Windows and Downlink Flow Contracts` vertical slice;
+- the `v0.5 — Commandability and Autonomy Contracts` development slice.
 
 The current vertical slice is functional:
 
@@ -55,17 +58,20 @@ The current vertical slice is functional:
 - optional `payloads.yaml` loading;
 - optional `data_products.yaml` loading;
 - optional `contacts.yaml` loading;
+- optional `commandability.yaml` loading;
 - structural validation;
 - semantic linting;
 - engineering lint rules;
 - payload contract lint rules;
 - data product contract lint rules;
 - contact/downlink contract lint rules;
+- commandability/autonomy contract lint rules;
 - JSON lint report generation;
 - generated Markdown documentation;
 - generated payload contract documentation;
 - generated data product contract documentation;
 - generated contact/downlink contract documentation;
+- generated commandability/autonomy contract documentation;
 - scenario YAML loading;
 - scenario reference validation;
 - deterministic scenario execution;
@@ -115,7 +121,8 @@ It models:
 - persistence and downlink policies;
 - optional Payload / IOD Payload Contracts;
 - optional Data Product and Storage Contracts;
-- optional Contact Windows and Downlink Flow Contracts.
+- optional Contact Windows and Downlink Flow Contracts;
+- optional Commandability and Autonomy Contracts.
 
 A payload contract describes mission-specific or IOD payload behavior as a declarative contract. It may reference:
 
@@ -150,7 +157,16 @@ A contact/downlink contract describes declared assumptions about how data produc
 - eligible data products;
 - generated contact/downlink documentation.
 
-Payload, Data Product and Contact/Downlink Contracts are part of the Mission Data Contract. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling or real downlink runtime behavior.
+A commandability/autonomy contract describes declared assumptions about how commands are intended to be used, constrained, dispatched by declared sources or referenced by autonomous recovery intent. It may define:
+
+- command sources;
+- commandability rules;
+- command confirmation intent;
+- autonomous action assumptions;
+- recovery intents;
+- generated commandability documentation.
+
+Payload, Data Product, Contact/Downlink and Commandability/Autonomy Contracts are part of the Mission Data Contract. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime or real FDIR behavior.
 
 From that model, OrbitFabric currently provides:
 
@@ -184,6 +200,13 @@ Optional Contact and Downlink Contract Model
         -> contact window validation
         -> downlink flow consistency validation
         -> contact/downlink documentation generation
+
+Optional Commandability and Autonomy Contract Model
+        -> command source validation
+        -> commandability rule validation
+        -> autonomous action validation
+        -> recovery intent validation
+        -> commandability/autonomy documentation generation
 ```
 
 ---
@@ -233,7 +256,8 @@ examples/demo-3u/
 │   ├── policies.yaml
 │   ├── payloads.yaml
 │   ├── data_products.yaml
-│   └── contacts.yaml
+│   ├── contacts.yaml
+│   └── commandability.yaml
 └── scenarios/
     ├── battery_low_during_payload.yaml
     └── nominal_payload_acquisition.yaml
@@ -269,6 +293,18 @@ primary_ground_contact
         eligible data product: payload.radiation_histogram
 ```
 
+The demo also includes one synthetic commandability/autonomy slice:
+
+```text
+ground_operator
+        commandability rule: payload_start_ground_rule
+        command: payload.start_acquisition
+
+onboard_autonomy
+        autonomous actions: stop payload on low/critical battery faults
+        recovery intents: DEGRADED and SAFE
+```
+
 This demonstrates the relationship:
 
 ```text
@@ -278,6 +314,7 @@ Payload Contract
         -> Downlink Intent
         -> Contact Window Assumption
         -> Downlink Flow Contract
+        -> Commandability and Autonomy Contract
 ```
 
 The demo contains:
@@ -511,7 +548,8 @@ generated/
 │   ├── packets.md
 │   ├── payloads.md
 │   ├── data_products.md
-│   └── contacts.md
+│   ├── contacts.md
+│   └── commandability.md
 ├── reports/
 │   ├── lint_report.json
 │   └── battery_low_during_payload_report.json
@@ -528,6 +566,7 @@ examples/demo-3u/mission/*.yaml
 examples/demo-3u/mission/payloads.yaml
 examples/demo-3u/mission/data_products.yaml
 examples/demo-3u/mission/contacts.yaml
+examples/demo-3u/mission/commandability.yaml
 examples/demo-3u/scenarios/*.yaml
 ```
 
@@ -583,6 +622,7 @@ Useful entry points:
 - `docs/reference/payload-contract-model.md`
 - `docs/reference/data-product-contract-model.md`
 - `docs/reference/contact-downlink-contract-model.md`
+- `docs/reference/commandability-contract-model.md`
 - `docs/adr/`
 
 Build the documentation site locally:

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -42,7 +42,8 @@ examples/demo-3u/
 │   ├── policies.yaml
 │   ├── payloads.yaml
 │   ├── data_products.yaml
-│   └── contacts.yaml
+│   ├── contacts.yaml
+│   └── commandability.yaml
 └── scenarios/
     ├── battery_low_during_payload.yaml
     └── nominal_payload_acquisition.yaml
@@ -196,6 +197,24 @@ payload.radiation_histogram
 
 This is contract intent only. It does not implement contact scheduling, RF behavior, onboard downlink queues or ground operations.
 
+### `commandability.yaml`
+
+Defines one synthetic Commandability and Autonomy Contract slice:
+
+```text
+ground_operator
+onboard_autonomy
+payload_start_ground_rule
+stop_payload_on_battery_low
+stop_payload_on_battery_critical
+payload_battery_low_recovery
+payload_battery_critical_recovery
+```
+
+The commandability contract makes explicit that `payload.start_acquisition` is ground-commandable in `NOMINAL`, while low/critical battery recovery assumptions may dispatch `payload.stop_acquisition` through `onboard_autonomy`.
+
+This is contract intent only. It does not implement live uplink, operator authentication, command queues, onboard schedulers, autonomy runtime or real FDIR behavior.
+
 ---
 
 ## 4. Scenarios
@@ -250,9 +269,9 @@ payload.start_acquisition
 → SCENARIO PASSED
 ```
 
-The data product and contact/downlink contracts are not executed by this scenario yet.
+The data product, contact/downlink and commandability/autonomy contracts are not executed as storage, downlink, uplink or autonomy runtime behavior by this scenario yet.
 
-They document declared mission-data and downlink-flow assumptions and prepare the model for future end-to-end mission data flow evidence.
+They document declared mission-data, downlink-flow, commandability and recovery assumptions and prepare the model for future end-to-end mission data flow evidence.
 
 ---
 
@@ -303,14 +322,17 @@ generated/docs/
 ├── packets.md
 ├── payloads.md
 ├── data_products.md
-└── contacts.md
+├── contacts.md
+└── commandability.md
 ```
 
 The generated data product documentation exposes storage and downlink intent as contract data.
 
 The generated contact/downlink documentation exposes contact profiles, link profiles, contact windows, declared capacity and downlink flow eligibility as contract data.
 
-Neither page describes runtime behavior.
+The generated commandability/autonomy documentation exposes command sources, commandability rules, autonomous actions and recovery intents as contract data.
+
+None of these pages describes runtime behavior.
 
 ---
 
@@ -330,7 +352,7 @@ During execution, OrbitFabric checks that:
 - auto-dispatched recovery commands are recorded;
 - scenario expectations pass.
 
-The simulator does not execute storage or downlink behavior in v0.4.0.
+The simulator does not execute storage, downlink, live uplink or autonomy runtime behavior in the current development preview.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -18,6 +18,7 @@ Mission Model YAML
   -> Payload Contract documentation
   -> Data Product Contract documentation
   -> Contact and Downlink Contract documentation
+  -> Commandability and Autonomy Contract documentation
   -> JSON reports
   -> simulation log
 ```
@@ -172,7 +173,8 @@ generated/docs/
 ├── packets.md
 ├── payloads.md
 ├── data_products.md
-└── contacts.md
+├── contacts.md
+└── commandability.md
 ```
 
 Generated mission documentation is derived from the validated Mission Model.
@@ -213,12 +215,12 @@ generated/logs/battery_low_during_payload.log
 The current demo proves that OrbitFabric can:
 
 - load a multi-file YAML Mission Model;
-- load optional `payloads.yaml`, `data_products.yaml` and `contacts.yaml` domains;
+- load optional `payloads.yaml`, `data_products.yaml`, `contacts.yaml` and `commandability.yaml` domains;
 - validate Mission Model structure;
 - run semantic lint rules;
-- validate payload, data product and contact/downlink references;
+- validate payload, data product, contact/downlink and commandability/autonomy references;
 - generate Markdown documentation;
-- generate payload, data product and contact/downlink documentation;
+- generate payload, data product, contact/downlink and commandability/autonomy documentation;
 - inspect a Mission Model summary;
 - validate a scenario without executing it;
 - load a scenario;
@@ -247,4 +249,4 @@ The current demo does not prove:
 - orbital, attitude, power or thermal dynamics;
 - qualification for operational spacecraft use.
 
-Those are intentionally outside the current v0.4.0 development preview scope.
+Those are intentionally outside the current development preview scope.

--- a/docs/adr/ADR-0010-commandability-and-autonomy-contracts.md
+++ b/docs/adr/ADR-0010-commandability-and-autonomy-contracts.md
@@ -1,6 +1,6 @@
 # ADR-0010 — Commandability and Autonomy Contracts
 
-Status: Proposed  
+Status: Accepted / Implemented  
 Date: 2026-05-07
 
 ---
@@ -166,24 +166,24 @@ commandability:
   autonomous_actions:
     - id: stop_payload_on_battery_warning
       trigger:
-        fault: eps.battery_warning
+        fault: eps.battery_low_fault
       dispatches:
         command: payload.stop_acquisition
         source: onboard_autonomy
       expected_events:
         - payload.acquisition_stopped
-      description: Contract-level autonomous recovery assumption for battery warning.
+      description: Contract-level autonomous recovery assumption for low battery conditions.
 
   recovery_intents:
     - id: payload_battery_warning_recovery
-      fault: eps.battery_warning
+      fault: eps.battery_low_fault
       target_mode: DEGRADED
       commands:
         - payload.stop_acquisition
-      description: Declared recovery intent for payload activity during battery warning.
+      description: Declared recovery intent for payload activity during low battery conditions.
 ```
 
-This shape is a proposed v0.5.0 contract shape.
+This shape is the implemented current v0.5 development contract shape.
 
 It is not a frozen v1.0 schema.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions and scenarios in a single Mission Data Contract.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts and scenarios in a single Mission Data Contract.
 
 From that contract, OrbitFabric validates consistency, generates documentation and executes host-side operational scenarios.
 
@@ -11,7 +11,7 @@ From that contract, OrbitFabric validates consistency, generates documentation a
 OrbitFabric is currently at:
 
 ```text
-v0.4.0 — Contact Windows and Downlink Flow Contracts
+v0.5 — Commandability and Autonomy Contracts
 ```
 
 The current public preview includes:
@@ -24,9 +24,11 @@ The current public preview includes:
 - optional Payload / IOD Payload Contracts;
 - optional Data Product and Storage Contracts;
 - optional Contact Windows and Downlink Flow Contracts;
+- optional Commandability and Autonomy Contracts;
 - generated payload documentation;
 - generated data product documentation;
 - generated contact/downlink documentation;
+- generated commandability/autonomy documentation;
 - a clean-room synthetic `demo-3u` mission.
 
 ## Core Idea
@@ -39,7 +41,8 @@ Mission Model
   -> payload contracts
   -> data product and storage contracts
   -> contact/downlink contracts
-  -> future commandability/autonomy contracts
+  -> commandability/autonomy contracts
+  -> future end-to-end mission data flow evidence
   -> future runtime and ground artifacts
 ```
 

--- a/docs/reference/commandability-contract-model.md
+++ b/docs/reference/commandability-contract-model.md
@@ -1,6 +1,6 @@
 # Commandability and Autonomy Contract Model
 
-Status: Proposed for OrbitFabric v0.5.0  
+Status: Implemented in the current v0.5 development baseline  
 Scope: Commandability and Autonomy Contract definition
 
 ---
@@ -151,7 +151,7 @@ Commandability and autonomy assumptions are expected to be defined in the option
 mission/commandability.yaml
 ```
 
-Proposed shape:
+Current shape:
 
 ```yaml
 commandability:
@@ -180,21 +180,21 @@ commandability:
   autonomous_actions:
     - id: stop_payload_on_battery_warning
       trigger:
-        fault: eps.battery_warning
+        fault: eps.battery_low_fault
       dispatches:
         command: payload.stop_acquisition
         source: onboard_autonomy
       expected_events:
         - payload.acquisition_stopped
-      description: Contract-level autonomous recovery assumption for battery warning.
+      description: Contract-level autonomous recovery assumption for low battery conditions.
 
   recovery_intents:
     - id: payload_battery_warning_recovery
-      fault: eps.battery_warning
+      fault: eps.battery_low_fault
       target_mode: DEGRADED
       commands:
         - payload.stop_acquisition
-      description: Declared recovery intent for payload activity during battery warning.
+      description: Declared recovery intent for payload activity during low battery conditions.
 ```
 
 This shape is intentionally minimal.
@@ -299,7 +299,7 @@ It exists to make recovery assumptions explicit before future scenario evidence 
 
 ## Initial Lint Direction
 
-Initial lint rules should focus on reference integrity and obvious consistency issues.
+Current lint rules focus on reference integrity and obvious consistency issues.
 
 Expected rule direction:
 
@@ -324,7 +324,7 @@ Warnings should expose engineering ambiguity without pretending to solve command
 
 ## Generated Documentation
 
-When commandability/autonomy contracts are present, OrbitFabric should generate Markdown documentation from the validated Mission Model.
+When commandability/autonomy contracts are present, OrbitFabric generates Markdown documentation from the validated Mission Model.
 
 Expected generated output:
 
@@ -350,7 +350,7 @@ Generated documentation must state that these are contract assumptions, not runt
 
 ## Current Boundary
 
-The v0.5.0 model must remain narrow.
+The v0.5 development model remains narrow.
 
 It should strengthen the Mission Data Chain without introducing command runtime or autonomy runtime behavior.
 

--- a/docs/reference/lint-rules-v0.1.md
+++ b/docs/reference/lint-rules-v0.1.md
@@ -5,7 +5,7 @@ This page documents the diagnostics and lint rules currently implemented by Orbi
 Current documented baseline:
 
 ```text
-v0.4.0 — Contact Windows and Downlink Flow Contracts
+v0.5 — Commandability and Autonomy Contracts
 ```
 
 OrbitFabric diagnostics are intentionally actionable. A diagnostic should tell the user:
@@ -88,6 +88,9 @@ The `suggestion` field is intentionally optional, but it should be provided when
 | `OF-DP-*` | Data Product Contract lint rules. |
 | `OF-CON-*` | Contact assumption rules. |
 | `OF-DL-*` | Downlink flow assumption rules. |
+| `OF-CAB-*` | Commandability rule diagnostics. |
+| `OF-AUT-*` | Autonomous action diagnostics. |
+| `OF-REC-*` | Recovery intent diagnostics. |
 | `OF-SCN-*` | Scenario loading and scenario reference diagnostics. |
 
 ---
@@ -123,6 +126,8 @@ Current optional Mission Model files:
 ```text
 payloads.yaml
 data_products.yaml
+contacts.yaml
+commandability.yaml
 ```
 
 ---
@@ -157,6 +162,14 @@ faults
 packets
 payloads
 data_products
+contact_profiles
+link_profiles
+contact_windows
+downlink_flows
+command_sources
+commandability_rules
+autonomous_actions
+recovery_intents
 ```
 
 ---
@@ -306,6 +319,44 @@ Data Product rules are contract-level rules. They do not validate real storage, 
 | `OF-DL-003` | `ERROR` | downlink_flows | Downlink flow references an unknown eligible data product. | Add the data product or fix `downlink_flow.eligible_data_products`. |
 | `OF-DL-004` | `WARNING` | data_products | High-priority data product has downlink intent but is not eligible in any downlink flow. | Add the data product to a downlink flow or revise its downlink intent. |
 | `OF-DL-005` | `WARNING` | downlink_flows | Estimated eligible data product volume may exceed declared contact capacity. | Increase capacity, reduce eligible volume or split the flow. |
+
+---
+
+## `OF-CAB-*` — Commandability rule diagnostics
+
+These rules validate optional Commandability and Autonomy Contracts.
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-CAB-001` | `ERROR` | commandability_rules | Commandability rule references an unknown command. | Add the command to `commands.yaml` or fix `rule.command`. |
+| `OF-CAB-002` | `ERROR` | commandability_rules | Commandability rule references an unknown mode. | Add the mode to `modes.yaml` or fix `rule.allowed_modes`. |
+| `OF-CAB-003` | `ERROR` | commandability_rules | Commandability rule references an unknown source. | Add the source to `commandability.sources` or fix `rule.sources`. |
+| `OF-CAB-004` | `WARNING` | command_sources | Ground command source requires contact but has no contact profile. | Set `contact_profile` or set `requires_contact` to false. |
+| `OF-CAB-005` | `ERROR` | command_sources | Command source references an unknown contact profile. | Add the contact profile to `contacts.yaml` or fix `source.contact_profile`. |
+| `OF-CAB-006` | `ERROR` | commandability_rules | Commandability rule references an unknown expected event. | Add the event to `events.yaml` or fix `rule.expected_events`. |
+| `OF-CAB-007` | `WARNING` | commandability_rules | Risky command lacks explicit required confirmation intent. | Add a commandability rule with `confirmation: required`, or lower the command risk if appropriate. |
+
+---
+
+## `OF-AUT-*` — Autonomous action diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-AUT-001` | `ERROR` | autonomous_actions | Autonomous action dispatches an unknown command. | Add the command to `commands.yaml` or fix `dispatches.command`. |
+| `OF-AUT-002` | `ERROR` | autonomous_actions | Autonomous action references an unknown source. | Add the source to `commandability.sources` or fix `dispatches.source`. |
+| `OF-AUT-003` | `ERROR` | autonomous_actions | Autonomous action trigger references an unknown event, fault, telemetry item or mode. | Add the referenced object to the Mission Model or fix `action.trigger`. |
+| `OF-AUT-004` | `ERROR` | autonomous_actions | Autonomous action references an unknown expected event. | Add the event to `events.yaml` or fix `expected_events`. |
+| `OF-AUT-005` | `WARNING` | autonomous_actions | Autonomous action lacks expected events or effects. | Add `expected_events` or `expected_effects` to make the assumption testable. |
+
+---
+
+## `OF-REC-*` — Recovery intent diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-REC-001` | `ERROR` | recovery_intents | Recovery intent references an unknown command. | Add the command to `commands.yaml` or fix `recovery_intent.commands`. |
+| `OF-REC-002` | `ERROR` | recovery_intents | Recovery intent references an unknown fault, event or mode. | Add the referenced object to the Mission Model or fix `recovery_intent`. |
+| `OF-REC-003` | `ERROR` | recovery_intents | Recovery intent references an unknown expected event. | Add the event to `events.yaml` or fix `recovery_intent.expected_events`. |
 
 ---
 

--- a/docs/reference/mission-model-v0.1.md
+++ b/docs/reference/mission-model-v0.1.md
@@ -4,7 +4,7 @@ Status: Draft
 Scope: OrbitFabric MVP v0.1
 Model version: 0.1.0
 
-This page documents the core v0.1 Mission Model surface. Optional extension domains added after v0.1, including Payload Contracts, Data Product Contracts and Contact/Downlink Contracts, are documented in their dedicated reference pages.
+This page documents the core v0.1 Mission Model surface. Optional extension domains added after v0.1, including Payload Contracts, Data Product Contracts, Contact/Downlink Contracts and Commandability/Autonomy Contracts, are documented in their dedicated reference pages.
 
 ---
 
@@ -80,13 +80,14 @@ examples/demo-3u/
 │   ├── policies.yaml
 │   ├── payloads.yaml
 │   ├── data_products.yaml
-│   └── contacts.yaml
+│   ├── contacts.yaml
+│   └── commandability.yaml
 └── scenarios/
     ├── battery_low_during_payload.yaml
     └── nominal_payload_acquisition.yaml
 ```
 
-Each YAML file must contain exactly one top-level domain key. The core v0.1 files remain required for the demo; `payloads.yaml`, `data_products.yaml` and `contacts.yaml` are optional extension domains described by later reference pages.
+Each YAML file must contain exactly one top-level domain key. The core v0.1 files remain required for the demo; `payloads.yaml`, `data_products.yaml`, `contacts.yaml` and `commandability.yaml` are optional extension domains described by later reference pages.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR aligns the public documentation with the current `v0.5 — Commandability and Autonomy Contracts` development baseline.

The implementation already includes the optional `commandability.yaml` domain, semantic lint rules, generated `commandability.md` documentation, and a demo mission commandability slice.

## Updated

- README current status and generated artifact list
- docs site home page
- Quickstart
- Demo Walkthrough
- Changelog Unreleased section
- Commandability reference status
- ADR-0010 status
- lint rule catalog for `OF-CAB-*`, `OF-AUT-*`, `OF-REC-*`
- Mission Model reference optional extension list

## Scope boundary

This PR intentionally does not add:

- release/version bump
- code changes
- new runtime behavior
- command queues
- live uplink
- operator authentication/authorization
- onboard scheduler
- autonomy runtime
- real FDIR or safing logic

The documentation continues to describe commandability/autonomy as contract-level assumptions only.

## Validation

Expected local validation:

```bash
ruff check .
pytest
orbitfabric lint examples/demo-3u/mission
orbitfabric gen docs examples/demo-3u/mission --output-dir generated/docs
mkdocs build --strict
```