### PR TITLE
release: prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ## [Unreleased]
 
+---
+
+## [v0.5.0] — Commandability and Autonomy Contracts
+
 ### Added
 
 - Added the Commandability and Autonomy Contract Model as an optional mission model domain.
@@ -27,6 +31,21 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 - Extended the synthetic `demo-3u` mission with contract-level commandability and recovery assumptions.
 - Extended generated mission documentation to include commandability/autonomy references when commandability contracts are present.
 - Extended the Mission Data Chain from contact/downlink assumptions to commandability, autonomy and recovery assumptions.
+
+### Boundaries
+
+The Commandability and Autonomy Contract slice intentionally does not introduce:
+
+- real command authentication;
+- real command authorization;
+- live uplink services;
+- operator consoles;
+- command queues;
+- onboard schedulers;
+- autonomy runtime;
+- real FDIR or safing behavior;
+- Yamcs/OpenC3 runtime services;
+- real spacecraft operations.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ ground integration
 
 ## Current Status
 
-OrbitFabric's current development baseline includes `v0.5 — Commandability and Autonomy Contracts`.
-
-The package/CLI version remains `0.4.0` until the next release tag.
+OrbitFabric is currently at `v0.5.0 — Commandability and Autonomy Contracts`.
 
 The current repository includes:
 
@@ -50,7 +48,7 @@ The current repository includes:
 - the `v0.2.3 — Mission Data Chain Roadmap Alignment` direction;
 - the `v0.3.0 — Data Product and Storage Contracts` vertical slice;
 - the `v0.4.0 — Contact Windows and Downlink Flow Contracts` vertical slice;
-- the `v0.5 — Commandability and Autonomy Contracts` development slice.
+- the `v0.5.0 — Commandability and Autonomy Contracts` vertical slice.
 
 The current vertical slice is functional:
 
@@ -406,7 +404,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.4.0
+orbitfabric 0.5.0
 ```
 
 ---
@@ -460,7 +458,8 @@ generated/docs/
 ├── packets.md
 ├── payloads.md
 ├── data_products.md
-└── contacts.md
+├── contacts.md
+└── commandability.md
 ```
 
 These files are generated from the validated Mission Model. Do not edit them manually.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # OrbitFabric — Architecture
 
-Version: 0.4.0
+Version: 0.5.0
 Status: Development preview
-Scope: Mission Data Contract architecture through Contact Windows and Downlink Flow Contracts
+Scope: Mission Data Contract architecture through Commandability and Autonomy Contracts
 
 ---
 
@@ -16,7 +16,7 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, documentation and scenario evidence from one source of truth.
+It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, documentation and scenario evidence from one source of truth.
 
 OrbitFabric is not designed as:
 
@@ -33,9 +33,9 @@ Its architectural role is:
 
 > define, validate, simulate and document the contract between mission design, onboard software, tests, documentation, simulation and future ground integration artifacts.
 
-The current architectural baseline is `v0.4.0 — Contact Windows and Downlink Flow Contracts`.
+The current architectural baseline is `v0.5.0 — Commandability and Autonomy Contracts`.
 
-The next architectural step is `v0.5 — Commandability and Autonomy Contracts`.
+The next architectural step is `v0.6 — End-to-End Mission Data Flow Evidence`.
 
 ---
 
@@ -69,7 +69,7 @@ Payload behavior
         -> Storage Intent
         -> Downlink Intent
         -> Contact Windows and Downlink Flow Contracts
-        -> future Commandability and Autonomy Contracts
+        -> Commandability and Autonomy Contracts
         -> future End-to-End Mission Data Flow Evidence
         -> future Runtime Skeletons
         -> future Ground Integration Artifacts
@@ -144,6 +144,7 @@ OrbitFabric
 │   ├── payload contracts
 │   ├── data product contracts
 │   ├── contact/downlink contracts
+│   ├── commandability/autonomy contracts
 │   └── scenarios
 │
 ├── Toolchain
@@ -167,6 +168,7 @@ OrbitFabric
 │   ├── payload contract rules
 │   ├── data product contract rules
 │   ├── contact/downlink contract rules
+│   ├── commandability/autonomy contract rules
 │   ├── findings
 │   └── JSON reports
 │
@@ -205,9 +207,9 @@ OrbitFabric
 
 ---
 
-## 4. Current Capability Boundary — v0.4.0
+## 4. Current Capability Boundary — v0.5.0
 
-OrbitFabric v0.4.0 includes:
+OrbitFabric v0.5.0 includes:
 
 ```text
 Mission Model YAML
@@ -215,12 +217,14 @@ canonical multi-file mission directory
 optional payloads.yaml domain
 optional data_products.yaml domain
 optional contacts.yaml domain
+optional commandability.yaml domain
 Pydantic typed validation
 structural validation
 semantic lint
 payload contract lint rules
 data product contract lint rules
 contact/downlink contract lint rules
+commandability/autonomy contract lint rules
 scenario loading
 scenario reference validation
 host-side deterministic scenario execution
@@ -229,13 +233,14 @@ generated Markdown docs
 generated payload documentation
 generated data product documentation
 generated contact/downlink documentation
+generated commandability/autonomy documentation
 JSON lint reports
 JSON scenario reports
 plain-text scenario logs
 synthetic demo mission
 ```
 
-OrbitFabric v0.4.0 excludes:
+OrbitFabric v0.5.0 excludes:
 
 ```text
 flight runtime
@@ -265,6 +270,14 @@ Basilisk bridge
 cFS/F Prime bridge
 formal verification
 security model
+real command authentication
+real command authorization
+live uplink services
+operator consoles
+command queues
+onboard schedulers
+flight autonomy runtime
+real FDIR or safing logic
 ```
 
 These are not accidental omissions.
@@ -324,6 +337,9 @@ Storage Intent and Downlink Intent
       │
       ▼
 Contact Windows and Downlink Flow Contracts
+      │
+      ▼
+Commandability and Autonomy Contracts
       │
       ▼
 Future End-to-End Mission Data Flow Evidence
@@ -418,6 +434,7 @@ Optional:
 payloads.yaml
 data_products.yaml
 contacts.yaml
+commandability.yaml
 ```
 
 ### 8.3 Current Typed Model Surface
@@ -438,7 +455,8 @@ MissionModel
 ├── policies
 ├── payloads
 ├── data_products
-└── contacts
+├── contacts
+└── commandability
 ```
 
 It also exposes ID helpers such as:
@@ -456,6 +474,10 @@ contact_profile_ids
 link_profile_ids
 contact_window_ids
 downlink_flow_ids
+command_source_ids
+commandability_rule_ids
+autonomous_action_ids
+recovery_intent_ids
 mode_ids
 ```
 
@@ -626,7 +648,63 @@ They describe contract assumptions only.
 
 ---
 
-## 12. Lint Layer
+## 12. Commandability and Autonomy Contract Architecture
+
+Commandability and Autonomy Contracts are optional Mission Model domains.
+
+They describe declared assumptions about command sources, command dispatch intent, autonomous actions and recovery intent.
+
+A commandability/autonomy contract may define:
+
+```text
+command source identity
+source type
+contact requirement
+linked contact profile
+commandability rule identity
+referenced command
+allowed command sources
+allowed modes
+confirmation intent
+timeout expectation
+expected events
+expected effects
+autonomous action trigger
+autonomous command dispatch intent
+recovery intent
+target recovery mode
+```
+
+Current demo example:
+
+```text
+ground_operator
+        -> payload.start_acquisition commandability rule
+
+onboard_autonomy
+        -> stop payload on low/critical battery faults
+        -> recovery intents toward DEGRADED and SAFE
+```
+
+Commandability and Autonomy Contracts do not describe:
+
+```text
+real command authentication
+real command authorization
+encryption
+live uplink services
+operator consoles
+command queues
+onboard schedulers
+flight autonomy runtime
+real FDIR or safing behavior
+```
+
+They describe contract assumptions only.
+
+---
+
+## 13. Lint Layer
 
 ### 12.1 Responsibility
 
@@ -665,6 +743,9 @@ OF-PAY-*   payload contract rules
 OF-DP-*    data product contract rules
 OF-CON-*   contact assumption rules
 OF-DL-*    downlink flow assumption rules
+OF-CAB-*   commandability rule diagnostics
+OF-AUT-*   autonomous action diagnostics
+OF-REC-*   recovery intent diagnostics
 OF-SCN-*   scenario rules
 ```
 
@@ -694,7 +775,7 @@ Documentation generation must not silently continue when lint errors exist.
 
 ---
 
-## 13. Simulation Layer
+## 14. Simulation Layer
 
 ### 13.1 Responsibility
 
@@ -756,13 +837,13 @@ payload lifecycle ACQUIRING -> READY
 scenario pass/fail result
 ```
 
-Data Product and Contact/Downlink Contracts are documented and linted in v0.4.0.
+Data Product, Contact/Downlink and Commandability/Autonomy Contracts are documented and linted in v0.5.0.
 
-They are not executed as storage/downlink runtime behavior yet.
+They are not executed as storage, downlink, uplink or autonomy runtime behavior yet.
 
 ---
 
-## 14. Generation Layer
+## 15. Generation Layer
 
 ### 14.1 Responsibility
 
@@ -780,6 +861,7 @@ generated/docs/packets.md
 generated/docs/payloads.md
 generated/docs/data_products.md
 generated/docs/contacts.md
+generated/docs/commandability.md
 ```
 
 ### 14.2 Generator Rule
@@ -809,7 +891,7 @@ Those belong to future milestones after the Mission Data Chain is more complete.
 
 ---
 
-## 15. Demo Mission Architecture
+## 16. Demo Mission Architecture
 
 The canonical demo is `demo-3u`.
 
@@ -833,7 +915,8 @@ examples/demo-3u/
 │   ├── policies.yaml
 │   ├── payloads.yaml
 │   ├── data_products.yaml
-│   └── contacts.yaml
+│   ├── contacts.yaml
+│   └── commandability.yaml
 └── scenarios/
     └── battery_low_during_payload.yaml
 ```
@@ -851,6 +934,11 @@ Contact Profile primary_ground_contact
 Link Profile uhf_downlink_nominal
 Contact Window demo_contact_001
 Downlink Flow science_next_available_contact
+Command Source ground_operator
+Command Source onboard_autonomy
+Commandability Rule payload_start_ground_rule
+Autonomous Actions stop payload on low/critical battery faults
+Recovery Intents toward DEGRADED and SAFE
 BOOT
 NOMINAL
 PAYLOAD_ACTIVE
@@ -871,7 +959,7 @@ It must not approximate a private mission.
 
 ---
 
-## 16. Repository Architecture
+## 17. Repository Architecture
 
 Current repository layout:
 
@@ -923,7 +1011,7 @@ orbitfabric/
 
 ---
 
-## 17. Dependency Architecture
+## 18. Dependency Architecture
 
 OrbitFabric uses a small dependency set.
 
@@ -963,7 +1051,7 @@ async frameworks unless necessary
 
 ---
 
-## 18. Layer Dependency Rules
+## 19. Layer Dependency Rules
 
 Allowed dependencies:
 
@@ -998,7 +1086,7 @@ The Model Layer must remain the lowest stable layer.
 
 ---
 
-## 19. Error and Diagnostics Architecture
+## 20. Error and Diagnostics Architecture
 
 OrbitFabric diagnostics should be consistent across loader, lint and simulation.
 
@@ -1038,7 +1126,7 @@ ERROR OF-DP-002 data_products.yaml payload.radiation_histogram producer 'unknown
 
 ---
 
-## 20. Reports Architecture
+## 21. Reports Architecture
 
 Reports are JSON where machine-readable output is required.
 
@@ -1049,7 +1137,7 @@ Conceptual shape:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mission": "demo-3u",
   "model_version": "0.1.0",
   "result": "passed",
@@ -1069,7 +1157,7 @@ Conceptual shape:
 ```json
 {
   "tool": "orbitfabric-sim",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scenario": "battery_low_during_payload",
   "mission": "demo-3u",
   "result": "passed",
@@ -1084,7 +1172,7 @@ Reports must be stable enough for tests and CI.
 
 ---
 
-## 21. Documentation Architecture
+## 22. Documentation Architecture
 
 OrbitFabric documentation has two classes.
 
@@ -1120,6 +1208,7 @@ generated/docs/packets.md
 generated/docs/payloads.md
 generated/docs/data_products.md
 generated/docs/contacts.md
+generated/docs/commandability.md
 ```
 
 These document a specific mission model.
@@ -1128,7 +1217,7 @@ Generated docs must not be manually edited.
 
 ---
 
-## 22. Testing Architecture
+## 23. Testing Architecture
 
 Current test strategy covers:
 
@@ -1165,7 +1254,7 @@ The documentation site is deployed separately through the Pages workflow.
 
 ---
 
-## 23. Future Extension Architecture
+## 24. Future Extension Architecture
 
 Future extensions should be added as generators, plugins or adapters.
 
@@ -1191,7 +1280,7 @@ They must not redefine the mission contract.
 
 ---
 
-## 24. Anti-Patterns
+## 25. Anti-Patterns
 
 The following patterns are architecturally wrong.
 
@@ -1237,9 +1326,9 @@ Using real private mission details as examples.
 
 ---
 
-## 25. v0.4.0 Acceptance Architecture
+## 26. v0.5.0 Acceptance Architecture
 
-OrbitFabric v0.4.0 is architecturally acceptable when this flow works end-to-end:
+OrbitFabric v0.5.0 is architecturally acceptable when this flow works end-to-end:
 
 ```bash
 ruff check .
@@ -1264,6 +1353,7 @@ Markdown mission documentation
 payload contract documentation
 data product contract documentation
 contact/downlink contract documentation
+commandability/autonomy contract documentation
 scenario execution log
 scenario JSON report
 ```
@@ -1277,6 +1367,7 @@ semantic linting
 payload contract validation
 data product contract validation
 contact/downlink contract validation
+commandability/autonomy contract validation
 command validation
 event emission
 fault detection
@@ -1287,49 +1378,37 @@ scenario pass/fail result
 generated documentation
 ```
 
-No runtime skeleton, ground export, orbital propagation, RF simulation or storage/downlink runtime is required for v0.4.0.
+No runtime skeleton, ground export, orbital propagation, RF simulation, storage/downlink runtime, live uplink or autonomy runtime is required for v0.5.0.
 
 ---
 
-## 26. Next Architectural Step — v0.5
+## 27. Next Architectural Step — v0.6
 
 The next architectural step is:
 
 ```text
-v0.5 — Commandability and Autonomy Contracts
+v0.6 — End-to-End Mission Data Flow Evidence
 ```
 
-The purpose is to model commandability and autonomy assumptions without becoming a live command stack, an operator console or a flight autonomy runtime.
+The purpose is to combine payload contracts, data products, storage intent, downlink assumptions, contact windows, commandability and recovery expectations into end-to-end mission data flow evidence.
 
 The expected direction is:
 
 ```text
-Contact Windows and Downlink Flow Contracts
-        -> command source assumptions
-        -> command dispatch intent
-        -> autonomous action assumptions
-        -> commandability consistency
-        -> future end-to-end mission data flow evidence
+Payload acquisition
+        -> data product generated
+        -> stored onboard by intent
+        -> eligible for downlink by intent
+        -> contact window available by assumption
+        -> downlink flow evidence produced
+        -> recovery/commandability evidence remains inspectable
 ```
 
-v0.5 must not implement:
-
-```text
-real command authentication
-real command authorization
-live uplink services
-operator consoles
-flight autonomy runtime
-onboard command dispatch software
-Yamcs/OpenC3 services
-real spacecraft operations
-```
-
-Commandability and autonomy must remain contract assumptions.
+v0.6 must not implement real onboard storage runtime, real downlink execution, real RF behavior, a live ground segment or an operations console.
 
 ---
 
-## 27. Final Architectural Statement
+## 28. Final Architectural Statement
 
 OrbitFabric is architecturally centered on the Mission Data Contract.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -43,7 +43,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.4.0
+orbitfabric 0.5.0
 ```
 
 ---
@@ -68,7 +68,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.4 Vertical Slice
+## Verify the Current v0.5 Vertical Slice
 
 Run mission lint:
 
@@ -108,6 +108,7 @@ generated/docs/packets.md
 generated/docs/payloads.md
 generated/docs/data_products.md
 generated/docs/contacts.md
+generated/docs/commandability.md
 ```
 
 ---
@@ -134,6 +135,7 @@ examples/demo-3u/mission/*.yaml
 examples/demo-3u/mission/payloads.yaml
 examples/demo-3u/mission/data_products.yaml
 examples/demo-3u/mission/contacts.yaml
+examples/demo-3u/mission/commandability.yaml
 examples/demo-3u/scenarios/*.yaml
 ```
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,6 +1,6 @@
 # OrbitFabric — Project Charter
 
-Version: 0.4
+Version: 0.5
 Status: Draft
 Scope: Mission Data Contract foundation and Mission Data Chain direction
 
@@ -10,7 +10,7 @@ Scope: Mission Data Contract foundation and Mission Data Chain direction
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions and operational scenarios once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions and operational scenarios once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
 
 OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool or a payload runtime framework.
 
@@ -219,7 +219,7 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 The early OrbitFabric preview has already demonstrated the core philosophy with a small but coherent vertical slice.
 
-The current v0.4.0 baseline includes:
+The current v0.5.0 baseline includes:
 
 - Mission Model YAML files;
 - model loading;
@@ -231,9 +231,11 @@ The current v0.4.0 baseline includes:
 - payload contract model;
 - data product contract model;
 - contact/downlink contract model;
+- commandability/autonomy contract model;
 - generated payload documentation;
 - generated data product documentation;
 - generated contact/downlink documentation;
+- generated commandability/autonomy documentation;
 - readable logs;
 - JSON reports;
 - one complete demo mission named `demo-3u`.
@@ -372,6 +374,10 @@ It contains:
 - link profile `uhf_downlink_nominal`;
 - contact window `demo_contact_001`;
 - downlink flow `science_next_available_contact`;
+- command sources `ground_operator` and `onboard_autonomy`;
+- commandability rule `payload_start_ground_rule`;
+- autonomous actions for low/critical battery recovery assumptions;
+- recovery intents toward DEGRADED and SAFE;
 - one nominal payload acquisition scenario;
 - one scenario where the payload is active, battery voltage degrades, a warning event is emitted, the spacecraft transitions to DEGRADED and the payload is automatically stopped.
 
@@ -389,7 +395,7 @@ The expected scenario narrative is:
 [00:40] SCENARIO PASSED
 ```
 
-The demo also includes a synthetic contact/downlink assumption slice.
+The demo also includes synthetic contact/downlink and commandability/autonomy assumption slices.
 
 Those assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
 
@@ -459,7 +465,7 @@ OrbitFabric is successful in the early public preview if a user can:
 7. understand the project positioning from the README in less than one minute;
 8. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
 9. understand how payload contracts fit into the Mission Data Contract;
-10. understand how data products, storage intent, downlink intent and contact assumptions fit into the roadmap before runtime skeletons.
+10. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints and recovery expectations fit into the roadmap before runtime skeletons.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -84,7 +84,7 @@ orbitfabric --help
 Expected version for the current development preview:
 
 ```text
-orbitfabric 0.4.0
+orbitfabric 0.5.0
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric — Roadmap
 
-Version: v0.4.0
+Version: v0.5.0
 Status: Development preview
 Scope: v0.3 to v1.0 planning
 
@@ -75,15 +75,15 @@ v0.2.2  Payload Contract Release Alignment                    completed
 v0.2.3  Mission Data Chain Roadmap Alignment                  completed
 v0.3.0  Data Product and Storage Contracts                    completed
 v0.4    Contact Windows and Downlink Flow Contracts           completed
-v0.5    Commandability and Autonomy Contracts                 next
-v0.6    End-to-End Mission Data Flow Evidence                 future
+v0.5    Commandability and Autonomy Contracts                 completed
+v0.6    End-to-End Mission Data Flow Evidence                 next
 v0.7    Generated Runtime Skeletons                           future
 v0.8    Ground Integration Artifacts                          future
 v0.9    Plugin and Extensibility Layer                        future
 v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target is `v0.5 — Commandability and Autonomy Contracts`.
+The immediate target is `v0.6 — End-to-End Mission Data Flow Evidence`.
 
 Runtime skeleton generation remains deferred until the Mission Data Chain is coherent enough to generate useful artifacts from it.
 
@@ -476,7 +476,7 @@ ground export generation
 Contact windows and downlink flows are contract assumptions, not physical simulation or runtime behavior.
 
 ---
-## 10. Next Milestone — v0.5 Commandability and Autonomy Contracts
+## 10. Completed Slice — v0.5.0 Commandability and Autonomy Contracts
 
 ### 10.1 Objective
 
@@ -486,24 +486,27 @@ Commands should not only exist.
 
 The model should express when they can be used, who or what may dispatch them, what they require and what evidence they should produce.
 
-### 10.2 Candidate Features
+### 10.2 Completed Capabilities
 
 ```text
-command source model: ground, onboard, autonomous
-requires_contact flag
-allowed modes refinement
-abstract operator confirmation hint
-expected events
-expected telemetry effects
-timeout expectations
-recovery command references
-command inhibition rules
-autonomy rule documentation
+ADR-0010 Commandability and Autonomy Contracts
+optional commandability.yaml domain
+CommandSource model
+CommandabilityRule model
+AutonomousActionContract model
+RecoveryIntent model
+commandability/autonomy semantic lint rules
+OF-CAB-* lint rule family
+OF-AUT-* lint rule family
+OF-REC-* lint rule family
+generated commandability/autonomy documentation
+generated commandability.md output
+one synthetic demo commandability/autonomy slice
 ```
 
 ### 10.3 Boundary
 
-v0.5 must not implement real command authentication, authorization, encryption, live uplink, operator consoles or flight-ready autonomy.
+v0.5 does not implement real command authentication, authorization, encryption, live uplink, operator consoles, command queues, onboard schedulers, autonomy runtime or real FDIR.
 
 It defines commandability and autonomy contracts only.
 
@@ -817,19 +820,18 @@ They must not become a live ground segment inside OrbitFabric.
 The immediate work package is:
 
 ```text
-v0.5 — Commandability and Autonomy Contracts
+v0.6 — End-to-End Mission Data Flow Evidence
 ```
 
 Required sequence:
 
 ```text
-1. define commandability/autonomy contract scope
-2. add ADR for Commandability and Autonomy Contracts
-3. refine command source and dispatch intent
-4. model autonomous command intent without implementing autonomy runtime
-5. add semantic lint rules for commandability consistency
-6. generate commandability/autonomy documentation
-7. update the synthetic demo mission with one clean commandability slice
+1. define end-to-end mission data flow evidence scope
+2. connect payload/data product/storage/downlink/contact assumptions into scenario evidence
+3. keep storage and downlink behavior deterministic and contract-level
+4. add scenario assertions for data product state where appropriate
+5. generate mission data flow documentation or reports
+6. update the synthetic demo mission with one clean end-to-end evidence slice
 ```
 
 Do not add runtime skeletons before the mission data chain model is coherent.
@@ -847,11 +849,13 @@ The Payload Contract Model strengthens this mission by making mission-specific a
 
 The Data Product and Storage Contract Model strengthens the mission data chain by making payload and subsystem data products, storage intent and downlink intent explicit.
 
-The v0.4 roadmap step has completed the first Contact Windows and Downlink Flow Contract slice.
+The v0.4 roadmap step completed the first Contact Windows and Downlink Flow Contract slice.
 
-The next roadmap step is to model commandability and autonomy assumptions before runtime or ground artifacts are generated.
+The v0.5 roadmap step completed the first Commandability and Autonomy Contract slice.
 
-Only after the mission data chain, commandability and autonomy contracts are clear should OrbitFabric grow into runtime skeleton generation, ground integration artifacts and plugin extensibility.
+The next roadmap step is to produce end-to-end mission data flow evidence before runtime or ground artifacts are generated.
+
+Only after the mission data chain, commandability, autonomy and end-to-end evidence contracts are clear should OrbitFabric grow into runtime skeleton generation, ground integration artifacts and plugin extensibility.
 
 The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/reference/json-reports-v0.1.md
+++ b/docs/reference/json-reports-v0.1.md
@@ -5,7 +5,7 @@ This page documents the JSON reports currently produced by OrbitFabric.
 Current documented baseline:
 
 ```text
-v0.4.0 — Contact Windows and Downlink Flow Contracts
+v0.5.0 — Commandability and Autonomy Contracts
 ```
 
 OrbitFabric JSON reports are generated artifacts intended for:
@@ -25,7 +25,7 @@ The source of truth remains the Mission Model YAML and scenario YAML.
 
 The JSON report structures documented here are development-preview contracts.
 
-They are stable enough for current v0.4 workflows, but they are not a v1.0 compatibility promise.
+They are stable enough for current v0.5 workflows, but they are not a v1.0 compatibility promise.
 
 Future versions may introduce:
 
@@ -46,7 +46,7 @@ Current example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.4.0"
+  "version": "0.5.0"
 }
 ```
 
@@ -163,7 +163,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mission": "demo-3u",
   "model_version": "0.1.0",
   "result": "passed",
@@ -274,7 +274,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-sim",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mission": "demo-3u",
   "scenario": "battery_low_during_payload",
   "result": "passed",

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -32,7 +32,7 @@ orbitfabric --version
 Current example:
 
 ```text
-orbitfabric 0.4.0
+orbitfabric 0.5.0
 ```
 
 This version answers the question:
@@ -85,7 +85,7 @@ Current example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mission": "demo-3u",
   "model_version": "0.1.0"
 }
@@ -104,7 +104,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.4.0
+OrbitFabric tool/package version: 0.5.0
 Mission Model version:           0.1.0
 ```
 
@@ -112,13 +112,13 @@ This is valid.
 
 It means:
 
-- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts and Contact/Downlink Contracts;
+- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts and Commandability/Autonomy Contracts;
 - the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record both pieces of information.
 
 ---
 
-## Current v0.4 rule
+## Current v0.5 rule
 
 For the current development preview:
 
@@ -153,4 +153,4 @@ Possible future additions include:
 - compatibility checks between tool version and Mission Model version;
 - JSON Schema export for Mission Model validation.
 
-These are not part of the current v0.4.0 development preview.
+These are not part of the current v0.5.0 development preview.

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,214 @@
+# OrbitFabric v0.5.0 — Commandability and Autonomy Contracts
+
+Status: Released  
+Scope: Commandability and Autonomy Contracts
+
+---
+
+## Summary
+
+OrbitFabric v0.5.0 introduces the first contract-level Commandability and Autonomy slice.
+
+This release extends the Mission Data Chain beyond Contact Windows and Downlink Flow Contracts:
+
+```text
+Payload Contract
+        -> Data Product Contract
+        -> Storage Intent
+        -> Downlink Intent
+        -> Contact Window Assumption
+        -> Downlink Flow Contract
+        -> Commandability and Autonomy Contract
+```
+
+The feature remains deliberately narrow.
+
+It models command sources, commandability rules, autonomous action assumptions and recovery intents so they can be validated, linted and documented.
+
+It does not implement live uplink.
+
+It does not implement command queues.
+
+It does not implement operator authentication or authorization.
+
+It does not implement an onboard scheduler.
+
+It does not implement flight autonomy or real FDIR.
+
+---
+
+## Added
+
+v0.5.0 adds:
+
+```text
+optional commandability.yaml domain
+Command Source model
+Commandability Rule model
+Autonomous Action Contract model
+Recovery Intent model
+commandability/autonomy semantic lint rules
+OF-CAB-* lint rule family
+OF-AUT-* lint rule family
+OF-REC-* lint rule family
+generated commandability.md documentation
+synthetic demo commandability/autonomy assumptions
+```
+
+---
+
+## New Mission Model Domain
+
+The new optional file is:
+
+```text
+mission/commandability.yaml
+```
+
+The demo mission now includes:
+
+```text
+examples/demo-3u/mission/commandability.yaml
+```
+
+The domain may define:
+
+```text
+command sources
+commandability rules
+autonomous action assumptions
+recovery intents
+```
+
+---
+
+## Lint Rules
+
+v0.5.0 introduces the first Commandability and Autonomy lint rule families:
+
+```text
+OF-CAB-*  commandability rule diagnostics
+OF-AUT-*  autonomous action diagnostics
+OF-REC-*  recovery intent diagnostics
+```
+
+These rules remain contract-level checks.
+
+They do not authenticate, authorize, queue, schedule, uplink or execute real spacecraft commands.
+
+---
+
+## Generated Documentation
+
+When commandability/autonomy contracts are present, OrbitFabric now generates:
+
+```text
+generated/docs/commandability.md
+```
+
+The generated page documents:
+
+```text
+command sources
+commandability rules
+autonomous actions
+recovery intents
+expected events
+expected effects
+```
+
+---
+
+## Demo Mission
+
+The synthetic `demo-3u` mission now demonstrates:
+
+```text
+ground_operator
+        -> payload.start_acquisition commandability rule
+
+onboard_autonomy
+        -> stop payload on low/critical battery faults
+        -> recovery intents toward DEGRADED and SAFE
+```
+
+The demo commandability/autonomy assumptions are synthetic and clean-room.
+
+They are not derived from a real mission, real operator concept, real command stack or real FDIR design.
+
+---
+
+## Validation Baseline
+
+The release baseline is:
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+
+orbitfabric --version
+
+orbitfabric lint examples/demo-3u/mission/ \
+  --json generated/reports/lint_report.json
+
+orbitfabric gen docs examples/demo-3u/mission/
+
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+```
+
+Expected result:
+
+```text
+orbitfabric 0.5.0
+all checks passing
+lint result: PASSED
+docs generation: PASSED
+scenario result: PASSED
+```
+
+---
+
+## Non-Goals
+
+v0.5.0 intentionally does not introduce:
+
+```text
+real command authentication
+real command authorization
+encryption
+live uplink services
+operator consoles
+command queues
+onboard schedulers
+flight autonomy runtime
+real FDIR or safing logic
+Yamcs/OpenC3 runtime services
+real spacecraft operations
+```
+
+These are not missing pieces of v0.5.0.
+
+They remain intentionally deferred.
+
+---
+
+## Architectural Meaning
+
+v0.5.0 completes the first declared commandability and recovery-assumption layer.
+
+OrbitFabric can now reason about whether commands, command sources, autonomous actions and recovery intents reference known mission objects and whether risky commands have explicit confirmation intent.
+
+That is the correct contract-level step before future end-to-end mission data flow evidence, runtime skeletons or ground integration artifacts.
+
+---
+
+## Final Position
+
+OrbitFabric v0.5.0 remains a Mission Data Contract framework.
+
+Commandability and autonomy definitions are contract assumptions.
+
+They are not command runtime behavior, operator tooling or flight autonomy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
       - v0.4.0 Contact Windows and Downlink Flow Contracts: releases/v0.4.0.md
+      - v0.5.0 Commandability and Autonomy Contracts: releases/v0.5.0.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.4.0"
+version = "0.5.0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Summary

This PR prepares the formal `v0.5.0 — Commandability and Autonomy Contracts` release.

The technical v0.5 milestone was already completed on `main`; this PR performs the release/version/documentation alignment needed to close it as `v0.5.0`.

## Updated

- bump package version from `0.4.0` to `0.5.0`
- bump `orbitfabric.__version__` from `0.4.0` to `0.5.0`
- update README version/status and generated docs listing
- move v0.5 changelog content from `[Unreleased]` to `[v0.5.0]`
- add `docs/releases/v0.5.0.md`
- add v0.5.0 release note to MkDocs navigation
- align Architecture with the v0.5.0 baseline
- align Roadmap: v0.5 completed, v0.6 next
- align Project Charter with commandability/autonomy as completed baseline
- align Quickstart and Development Guide expected CLI version/docs list
- align Versioning and JSON Reports references to `0.5.0`

## Scope boundary

This PR intentionally does not add:

- new model behavior
- new lint rules
- new scenario behavior
- runtime skeletons
- live uplink
- command queues
- operator authentication/authorization
- onboard scheduler
- autonomy runtime
- real FDIR or safing logic

This is a release alignment PR only.

## Validation

Expected local validation:

```bash
ruff check .
pytest
orbitfabric --version
orbitfabric lint examples/demo-3u/mission
orbitfabric gen docs examples/demo-3u/mission --output-dir generated/docs
orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
  --json generated/reports/battery_low_during_payload_report.json \
  --log generated/logs/battery_low_during_payload.log
mkdocs build --strict
```

Expected version output:

```text
orbitfabric 0.5.0
```