### PR TITLE
feat(v0.6): declare data product effects for payload commands

### DIFF
--- a/examples/demo-3u/mission/commands.yaml
+++ b/examples/demo-3u/mission/commands.yaml
@@ -27,6 +27,8 @@ commands:
         payload.acquisition.active: true
       mode_transition:
         to: PAYLOAD_ACTIVE
+      data_products:
+        - payload.radiation_histogram
 
   - id: payload.stop_acquisition
     target: payload

--- a/src/orbitfabric/lint/rules_commands.py
+++ b/src/orbitfabric/lint/rules_commands.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from orbitfabric.lint.finding import LintFinding
 from orbitfabric.model.mission import Command, MissionModel
 
@@ -8,11 +10,12 @@ RISKY_COMMAND_LEVELS = {"medium", "high", "critical"}
 
 def check_commands(model: MissionModel) -> list[LintFinding]:
     """Check command engineering consistency."""
-    findings: list[LintFinding] = []
+    findings = []
 
     for command in model.commands:
         findings.extend(_check_timeout(command))
         findings.extend(_check_expected_effects(command))
+        findings.extend(_check_expected_effect_data_products(model, command))
         findings.extend(_check_safe_mode_risk(command))
 
     return findings
@@ -50,6 +53,86 @@ def _check_expected_effects(command: Command) -> list[LintFinding]:
             suggestion="Add expected_effects or explicitly justify no expected effects.",
         )
     ]
+
+
+def _check_expected_effect_data_products(
+    model: MissionModel,
+    command: Command,
+) -> list[LintFinding]:
+    data_products = command.expected_effects.get("data_products")
+    if data_products is None:
+        return []
+
+    if not isinstance(data_products, list):
+        return [
+            LintFinding(
+                severity="ERROR",
+                code="OF-CMD-008",
+                file="commands.yaml",
+                domain="commands",
+                object_id=command.id,
+                message="command expected_effects.data_products must be a list",
+                suggestion=(
+                    "Set expected_effects.data_products to a list of data product "
+                    "IDs declared in data_products.yaml."
+                ),
+            )
+        ]
+
+    findings: list[LintFinding] = []
+    for data_product_id in data_products:
+        if not isinstance(data_product_id, str):
+            findings.append(_invalid_data_product_effect(command, data_product_id))
+            continue
+
+        if data_product_id in model.data_product_ids:
+            continue
+
+        findings.append(_unknown_data_product_effect(command, data_product_id))
+
+    return findings
+
+
+def _invalid_data_product_effect(
+    command: Command,
+    value: Any,
+) -> LintFinding:
+    return LintFinding(
+        severity="ERROR",
+        code="OF-CMD-008",
+        file="commands.yaml",
+        domain="commands",
+        object_id=command.id,
+        message=(
+            "command expected_effects.data_products contains a non-string "
+            f"entry '{value}'"
+        ),
+        suggestion=(
+            "Use only data product IDs declared in data_products.yaml under "
+            "expected_effects.data_products."
+        ),
+    )
+
+
+def _unknown_data_product_effect(
+    command: Command,
+    data_product_id: str,
+) -> LintFinding:
+    return LintFinding(
+        severity="ERROR",
+        code="OF-CMD-009",
+        file="commands.yaml",
+        domain="commands",
+        object_id=command.id,
+        message=(
+            "command expected_effects references unknown data product "
+            f"'{data_product_id}'"
+        ),
+        suggestion=(
+            "Add the data product to data_products.yaml or fix "
+            "expected_effects.data_products."
+        ),
+    )
 
 
 def _check_safe_mode_risk(command: Command) -> list[LintFinding]:

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -185,6 +185,41 @@ def test_command_expected_effect_payload_lifecycle_state_must_exist() -> None:
     assert report.has_errors
 
 
+def test_command_expected_effect_data_product_must_exist() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commands[0].expected_effects["data_products"] = [
+        "payload.unknown_data_product"
+    ]
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-CMD-009" in codes
+    assert report.has_errors
+
+
+def test_command_expected_effect_data_products_must_be_list() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commands[0].expected_effects["data_products"] = "payload.radiation_histogram"
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-CMD-008" in codes
+    assert report.has_errors
+
+
+def test_command_expected_effect_data_product_entries_must_be_strings() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    model.commands[0].expected_effects["data_products"] = [123]
+
+    report = LintEngine().run(model)
+
+    codes = {finding.code for finding in report.findings}
+    assert "OF-CMD-008" in codes
+    assert report.has_errors
+
+
 def test_valid_data_product_contract_has_no_lint_findings() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
     model.data_products.append(make_valid_data_product())


### PR DESCRIPTION
## Summary

This PR starts the `v0.6.0 — End-to-End Mission Data Flow Evidence` milestone with the smallest contract-level step.

It makes payload data-product production explicit in the Mission Model by allowing commands to declare produced data products through `expected_effects.data_products`.

## Changes

- Declares `payload.radiation_histogram` as a contractual expected effect of `payload.start_acquisition` in the synthetic `demo-3u` mission.
- Adds command lint validation for `expected_effects.data_products`.
- Reports an error when `expected_effects.data_products` is not a list.
- Reports an error when a command references an unknown data product in `expected_effects.data_products`.
- Adds tests for valid and invalid command data-product expected effects.

## Architectural boundary

This PR does **not** implement:

- real payload data generation;
- real onboard storage;
- file-system behavior;
- downlink execution;
- contact scheduling;
- RF behavior;
- command queues;
- runtime skeleton generation;
- ground integration.

The change remains strictly contract-level and prepares the next PR, where the simulator can produce machine-readable mission data-flow evidence from the declared contract.

## Validation

Expected local validation:

```bash
ruff check .
pytest
orbitfabric lint examples/demo-3u/mission/
```

I did not run local tests from this environment; CI should be treated as the execution authority for this PR.