### PR TITLE
feat(v0.6): export simulation data flow evidence

### DIFF
--- a/src/orbitfabric/sim/json_report.py
+++ b/src/orbitfabric/sim/json_report.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric import __version__
-from orbitfabric.sim.state import SimulationResult
+from orbitfabric.sim.state import SimDataFlowEvidenceRecord, SimulationResult
 
 
 def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
@@ -20,6 +20,7 @@ def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
             "events": len(result.state.events),
             "commands": len(result.state.commands),
             "mode_transitions": len(result.state.mode_transitions),
+            "data_flow_evidence": len(result.state.data_flow_evidence),
             "failed_expectations": len(result.state.failed_expectations),
         },
         "timeline": [
@@ -57,6 +58,10 @@ def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
             }
             for transition in result.state.mode_transitions
         ],
+        "data_flow_evidence": [
+            _data_flow_evidence_to_dict(evidence)
+            for evidence in result.state.data_flow_evidence
+        ],
         "final_state": {
             "mode": result.state.current_mode,
             "telemetry": result.state.telemetry,
@@ -76,6 +81,22 @@ def write_simulation_report_json(
     with output_path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2, sort_keys=True)
         handle.write("\n")
+
+
+def _data_flow_evidence_to_dict(
+    evidence: SimDataFlowEvidenceRecord,
+) -> dict[str, Any]:
+    return {
+        "t": evidence.t,
+        "data_product_id": evidence.data_product_id,
+        "producer": evidence.producer,
+        "producer_type": evidence.producer_type,
+        "triggered_by_command": evidence.command_id,
+        "storage_intent": evidence.storage_intent,
+        "downlink_intent": evidence.downlink_intent,
+        "eligible_downlink_flows": evidence.eligible_downlink_flows,
+        "contact_windows": evidence.contact_windows,
+    }
 
 
 def _json_result_label(result: SimulationResult) -> str:

--- a/src/orbitfabric/sim/runner.py
+++ b/src/orbitfabric/sim/runner.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 from typing import Any
 
+from orbitfabric.model.mission import (
+    DataProductContract,
+    DataProductDownlinkIntent,
+    DataProductStorageIntent,
+    MissionModel,
+)
 from orbitfabric.model.scenario import LoadedScenario, ScenarioStep
 from orbitfabric.sim.command_router import CommandDispatchResult, CommandRouter
 from orbitfabric.sim.event_bus import EventBus
 from orbitfabric.sim.fault_monitor import FaultMonitor, FaultTrigger
 from orbitfabric.sim.mode_manager import ModeManager
-from orbitfabric.sim.state import SimulationResult, SimulationState
+from orbitfabric.sim.state import (
+    SimDataFlowEvidenceRecord,
+    SimulationResult,
+    SimulationState,
+)
 from orbitfabric.sim.telemetry_registry import TelemetryRegistry
 
 
@@ -41,6 +51,7 @@ class ScenarioRunner:
             state.current_time = step.t
             self._execute_step(
                 step=step,
+                mission=mission,
                 state=state,
                 telemetry=telemetry,
                 event_bus=event_bus,
@@ -67,6 +78,7 @@ class ScenarioRunner:
     def _execute_step(
         self,
         step: ScenarioStep,
+        mission: MissionModel,
         state: SimulationState,
         telemetry: TelemetryRegistry,
         event_bus: EventBus,
@@ -83,6 +95,7 @@ class ScenarioRunner:
             )
             self._apply_command_effects(
                 result=result,
+                mission=mission,
                 t=step.t,
                 state=state,
                 telemetry=telemetry,
@@ -95,6 +108,7 @@ class ScenarioRunner:
             telemetry.inject(step.inject.telemetry, step.inject.value, step.t)
             self._apply_fault_triggers(
                 triggers=fault_monitor.evaluate(),
+                mission=mission,
                 t=step.t,
                 state=state,
                 telemetry=telemetry,
@@ -115,6 +129,7 @@ class ScenarioRunner:
     def _apply_command_effects(
         self,
         result: CommandDispatchResult,
+        mission: MissionModel,
         t: float,
         state: SimulationState,
         telemetry: TelemetryRegistry,
@@ -134,6 +149,7 @@ class ScenarioRunner:
 
         expected_effects = command.expected_effects
         self._apply_payload_lifecycle_effects(expected_effects, state, t)
+        self._record_data_flow_evidence(expected_effects, command.id, mission, state, t)
 
         telemetry_effects = expected_effects.get("telemetry", {})
         for telemetry_id, value in telemetry_effects.items():
@@ -165,9 +181,40 @@ class ScenarioRunner:
         state.payload_lifecycle[payload_id] = lifecycle_state
         state.log(t, f"PAYLOAD {payload_id} LIFECYCLE={lifecycle_state}")
 
+    def _record_data_flow_evidence(
+        self,
+        expected_effects: dict[str, Any],
+        command_id: str,
+        mission: MissionModel,
+        state: SimulationState,
+        t: float,
+    ) -> None:
+        data_product_ids = expected_effects.get("data_products")
+        if not isinstance(data_product_ids, list):
+            return
+
+        data_products = {data_product.id: data_product for data_product in mission.data_products}
+        for data_product_id in data_product_ids:
+            if not isinstance(data_product_id, str):
+                continue
+
+            data_product = data_products.get(data_product_id)
+            if data_product is None:
+                continue
+
+            evidence = _build_data_flow_evidence(
+                data_product=data_product,
+                command_id=command_id,
+                mission=mission,
+                t=t,
+            )
+            state.data_flow_evidence.append(evidence)
+            state.log(t, f"DATA_PRODUCT {data_product_id} CONTRACT_EVIDENCE_RECORDED")
+
     def _apply_fault_triggers(
         self,
         triggers: list[FaultTrigger],
+        mission: MissionModel,
         t: float,
         state: SimulationState,
         telemetry: TelemetryRegistry,
@@ -191,6 +238,7 @@ class ScenarioRunner:
                 )
                 self._apply_command_effects(
                     result=result,
+                    mission=mission,
                     t=t,
                     state=state,
                     telemetry=telemetry,
@@ -321,6 +369,76 @@ class ScenarioRunner:
                 step.t,
                 f"expected scenario status {expected_status} but got {actual_status}",
             )
+
+
+def _build_data_flow_evidence(
+    data_product: DataProductContract,
+    command_id: str,
+    mission: MissionModel,
+    t: float,
+) -> SimDataFlowEvidenceRecord:
+    eligible_flows = [
+        flow.id
+        for flow in mission.contacts.downlink_flows
+        if data_product.id in flow.eligible_data_products
+    ]
+    contact_windows = _contact_windows_for_flows(eligible_flows, mission)
+
+    return SimDataFlowEvidenceRecord(
+        t=t,
+        data_product_id=data_product.id,
+        producer=data_product.producer,
+        producer_type=data_product.producer_type,
+        command_id=command_id,
+        storage_intent=_storage_intent_to_dict(data_product.storage),
+        downlink_intent=_downlink_intent_to_dict(data_product.downlink),
+        eligible_downlink_flows=eligible_flows,
+        contact_windows=contact_windows,
+    )
+
+
+def _contact_windows_for_flows(
+    flow_ids: list[str],
+    mission: MissionModel,
+) -> list[str]:
+    flows = [flow for flow in mission.contacts.downlink_flows if flow.id in flow_ids]
+    windows: list[str] = []
+
+    for flow in flows:
+        for window in mission.contacts.contact_windows:
+            if window.contact_profile != flow.contact_profile:
+                continue
+            if window.link_profile != flow.link_profile:
+                continue
+            windows.append(window.id)
+
+    return sorted(set(windows))
+
+
+def _storage_intent_to_dict(
+    storage: DataProductStorageIntent | None,
+) -> dict[str, Any]:
+    if storage is None:
+        return {"declared": False}
+
+    return {
+        "declared": True,
+        "class": storage.storage_class,
+        "retention": storage.retention,
+        "overflow_policy": storage.overflow_policy,
+    }
+
+
+def _downlink_intent_to_dict(
+    downlink: DataProductDownlinkIntent | None,
+) -> dict[str, Any]:
+    if downlink is None:
+        return {"declared": False}
+
+    return {
+        "declared": downlink.policy is not None,
+        "policy": downlink.policy,
+    }
 
 
 def _format_value(value: Any) -> str:

--- a/src/orbitfabric/sim/state.py
+++ b/src/orbitfabric/sim/state.py
@@ -39,6 +39,19 @@ class SimModeTransitionRecord:
     reason: str
 
 
+@dataclass(frozen=True)
+class SimDataFlowEvidenceRecord:
+    t: float
+    data_product_id: str
+    producer: str
+    producer_type: str
+    command_id: str
+    storage_intent: dict[str, Any]
+    downlink_intent: dict[str, Any]
+    eligible_downlink_flows: list[str]
+    contact_windows: list[str]
+
+
 @dataclass
 class SimulationState:
     current_time: float
@@ -49,6 +62,7 @@ class SimulationState:
     events: list[SimEventRecord] = field(default_factory=list)
     commands: list[SimCommandRecord] = field(default_factory=list)
     mode_transitions: list[SimModeTransitionRecord] = field(default_factory=list)
+    data_flow_evidence: list[SimDataFlowEvidenceRecord] = field(default_factory=list)
     failed_expectations: list[str] = field(default_factory=list)
 
     def log(self, t: float, message: str) -> None:

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -61,6 +61,34 @@ def test_runner_executes_nominal_payload_lifecycle_scenario() -> None:
     assert "payload.stop_acquisition" in ground_commands
 
 
+def test_runner_records_data_flow_evidence_for_declared_data_product() -> None:
+    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+
+    result = ScenarioRunner().run(loaded)
+
+    assert result.passed
+    assert len(result.state.data_flow_evidence) == 1
+
+    evidence = result.state.data_flow_evidence[0]
+    assert evidence.t == 5
+    assert evidence.data_product_id == "payload.radiation_histogram"
+    assert evidence.producer == "demo_iod_payload"
+    assert evidence.producer_type == "payload"
+    assert evidence.command_id == "payload.start_acquisition"
+    assert evidence.storage_intent == {
+        "declared": True,
+        "class": "science",
+        "retention": "7d",
+        "overflow_policy": "drop_oldest",
+    }
+    assert evidence.downlink_intent == {
+        "declared": True,
+        "policy": "next_available_contact",
+    }
+    assert evidence.eligible_downlink_flows == ["science_next_available_contact"]
+    assert evidence.contact_windows == ["demo_contact_001"]
+
+
 def test_sim_cli_executes_demo_scenario() -> None:
     result = runner.invoke(app, ["sim", str(DEMO_SCENARIO)])
 
@@ -82,5 +110,6 @@ def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
     assert "PAYLOAD demo_iod_payload LIFECYCLE=READY" in result.output
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING" in result.output
+    assert "DATA_PRODUCT payload.radiation_histogram CONTRACT_EVIDENCE_RECORDED" in result.output
     assert "COMMAND payload.stop_acquisition -> ACCEPTED" in result.output
     assert "Result: PASSED" in result.output

--- a/tests/test_sim_json_report.py
+++ b/tests/test_sim_json_report.py
@@ -27,6 +27,7 @@ def test_simulation_result_to_dict_for_demo_scenario() -> None:
     assert payload["scenario"] == "battery_low_during_payload"
     assert payload["result"] == "passed"
     assert payload["summary"]["failed_expectations"] == 0
+    assert payload["summary"]["data_flow_evidence"] == 1
     assert payload["final_state"]["mode"] == "DEGRADED"
     assert payload["final_state"]["telemetry"]["payload.acquisition.active"] is False
 
@@ -40,6 +41,28 @@ def test_simulation_result_to_dict_for_demo_scenario() -> None:
         if command["dispatch"] == "AUTO"
     }
     assert "payload.stop_acquisition" in auto_commands
+
+    assert payload["data_flow_evidence"] == [
+        {
+            "t": 5,
+            "data_product_id": "payload.radiation_histogram",
+            "producer": "demo_iod_payload",
+            "producer_type": "payload",
+            "triggered_by_command": "payload.start_acquisition",
+            "storage_intent": {
+                "declared": True,
+                "class": "science",
+                "retention": "7d",
+                "overflow_policy": "drop_oldest",
+            },
+            "downlink_intent": {
+                "declared": True,
+                "policy": "next_available_contact",
+            },
+            "eligible_downlink_flows": ["science_next_available_contact"],
+            "contact_windows": ["demo_contact_001"],
+        }
+    ]
 
 
 def test_sim_command_writes_json_report(tmp_path: Path) -> None:
@@ -66,3 +89,6 @@ def test_sim_command_writes_json_report(tmp_path: Path) -> None:
     assert payload["scenario"] == "battery_low_during_payload"
     assert payload["result"] == "passed"
     assert payload["summary"]["failed_expectations"] == 0
+    assert payload["summary"]["data_flow_evidence"] == 1
+    assert payload["data_flow_evidence"][0]["data_product_id"] == "payload.radiation_histogram"
+    assert payload["data_flow_evidence"][0]["triggered_by_command"] == "payload.start_acquisition"


### PR DESCRIPTION
## Summary

This PR continues the `v0.6.0 — End-to-End Mission Data Flow Evidence` milestone by turning the data-product effect declared in PR #103 into machine-readable simulation evidence.

When an accepted command declares `expected_effects.data_products`, the scenario runner now records contract-level data-flow evidence for the referenced data product.

## Changes

- Adds `SimDataFlowEvidenceRecord` to simulation state.
- Records data-flow evidence when a command effect declares produced data products.
- Captures declared producer, storage intent, downlink intent, eligible downlink flows and matching contact windows.
- Exports `data_flow_evidence` in the simulation JSON report.
- Adds `summary.data_flow_evidence` to the JSON report summary.
- Adds tests for simulation state evidence and JSON evidence output.

## Architectural boundary

This remains contract-level evidence only.

This PR does **not** implement:

- real payload data generation;
- file creation;
- onboard storage runtime;
- queue execution;
- contact scheduling;
- RF/downlink execution;
- ground segment integration;
- CCSDS/PUS/CFDP behavior;
- runtime skeleton generation.

The evidence says: this scenario exercised a command whose Mission Model contract declares that a data product is produced, with storage/downlink/contact assumptions traceable from the model.

## Validation

Expected local validation:

```bash
ruff check .
pytest
orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
  --json generated/reports/battery_low_during_payload_report.json
```

I did not run local tests from this environment; local validation and CI should be treated as authoritative.