### PR TITLE
feat(v0.6): add data flow scenario assertions

### DIFF
--- a/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
+++ b/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
@@ -45,6 +45,16 @@ steps:
     expect_telemetry:
       payload.acquisition.active: true
 
+  - t: 9
+    expect:
+      data_flow:
+        data_product: payload.radiation_histogram
+        triggered_by_command: payload.start_acquisition
+        storage_intent_declared: true
+        downlink_intent_declared: true
+        eligible_downlink_flow: science_next_available_contact
+        contact_window: demo_contact_001
+
   - t: 20
     command: payload.stop_acquisition
     expect:

--- a/src/orbitfabric/model/scenario_loader.py
+++ b/src/orbitfabric/model/scenario_loader.py
@@ -87,6 +87,9 @@ class ScenarioLoader:
         telemetry_ids = mission_model.telemetry_ids
         command_ids = mission_model.command_ids
         event_ids = mission_model.event_ids
+        data_product_ids = mission_model.data_product_ids
+        downlink_flow_ids = mission_model.downlink_flow_ids
+        contact_window_ids = mission_model.contact_window_ids
 
         if scenario.initial_state.mode not in mode_ids:
             findings.append(
@@ -232,6 +235,18 @@ class ScenarioLoader:
                             )
                         )
 
+            if step.expect is not None:
+                findings.extend(
+                    _validate_data_flow_expectation_references(
+                        expectation=step.expect,
+                        scenario_id=scenario.scenario.id,
+                        data_product_ids=data_product_ids,
+                        command_ids=command_ids,
+                        downlink_flow_ids=downlink_flow_ids,
+                        contact_window_ids=contact_window_ids,
+                    )
+                )
+
         return findings
 
     def _load_yaml_file(
@@ -335,3 +350,93 @@ class ScenarioLoader:
             return mission_path.resolve()
 
         return (scenario_file.parent / mission_path).resolve()
+
+
+def _validate_data_flow_expectation_references(
+    expectation: dict[str, Any],
+    scenario_id: str,
+    data_product_ids: set[str],
+    command_ids: set[str],
+    downlink_flow_ids: set[str],
+    contact_window_ids: set[str],
+) -> list[LintFinding]:
+    data_flow = expectation.get("data_flow")
+    if not isinstance(data_flow, dict):
+        return []
+
+    findings: list[LintFinding] = []
+
+    data_product_id = data_flow.get("data_product")
+    if isinstance(data_product_id, str) and data_product_id not in data_product_ids:
+        findings.append(
+            _scenario_reference_finding(
+                scenario_id=scenario_id,
+                code="OF-SCN-014",
+                message=(
+                    "scenario data flow expectation references unknown data "
+                    f"product '{data_product_id}'"
+                ),
+                suggestion="Use a data product defined in data_products.yaml.",
+            )
+        )
+
+    command_id = data_flow.get("triggered_by_command")
+    if isinstance(command_id, str) and command_id not in command_ids:
+        findings.append(
+            _scenario_reference_finding(
+                scenario_id=scenario_id,
+                code="OF-SCN-015",
+                message=(
+                    "scenario data flow expectation references unknown command "
+                    f"'{command_id}'"
+                ),
+                suggestion="Use a command defined in commands.yaml.",
+            )
+        )
+
+    downlink_flow_id = data_flow.get("eligible_downlink_flow")
+    if isinstance(downlink_flow_id, str) and downlink_flow_id not in downlink_flow_ids:
+        findings.append(
+            _scenario_reference_finding(
+                scenario_id=scenario_id,
+                code="OF-SCN-016",
+                message=(
+                    "scenario data flow expectation references unknown downlink "
+                    f"flow '{downlink_flow_id}'"
+                ),
+                suggestion="Use a downlink flow defined in contacts.yaml.",
+            )
+        )
+
+    contact_window_id = data_flow.get("contact_window")
+    if isinstance(contact_window_id, str) and contact_window_id not in contact_window_ids:
+        findings.append(
+            _scenario_reference_finding(
+                scenario_id=scenario_id,
+                code="OF-SCN-017",
+                message=(
+                    "scenario data flow expectation references unknown contact "
+                    f"window '{contact_window_id}'"
+                ),
+                suggestion="Use a contact window defined in contacts.yaml.",
+            )
+        )
+
+    return findings
+
+
+def _scenario_reference_finding(
+    scenario_id: str,
+    code: str,
+    message: str,
+    suggestion: str,
+) -> LintFinding:
+    return LintFinding(
+        severity="ERROR",
+        code=code,
+        file="scenario.yaml",
+        domain="scenario",
+        object_id=scenario_id,
+        message=message,
+        suggestion=suggestion,
+    )

--- a/src/orbitfabric/sim/runner.py
+++ b/src/orbitfabric/sim/runner.py
@@ -297,6 +297,7 @@ class ScenarioRunner:
 
         if step.expect is not None:
             self._check_payload_lifecycle_expectation(step, state)
+            self._check_data_flow_expectation(step, state)
             self._check_scenario_status_expectation(step, state)
 
     def _check_telemetry_expectations(
@@ -350,6 +351,37 @@ class ScenarioRunner:
             )
         else:
             state.log(step.t, f"PAYLOAD {payload_id} LIFECYCLE={actual_state}")
+
+    def _check_data_flow_expectation(
+        self,
+        step: ScenarioStep,
+        state: SimulationState,
+    ) -> None:
+        if step.expect is None:
+            return
+
+        expected_data_flow = step.expect.get("data_flow")
+        if not isinstance(expected_data_flow, dict):
+            return
+
+        data_product_id = expected_data_flow.get("data_product")
+        if not isinstance(data_product_id, str):
+            state.fail_expectation(step.t, "invalid data flow expectation")
+            return
+
+        evidence = _find_data_flow_evidence(state, data_product_id)
+        if evidence is None:
+            state.fail_expectation(
+                step.t,
+                f"missing data flow evidence for {data_product_id}",
+            )
+            return
+
+        mismatches = _data_flow_expectation_mismatches(expected_data_flow, evidence)
+        if mismatches:
+            state.fail_expectation(step.t, "; ".join(mismatches))
+        else:
+            state.log(step.t, f"DATA_FLOW {data_product_id} EXPECTATION_MET")
 
     def _check_scenario_status_expectation(
         self,
@@ -439,6 +471,60 @@ def _downlink_intent_to_dict(
         "declared": downlink.policy is not None,
         "policy": downlink.policy,
     }
+
+
+def _find_data_flow_evidence(
+    state: SimulationState,
+    data_product_id: str,
+) -> SimDataFlowEvidenceRecord | None:
+    for evidence in reversed(state.data_flow_evidence):
+        if evidence.data_product_id == data_product_id:
+            return evidence
+
+    return None
+
+
+def _data_flow_expectation_mismatches(
+    expected: dict[str, Any],
+    evidence: SimDataFlowEvidenceRecord,
+) -> list[str]:
+    mismatches: list[str] = []
+
+    triggered_by_command = expected.get("triggered_by_command")
+    if triggered_by_command is not None and triggered_by_command != evidence.command_id:
+        mismatches.append(
+            f"expected data flow command {triggered_by_command} "
+            f"but got {evidence.command_id}"
+        )
+
+    storage_declared = expected.get("storage_intent_declared")
+    if storage_declared is not None:
+        actual = evidence.storage_intent.get("declared")
+        if storage_declared != actual:
+            mismatches.append(
+                f"expected storage_intent_declared={storage_declared} but got {actual}"
+            )
+
+    downlink_declared = expected.get("downlink_intent_declared")
+    if downlink_declared is not None:
+        actual = evidence.downlink_intent.get("declared")
+        if downlink_declared != actual:
+            mismatches.append(
+                f"expected downlink_intent_declared={downlink_declared} but got {actual}"
+            )
+
+    eligible_downlink_flow = expected.get("eligible_downlink_flow")
+    if eligible_downlink_flow is not None:
+        if eligible_downlink_flow not in evidence.eligible_downlink_flows:
+            mismatches.append(
+                f"expected eligible downlink flow {eligible_downlink_flow}"
+            )
+
+    contact_window = expected.get("contact_window")
+    if contact_window is not None and contact_window not in evidence.contact_windows:
+        mismatches.append(f"expected contact window {contact_window}")
+
+    return mismatches
 
 
 def _format_value(value: Any) -> str:

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -13,6 +13,7 @@ from orbitfabric.model.errors import MissionModelError
 from orbitfabric.model.scenario_loader import ScenarioLoader
 
 DEMO_SCENARIO = Path("examples/demo-3u/scenarios/battery_low_during_payload.yaml")
+PAYLOAD_SCENARIO = Path("examples/demo-3u/scenarios/nominal_payload_acquisition.yaml")
 runner = CliRunner()
 
 
@@ -23,6 +24,13 @@ def test_load_demo_scenario() -> None:
     assert loaded.mission_model.spacecraft.id == "demo-3u"
     assert loaded.scenario.initial_state.mode == "NOMINAL"
     assert len(loaded.scenario.steps) == 13
+
+
+def test_load_payload_scenario_with_data_flow_expectation() -> None:
+    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+
+    assert loaded.scenario.scenario.id == "nominal_payload_acquisition"
+    assert len(loaded.scenario.steps) == 12
 
 
 def test_sim_cli_loads_demo_scenario() -> None:
@@ -141,6 +149,48 @@ def test_scenario_loader_rejects_invalid_references(
     assert any(diagnostic.suggestion for diagnostic in exc_info.value.diagnostics)
 
 
+@pytest.mark.parametrize(
+    ("old", "new", "expected_code"),
+    [
+        (
+            "data_product: payload.radiation_histogram",
+            "data_product: payload.unknown_product",
+            "OF-SCN-014",
+        ),
+        (
+            "triggered_by_command: payload.start_acquisition",
+            "triggered_by_command: payload.unknown_command",
+            "OF-SCN-015",
+        ),
+        (
+            "eligible_downlink_flow: science_next_available_contact",
+            "eligible_downlink_flow: unknown_flow",
+            "OF-SCN-016",
+        ),
+        (
+            "contact_window: demo_contact_001",
+            "contact_window: unknown_contact_window",
+            "OF-SCN-017",
+        ),
+    ],
+)
+def test_scenario_loader_rejects_invalid_data_flow_references(
+    tmp_path: Path,
+    old: str,
+    new: str,
+    expected_code: str,
+) -> None:
+    scenario_path = _copy_payload_scenario_with_replacement(tmp_path, old, new)
+
+    with pytest.raises(MissionModelError) as exc_info:
+        ScenarioLoader().load(scenario_path)
+
+    codes = {diagnostic.code for diagnostic in exc_info.value.diagnostics}
+
+    assert expected_code in codes
+    assert any(diagnostic.suggestion for diagnostic in exc_info.value.diagnostics)
+
+
 def test_scenario_loader_rejects_missing_required_top_level_key(tmp_path: Path) -> None:
     scenario_path = tmp_path / "missing-steps.yaml"
     scenario_path.write_text(
@@ -213,5 +263,21 @@ def _copy_demo_scenario_with_mutation(
     scenario_path = demo_dir / "scenarios" / "battery_low_during_payload.yaml"
     scenario = scenario_path.read_text(encoding="utf-8")
     scenario_path.write_text(mutate(scenario), encoding="utf-8")
+
+    return scenario_path
+
+
+def _copy_payload_scenario_with_replacement(
+    tmp_path: Path,
+    old: str,
+    new: str,
+) -> Path:
+    source = Path("examples/demo-3u")
+    demo_dir = tmp_path / "demo-3u"
+    shutil.copytree(source, demo_dir)
+
+    scenario_path = demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"
+    scenario = scenario_path.read_text(encoding="utf-8")
+    scenario_path.write_text(scenario.replace(old, new, 1), encoding="utf-8")
 
     return scenario_path

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -89,6 +90,34 @@ def test_runner_records_data_flow_evidence_for_declared_data_product() -> None:
     assert evidence.contact_windows == ["demo_contact_001"]
 
 
+def test_runner_checks_data_flow_expectation() -> None:
+    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+
+    result = ScenarioRunner().run(loaded)
+
+    assert result.passed
+    assert any(
+        "DATA_FLOW payload.radiation_histogram EXPECTATION_MET" in entry.message
+        for entry in result.state.logs
+    )
+
+
+def test_runner_fails_missing_data_flow_expectation(tmp_path: Path) -> None:
+    scenario_path = _copy_payload_scenario_with_replacement(
+        tmp_path,
+        "data_product: payload.radiation_histogram",
+        "data_product: payload.missing_runtime_evidence",
+    )
+    loaded = ScenarioLoader().load(scenario_path)
+
+    result = ScenarioRunner().run(loaded)
+
+    assert not result.passed
+    assert "missing data flow evidence for payload.missing_runtime_evidence" in (
+        result.state.failed_expectations
+    )
+
+
 def test_sim_cli_executes_demo_scenario() -> None:
     result = runner.invoke(app, ["sim", str(DEMO_SCENARIO)])
 
@@ -111,5 +140,22 @@ def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING" in result.output
     assert "DATA_PRODUCT payload.radiation_histogram CONTRACT_EVIDENCE_RECORDED" in result.output
+    assert "DATA_FLOW payload.radiation_histogram EXPECTATION_MET" in result.output
     assert "COMMAND payload.stop_acquisition -> ACCEPTED" in result.output
     assert "Result: PASSED" in result.output
+
+
+def _copy_payload_scenario_with_replacement(
+    tmp_path: Path,
+    old: str,
+    new: str,
+) -> Path:
+    source = Path("examples/demo-3u")
+    demo_dir = tmp_path / "demo-3u"
+    shutil.copytree(source, demo_dir)
+
+    scenario_path = demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"
+    scenario = scenario_path.read_text(encoding="utf-8")
+    scenario_path.write_text(scenario.replace(old, new, 1), encoding="utf-8")
+
+    return scenario_path

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -103,17 +103,13 @@ def test_runner_checks_data_flow_expectation() -> None:
 
 
 def test_runner_fails_missing_data_flow_expectation(tmp_path: Path) -> None:
-    scenario_path = _copy_payload_scenario_with_replacement(
-        tmp_path,
-        "data_product: payload.radiation_histogram",
-        "data_product: payload.missing_runtime_evidence",
-    )
+    scenario_path = _copy_payload_scenario_without_data_product_effect(tmp_path)
     loaded = ScenarioLoader().load(scenario_path)
 
     result = ScenarioRunner().run(loaded)
 
     assert not result.passed
-    assert "missing data flow evidence for payload.missing_runtime_evidence" in (
+    assert "missing data flow evidence for payload.radiation_histogram" in (
         result.state.failed_expectations
     )
 
@@ -145,17 +141,21 @@ def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
     assert "Result: PASSED" in result.output
 
 
-def _copy_payload_scenario_with_replacement(
-    tmp_path: Path,
-    old: str,
-    new: str,
-) -> Path:
+def _copy_payload_scenario_without_data_product_effect(tmp_path: Path) -> Path:
     source = Path("examples/demo-3u")
     demo_dir = tmp_path / "demo-3u"
     shutil.copytree(source, demo_dir)
 
-    scenario_path = demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"
-    scenario = scenario_path.read_text(encoding="utf-8")
-    scenario_path.write_text(scenario.replace(old, new, 1), encoding="utf-8")
+    commands_path = demo_dir / "mission" / "commands.yaml"
+    commands = commands_path.read_text(encoding="utf-8")
+    commands_path.write_text(
+        commands.replace(
+            "      data_products:\n"
+            "        - payload.radiation_histogram\n",
+            "",
+            1,
+        ),
+        encoding="utf-8",
+    )
 
-    return scenario_path
+    return demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"


### PR DESCRIPTION
## Summary

This PR continues the `v0.6.0 — End-to-End Mission Data Flow Evidence` milestone by allowing scenarios to assert that contract-level data-flow evidence exists.

After PR #104 introduced simulation-side `data_flow_evidence`, this PR makes that evidence scenario-checkable through `expect.data_flow`.

## Changes

- Adds `expect.data_flow` to the demo nominal payload scenario.
- Checks data-flow expectations during scenario execution.
- Validates scenario references for expected data product, triggering command, downlink flow and contact window.
- Adds tests for successful data-flow scenario expectations.
- Adds tests for missing runtime data-flow evidence.
- Adds tests for invalid data-flow scenario references.

## Supported expectation fields

```yaml
expect:
  data_flow:
    data_product: payload.radiation_histogram
    triggered_by_command: payload.start_acquisition
    storage_intent_declared: true
    downlink_intent_declared: true
    eligible_downlink_flow: science_next_available_contact
    contact_window: demo_contact_001
```

## Architectural boundary

This remains contract-level and scenario-level evidence only.

This PR does **not** implement:

- real payload product generation;
- real storage writes;
- downlink queue execution;
- contact scheduling;
- RF behavior;
- ground integration;
- CCSDS/PUS/CFDP behavior;
- runtime skeleton generation.

The scenario assertion verifies that the simulator observed declared Mission Model evidence, not that a physical data product was stored or downlinked.

## Validation

Expected local validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric validate scenario examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
orbitfabric sim examples/demo-3u/scenarios/nominal_payload_acquisition.yaml \
  --json generated/reports/nominal_payload_acquisition_report.json
```

After local validation is confirmed, add the following squash/merge validation note:

```text
Validation:
- Local test suite executed successfully before merge.
- ruff check . passed.
- pytest passed.
- mkdocs build --strict passed.
- Scenario validation and simulation with JSON report generation passed.
```