### PR TITLE
feat(v0.6): add end-to-end data flow evidence scenario

### DIFF
--- a/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
+++ b/examples/demo-3u/scenarios/nominal_payload_acquisition.yaml
@@ -45,16 +45,6 @@ steps:
     expect_telemetry:
       payload.acquisition.active: true
 
-  - t: 9
-    expect:
-      data_flow:
-        data_product: payload.radiation_histogram
-        triggered_by_command: payload.start_acquisition
-        storage_intent_declared: true
-        downlink_intent_declared: true
-        eligible_downlink_flow: science_next_available_contact
-        contact_window: demo_contact_001
-
   - t: 20
     command: payload.stop_acquisition
     expect:

--- a/examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
+++ b/examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
@@ -1,0 +1,78 @@
+scenario:
+  id: payload_data_flow_evidence
+  name: Payload data flow evidence
+  description: Synthetic end-to-end scenario demonstrating contract-level evidence from payload commandability to data product, storage intent, downlink intent and contact assumptions.
+
+mission:
+  path: ../mission
+
+initial_state:
+  mode: NOMINAL
+  telemetry:
+    obc.mode: NOMINAL
+    eps.battery.voltage: 7.4
+    eps.battery.current: 0.4
+    payload.acquisition.active: false
+    radio.downlink.available: true
+
+steps:
+  - t: 0
+    expect_mode: NOMINAL
+
+  - t: 1
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
+
+  - t: 5
+    command: payload.start_acquisition
+    args:
+      duration_s: 120
+    expect:
+      command_status: ACCEPTED
+
+  - t: 6
+    expect_event: payload.acquisition_started
+
+  - t: 7
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: ACQUIRING
+
+  - t: 8
+    expect_telemetry:
+      payload.acquisition.active: true
+
+  - t: 9
+    expect:
+      data_flow:
+        data_product: payload.radiation_histogram
+        triggered_by_command: payload.start_acquisition
+        storage_intent_declared: true
+        downlink_intent_declared: true
+        eligible_downlink_flow: science_next_available_contact
+        contact_window: demo_contact_001
+
+  - t: 20
+    command: payload.stop_acquisition
+    expect:
+      command_status: ACCEPTED
+
+  - t: 21
+    expect_event: payload.acquisition_stopped
+
+  - t: 22
+    expect:
+      payload_lifecycle:
+        payload: demo_iod_payload
+        state: READY
+
+  - t: 23
+    expect_telemetry:
+      payload.acquisition.active: false
+
+  - t: 25
+    expect:
+      scenario_status: PASSED

--- a/tests/test_scenario_loader.py
+++ b/tests/test_scenario_loader.py
@@ -14,6 +14,7 @@ from orbitfabric.model.scenario_loader import ScenarioLoader
 
 DEMO_SCENARIO = Path("examples/demo-3u/scenarios/battery_low_during_payload.yaml")
 PAYLOAD_SCENARIO = Path("examples/demo-3u/scenarios/nominal_payload_acquisition.yaml")
+DATA_FLOW_SCENARIO = Path("examples/demo-3u/scenarios/payload_data_flow_evidence.yaml")
 runner = CliRunner()
 
 
@@ -26,10 +27,17 @@ def test_load_demo_scenario() -> None:
     assert len(loaded.scenario.steps) == 13
 
 
-def test_load_payload_scenario_with_data_flow_expectation() -> None:
+def test_load_payload_scenario() -> None:
     loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
 
     assert loaded.scenario.scenario.id == "nominal_payload_acquisition"
+    assert len(loaded.scenario.steps) == 11
+
+
+def test_load_data_flow_evidence_scenario() -> None:
+    loaded = ScenarioLoader().load(DATA_FLOW_SCENARIO)
+
+    assert loaded.scenario.scenario.id == "payload_data_flow_evidence"
     assert len(loaded.scenario.steps) == 12
 
 
@@ -62,6 +70,18 @@ def test_validate_scenario_cli_loads_demo_scenario() -> None:
     assert "Result: PASSED" in result.output
     assert "Timeline:" not in result.output
     assert "COMMAND payload.start_acquisition" not in result.output
+
+
+def test_validate_scenario_cli_loads_data_flow_evidence_scenario() -> None:
+    result = runner.invoke(app, ["validate", "scenario", str(DATA_FLOW_SCENARIO)])
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Scenario Validation {__version__}" in result.output
+    assert "Scenario: payload_data_flow_evidence" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Steps: 12" in result.output
+    assert "Result: PASSED" in result.output
+    assert "Timeline:" not in result.output
 
 
 def test_validate_scenario_cli_rejects_unknown_command(tmp_path: Path) -> None:
@@ -180,7 +200,7 @@ def test_scenario_loader_rejects_invalid_data_flow_references(
     new: str,
     expected_code: str,
 ) -> None:
-    scenario_path = _copy_payload_scenario_with_replacement(tmp_path, old, new)
+    scenario_path = _copy_data_flow_scenario_with_replacement(tmp_path, old, new)
 
     with pytest.raises(MissionModelError) as exc_info:
         ScenarioLoader().load(scenario_path)
@@ -267,7 +287,7 @@ def _copy_demo_scenario_with_mutation(
     return scenario_path
 
 
-def _copy_payload_scenario_with_replacement(
+def _copy_data_flow_scenario_with_replacement(
     tmp_path: Path,
     old: str,
     new: str,
@@ -276,7 +296,7 @@ def _copy_payload_scenario_with_replacement(
     demo_dir = tmp_path / "demo-3u"
     shutil.copytree(source, demo_dir)
 
-    scenario_path = demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"
+    scenario_path = demo_dir / "scenarios" / "payload_data_flow_evidence.yaml"
     scenario = scenario_path.read_text(encoding="utf-8")
     scenario_path.write_text(scenario.replace(old, new, 1), encoding="utf-8")
 

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -12,6 +12,7 @@ from orbitfabric.sim.runner import ScenarioRunner
 
 DEMO_SCENARIO = Path("examples/demo-3u/scenarios/battery_low_during_payload.yaml")
 PAYLOAD_SCENARIO = Path("examples/demo-3u/scenarios/nominal_payload_acquisition.yaml")
+DATA_FLOW_SCENARIO = Path("examples/demo-3u/scenarios/payload_data_flow_evidence.yaml")
 runner = CliRunner()
 
 
@@ -63,7 +64,7 @@ def test_runner_executes_nominal_payload_lifecycle_scenario() -> None:
 
 
 def test_runner_records_data_flow_evidence_for_declared_data_product() -> None:
-    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+    loaded = ScenarioLoader().load(DATA_FLOW_SCENARIO)
 
     result = ScenarioRunner().run(loaded)
 
@@ -91,7 +92,7 @@ def test_runner_records_data_flow_evidence_for_declared_data_product() -> None:
 
 
 def test_runner_checks_data_flow_expectation() -> None:
-    loaded = ScenarioLoader().load(PAYLOAD_SCENARIO)
+    loaded = ScenarioLoader().load(DATA_FLOW_SCENARIO)
 
     result = ScenarioRunner().run(loaded)
 
@@ -103,7 +104,7 @@ def test_runner_checks_data_flow_expectation() -> None:
 
 
 def test_runner_fails_missing_data_flow_expectation(tmp_path: Path) -> None:
-    scenario_path = _copy_payload_scenario_without_data_product_effect(tmp_path)
+    scenario_path = _copy_data_flow_scenario_without_data_product_effect(tmp_path)
     loaded = ScenarioLoader().load(scenario_path)
 
     result = ScenarioRunner().run(loaded)
@@ -135,13 +136,24 @@ def test_sim_cli_executes_nominal_payload_lifecycle_scenario() -> None:
     assert "PAYLOAD demo_iod_payload LIFECYCLE=READY" in result.output
     assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING" in result.output
+    assert "COMMAND payload.stop_acquisition -> ACCEPTED" in result.output
+    assert "Result: PASSED" in result.output
+
+
+def test_sim_cli_executes_data_flow_evidence_scenario() -> None:
+    result = runner.invoke(app, ["sim", str(DATA_FLOW_SCENARIO)])
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Scenario Simulator {__version__}" in result.output
+    assert "Scenario: payload_data_flow_evidence" in result.output
+    assert "COMMAND payload.start_acquisition -> ACCEPTED" in result.output
     assert "DATA_PRODUCT payload.radiation_histogram CONTRACT_EVIDENCE_RECORDED" in result.output
     assert "DATA_FLOW payload.radiation_histogram EXPECTATION_MET" in result.output
     assert "COMMAND payload.stop_acquisition -> ACCEPTED" in result.output
     assert "Result: PASSED" in result.output
 
 
-def _copy_payload_scenario_without_data_product_effect(tmp_path: Path) -> Path:
+def _copy_data_flow_scenario_without_data_product_effect(tmp_path: Path) -> Path:
     source = Path("examples/demo-3u")
     demo_dir = tmp_path / "demo-3u"
     shutil.copytree(source, demo_dir)
@@ -158,4 +170,4 @@ def _copy_payload_scenario_without_data_product_effect(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
 
-    return demo_dir / "scenarios" / "nominal_payload_acquisition.yaml"
+    return demo_dir / "scenarios" / "payload_data_flow_evidence.yaml"

--- a/tests/test_sim_json_report.py
+++ b/tests/test_sim_json_report.py
@@ -12,6 +12,7 @@ from orbitfabric.sim.json_report import simulation_result_to_dict
 from orbitfabric.sim.runner import ScenarioRunner
 
 DEMO_SCENARIO = Path("examples/demo-3u/scenarios/battery_low_during_payload.yaml")
+DATA_FLOW_SCENARIO = Path("examples/demo-3u/scenarios/payload_data_flow_evidence.yaml")
 runner = CliRunner()
 
 
@@ -65,6 +66,25 @@ def test_simulation_result_to_dict_for_demo_scenario() -> None:
     ]
 
 
+def test_simulation_result_to_dict_for_data_flow_evidence_scenario() -> None:
+    loaded = ScenarioLoader().load(DATA_FLOW_SCENARIO)
+    result = ScenarioRunner().run(loaded)
+
+    payload = simulation_result_to_dict(result)
+
+    assert payload["mission"] == "demo-3u"
+    assert payload["scenario"] == "payload_data_flow_evidence"
+    assert payload["result"] == "passed"
+    assert payload["summary"]["data_flow_evidence"] == 1
+    assert payload["summary"]["failed_expectations"] == 0
+    assert payload["data_flow_evidence"][0]["data_product_id"] == (
+        "payload.radiation_histogram"
+    )
+    assert payload["data_flow_evidence"][0]["triggered_by_command"] == (
+        "payload.start_acquisition"
+    )
+
+
 def test_sim_command_writes_json_report(tmp_path: Path) -> None:
     output_path = tmp_path / "battery_low_report.json"
 
@@ -92,3 +112,31 @@ def test_sim_command_writes_json_report(tmp_path: Path) -> None:
     assert payload["summary"]["data_flow_evidence"] == 1
     assert payload["data_flow_evidence"][0]["data_product_id"] == "payload.radiation_histogram"
     assert payload["data_flow_evidence"][0]["triggered_by_command"] == "payload.start_acquisition"
+
+
+def test_sim_command_writes_data_flow_evidence_json_report(tmp_path: Path) -> None:
+    output_path = tmp_path / "payload_data_flow_evidence_report.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "sim",
+            str(DATA_FLOW_SCENARIO),
+            "--json",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output_path.exists()
+    assert "JSON report written to" in result.output
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert payload["scenario"] == "payload_data_flow_evidence"
+    assert payload["result"] == "passed"
+    assert payload["summary"]["data_flow_evidence"] == 1
+    assert payload["summary"]["failed_expectations"] == 0
+    assert payload["data_flow_evidence"][0]["data_product_id"] == (
+        "payload.radiation_histogram"
+    )


### PR DESCRIPTION
## Summary

This PR continues the `v0.6.0 — End-to-End Mission Data Flow Evidence` milestone by adding a dedicated scenario for data-flow evidence.

PR #105 made data-flow evidence scenario-checkable. This PR separates the public proof scenario from the nominal payload lifecycle scenario, so the demo set has clearer intent:

- `nominal_payload_acquisition.yaml` remains focused on payload lifecycle behavior.
- `payload_data_flow_evidence.yaml` demonstrates contract-level end-to-end evidence from commandability to data product, storage intent, downlink intent and contact assumptions.

## Changes

- Adds `examples/demo-3u/scenarios/payload_data_flow_evidence.yaml`.
- Moves the data-flow assertion out of `nominal_payload_acquisition.yaml`.
- Adds scenario loader coverage for the dedicated data-flow evidence scenario.
- Adds simulator coverage for the dedicated data-flow evidence scenario.
- Adds JSON report coverage for the dedicated data-flow evidence scenario.

## Architectural boundary

This remains synthetic, deterministic, host-side evidence.

This PR does **not** implement:

- real payload data generation;
- file creation;
- onboard storage runtime;
- queue execution;
- contact scheduling;
- RF/downlink execution;
- ground segment integration;
- CCSDS/PUS/CFDP behavior;
- runtime skeleton generation.

The scenario proves traceability through declared Mission Model contracts and simulator evidence, not physical data movement.

## Validation

Expected local validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric validate scenario examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
  --json generated/reports/payload_data_flow_evidence_report.json
```

After local validation is confirmed, add the following squash/merge validation note:

```text
Validation:
- Local test suite executed successfully before merge.
- ruff check . passed.
- pytest passed.
- mkdocs build --strict passed.
- Dedicated data-flow scenario validation and simulation with JSON report generation passed.
```