### PR TITLE
feat(v0.6): generate data flow evidence docs

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from orbitfabric import __version__
+from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.lint.engine import LintEngine
 from orbitfabric.lint.finding import LintReport
@@ -148,6 +149,50 @@ def gen_docs(
     for path in generated_files:
         typer.echo(f"  {path}")
 
+    typer.echo("\nResult: PASSED")
+
+
+@gen_app.command("data-flow")
+def gen_data_flow(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory used to generate data-flow documentation.",
+        ),
+    ],
+    output_file: Annotated[
+        Path,
+        typer.Option(
+            "--output-file",
+            help="Markdown file where data-flow documentation will be written.",
+        ),
+    ] = Path("generated/docs/data_flow.md"),
+) -> None:
+    """Generate Markdown data-flow documentation from a Mission Model."""
+    typer.echo(f"OrbitFabric Data Flow Docs Generator {__version__}")
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    report = LintEngine().run(model)
+    if report.has_errors:
+        _print_loaded_model_summary(model)
+        _print_lint_report(report)
+        typer.echo("\nData-flow documentation generation aborted because lint errors exist.")
+        raise typer.Exit(code=1)
+
+    generated_file = generate_data_flow_markdown_doc(model, output_file)
+
+    typer.echo(f"\nMission: {model.spacecraft.id}")
+    typer.echo(f"Model version: {model.spacecraft.model_version}")
+    typer.echo(f"Generated file: {generated_file}")
     typer.echo("\nResult: PASSED")
 
 

--- a/src/orbitfabric/gen/data_flow.py
+++ b/src/orbitfabric/gen/data_flow.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.model.mission import (
+    Command,
+    DataProductContract,
+    DownlinkFlowContract,
+    MissionModel,
+)
+
+
+@dataclass(frozen=True)
+class DataFlowDocRecord:
+    command: Command
+    data_product: DataProductContract
+    downlink_flows: list[DownlinkFlowContract]
+    contact_windows: list[str]
+
+
+def generate_data_flow_markdown_doc(
+    model: MissionModel,
+    output_file: Path,
+) -> Path:
+    """Generate a Markdown data-flow evidence reference from a Mission Model."""
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(_render_data_flow_doc(model), encoding="utf-8")
+    return output_file
+
+
+def _render_data_flow_doc(model: MissionModel) -> str:
+    records = _data_flow_records(model)
+    data_product_ids = {record.data_product.id for record in records}
+    downlink_flow_ids = {
+        flow.id for record in records for flow in record.downlink_flows
+    }
+    contact_window_ids = {
+        window_id for record in records for window_id in record.contact_windows
+    }
+
+    lines = [_header("Mission Data Flow Evidence Reference", model)]
+
+    lines.append("## Summary\n\n")
+    lines.append(f"- Declared data-flow paths: `{len(records)}`\n")
+    lines.append(f"- Data products with command effects: `{len(data_product_ids)}`\n")
+    lines.append(f"- Downlink flows involved: `{len(downlink_flow_ids)}`\n")
+    lines.append(f"- Contact windows involved: `{len(contact_window_ids)}`\n\n")
+    lines.append(
+        "This document is generated from declared Mission Model contracts. "
+        "It traces command expected effects to data products, storage intent, "
+        "downlink intent, eligible downlink flows and matching contact windows. "
+        "It does not imply real payload file generation, onboard storage writes, "
+        "queue execution, contact scheduling, RF behavior or ground integration.\n\n"
+    )
+
+    lines.append("## Declared data-flow paths\n\n")
+
+    if not records:
+        lines.append("No command-declared data-flow paths found.\n")
+        return "".join(lines)
+
+    lines.append(
+        "| Command | Data Product | Producer | Storage Intent | Downlink Intent | "
+        "Eligible Downlink Flows | Matching Contact Windows |\n"
+    )
+    lines.append("|---|---|---|---|---|---|---|\n")
+
+    for record in records:
+        lines.append(_render_record_row(model, record))
+
+    return "".join(lines)
+
+
+def _data_flow_records(model: MissionModel) -> list[DataFlowDocRecord]:
+    data_products = {data_product.id: data_product for data_product in model.data_products}
+    records: list[DataFlowDocRecord] = []
+
+    for command in sorted(model.commands, key=lambda item: item.id):
+        data_product_ids = command.expected_effects.get("data_products")
+        if not isinstance(data_product_ids, list):
+            continue
+
+        for data_product_id in data_product_ids:
+            if not isinstance(data_product_id, str):
+                continue
+
+            data_product = data_products.get(data_product_id)
+            if data_product is None:
+                continue
+
+            flows = _eligible_downlink_flows(model, data_product.id)
+            records.append(
+                DataFlowDocRecord(
+                    command=command,
+                    data_product=data_product,
+                    downlink_flows=flows,
+                    contact_windows=_matching_contact_windows(model, flows),
+                )
+            )
+
+    return records
+
+
+def _eligible_downlink_flows(
+    model: MissionModel,
+    data_product_id: str,
+) -> list[DownlinkFlowContract]:
+    return [
+        flow
+        for flow in sorted(model.contacts.downlink_flows, key=lambda item: item.id)
+        if data_product_id in flow.eligible_data_products
+    ]
+
+
+def _matching_contact_windows(
+    model: MissionModel,
+    flows: list[DownlinkFlowContract],
+) -> list[str]:
+    windows: set[str] = set()
+
+    for flow in flows:
+        for window in model.contacts.contact_windows:
+            if window.contact_profile != flow.contact_profile:
+                continue
+            if window.link_profile != flow.link_profile:
+                continue
+            windows.add(window.id)
+
+    return sorted(windows)
+
+
+def _render_record_row(model: MissionModel, record: DataFlowDocRecord) -> str:
+    return (
+        f"| {_code(record.command.id)} "
+        f"| {_code(record.data_product.id)} "
+        f"| {_producer_heading(model, record.data_product)} "
+        f"| {_format_storage_intent(record.data_product)} "
+        f"| {_format_downlink_intent(record.data_product)} "
+        f"| {_format_list([flow.id for flow in record.downlink_flows])} "
+        f"| {_format_list(record.contact_windows)} |\n"
+    )
+
+
+def _header(title: str, model: MissionModel) -> str:
+    return (
+        f"# {title}\n\n"
+        f"Mission: `{model.spacecraft.id}`  \n"
+        f"Model version: `{model.spacecraft.model_version}`  \n"
+        "Generated by OrbitFabric. Do not edit manually.\n\n"
+        "This page is generated from the validated Mission Model.\n\n"
+    )
+
+
+def _producer_heading(model: MissionModel, data_product: DataProductContract) -> str:
+    if data_product.producer_type != "subsystem":
+        return f"{_code(data_product.producer)} ({_code(data_product.producer_type)})"
+
+    subsystems = {subsystem.id: subsystem for subsystem in model.subsystems}
+    subsystem = subsystems.get(data_product.producer)
+    if subsystem is None:
+        return _code(data_product.producer)
+
+    return f"{_code(data_product.producer)} - {_text(subsystem.name)}"
+
+
+def _format_storage_intent(data_product: DataProductContract) -> str:
+    storage = data_product.storage
+    if storage is None:
+        return "-"
+
+    lines = [f"class {_code(storage.storage_class)}"]
+
+    if storage.retention is not None:
+        lines.append(f"retention {_code(storage.retention)}")
+
+    if storage.overflow_policy is not None:
+        lines.append(f"overflow {_code(storage.overflow_policy)}")
+
+    return _line_break_join(lines)
+
+
+def _format_downlink_intent(data_product: DataProductContract) -> str:
+    downlink = data_product.downlink
+    if downlink is None or downlink.policy is None:
+        return "-"
+
+    return f"policy {_code(downlink.policy)}"
+
+
+def _format_list(values: list[str]) -> str:
+    if not values:
+        return "-"
+
+    return ", ".join(_code(value) for value in values)
+
+
+def _line_break_join(values: list[str]) -> str:
+    items = [value for value in values if value]
+    if not items:
+        return "-"
+
+    return "<br>".join(items)
+
+
+def _code(value: Any) -> str:
+    return f"`{_text(_format_plain_value(value))}`"
+
+
+def _format_plain_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _text(value: str) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,35 @@ def test_lint_loads_demo_mission() -> None:
     assert "Result: PASSED" in result.output
 
 
+def test_gen_data_flow_docs_writes_markdown(tmp_path: Path) -> None:
+    output_file = tmp_path / "data_flow.md"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "data-flow",
+            "examples/demo-3u/mission",
+            "--output-file",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Data Flow Docs Generator {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert f"Generated file: {output_file}" in result.output
+    assert "Result: PASSED" in result.output
+    assert output_file.exists()
+
+    content = output_file.read_text(encoding="utf-8")
+    assert "# Mission Data Flow Evidence Reference" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`payload.radiation_histogram`" in content
+    assert "`science_next_available_contact`" in content
+    assert "`demo_contact_001`" in content
+
+
 def test_inspect_mission_loads_demo_mission() -> None:
     result = runner.invoke(app, ["inspect", "mission", "examples/demo-3u/mission"])
 

--- a/tests/test_data_flow_docs_generator.py
+++ b/tests/test_data_flow_docs_generator.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_generate_data_flow_markdown_doc(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    output_file = tmp_path / "data_flow.md"
+
+    generated_file = generate_data_flow_markdown_doc(model, output_file)
+
+    assert generated_file == output_file
+    assert output_file.exists()
+
+    content = output_file.read_text(encoding="utf-8")
+
+    assert "# Mission Data Flow Evidence Reference" in content
+    assert "Mission: `demo-3u`" in content
+    assert "Declared data-flow paths: `1`" in content
+    assert "Data products with command effects: `1`" in content
+    assert "Downlink flows involved: `1`" in content
+    assert "Contact windows involved: `1`" in content
+    assert "This document is generated from declared Mission Model contracts." in content
+    assert "It does not imply real payload file generation" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`payload.radiation_histogram`" in content
+    assert "`demo_iod_payload` (`payload`)" in content
+    assert "class `science`" in content
+    assert "retention `7d`" in content
+    assert "overflow `drop_oldest`" in content
+    assert "policy `next_available_contact`" in content
+    assert "`science_next_available_contact`" in content
+    assert "`demo_contact_001`" in content
+
+
+def test_generate_data_flow_markdown_doc_without_command_effects(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    for command in model.commands:
+        command.expected_effects.pop("data_products", None)
+
+    output_file = tmp_path / "data_flow.md"
+
+    generate_data_flow_markdown_doc(model, output_file)
+
+    content = output_file.read_text(encoding="utf-8")
+
+    assert "Declared data-flow paths: `0`" in content
+    assert "No command-declared data-flow paths found." in content


### PR DESCRIPTION
## Summary

This PR continues the `v0.6.0 — End-to-End Mission Data Flow Evidence` milestone by adding a generated Markdown artifact for Mission Model data-flow evidence.

The new generator creates a static, human-readable view of declared command-to-data-product paths:

```text
command -> data product -> storage intent -> downlink intent -> downlink flow -> contact window
```

## Changes

- Adds `src/orbitfabric/gen/data_flow.py`.
- Adds a new CLI command:

```bash
orbitfabric gen data-flow examples/demo-3u/mission \
  --output-file generated/docs/data_flow.md
```

- Generates `data_flow.md` from the validated Mission Model.
- Adds Markdown generator tests.
- Adds CLI coverage for the new generator.

## Architectural boundary

This is static documentation generated from declared contracts only.

It does **not** implement:

- real payload file generation;
- onboard storage writes;
- downlink queue execution;
- contact scheduling;
- RF behavior;
- ground integration;
- CCSDS/PUS/CFDP behavior;
- runtime skeleton generation.

The artifact is intended to make the v0.6 evidence chain readable and reviewable, while keeping the Mission Model as the source of truth.

## Validation

Expected local validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric gen data-flow examples/demo-3u/mission \
  --output-file generated/docs/data_flow.md
```

After local validation is confirmed, add the following squash/merge validation note:

```text
Validation:
- Local test suite executed successfully before merge.
- ruff check . passed.
- pytest passed.
- mkdocs build --strict passed.
- Data-flow Markdown documentation generated successfully.
```