### PR TITLE
feat(v0.6): include data flow reference in generated docs

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -141,6 +141,9 @@ def gen_docs(
         raise typer.Exit(code=1)
 
     generated_files = generate_markdown_docs(model, output_dir)
+    generated_files.append(
+        generate_data_flow_markdown_doc(model, output_dir / "data_flow.md")
+    )
 
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,38 @@ def test_lint_loads_demo_mission() -> None:
     assert "Result: PASSED" in result.output
 
 
+def test_gen_docs_includes_data_flow_reference(tmp_path: Path) -> None:
+    output_dir = tmp_path / "docs"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "docs",
+            "examples/demo-3u/mission",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Docs Generator {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert f"Output directory: {output_dir}" in result.output
+    assert f"  {output_dir / 'data_flow.md'}" in result.output
+    assert "Result: PASSED" in result.output
+
+    data_flow_path = output_dir / "data_flow.md"
+    assert data_flow_path.exists()
+
+    content = data_flow_path.read_text(encoding="utf-8")
+    assert "# Mission Data Flow Evidence Reference" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`payload.radiation_histogram`" in content
+    assert "`science_next_available_contact`" in content
+    assert "`demo_contact_001`" in content
+
+
 def test_gen_data_flow_docs_writes_markdown(tmp_path: Path) -> None:
     output_file = tmp_path / "data_flow.md"
 


### PR DESCRIPTION
## Summary

This PR completes the v0.6 documentation path by making the standard docs generator include the Mission Data Flow Evidence Reference.

After this change:

```bash
orbitfabric gen docs examples/demo-3u/mission
```

also generates:

```text
generated/docs/data_flow.md
```

The dedicated command remains available for targeted regeneration:

```bash
orbitfabric gen data-flow examples/demo-3u/mission \
  --output-file generated/docs/data_flow.md
```

## Changes

- Appends `data_flow.md` to the files produced by `orbitfabric gen docs`.
- Adds CLI coverage proving that `gen docs` writes and reports the generated data-flow reference.
- Keeps the existing dedicated `gen data-flow` command unchanged.

## Architectural boundary

This is documentation integration only.

It does **not** change:

- Mission Model schema;
- scenario semantics;
- simulator behavior;
- JSON evidence format;
- storage/downlink runtime behavior;
- contact scheduling;
- runtime skeleton generation;
- ground integration artifacts.

## Validation

Expected local validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric gen docs examples/demo-3u/mission
```

Expected generated file:

```text
generated/docs/data_flow.md
```

After local validation is confirmed, add the following squash/merge validation note:

```text
Validation:
- Local test suite executed successfully before merge.
- ruff check . passed.
- pytest passed.
- mkdocs build --strict passed.
- Standard docs generation produced generated/docs/data_flow.md.
```