### PR TITLE
chore: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a reproducible OrbitFabric problem
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible problems in the OrbitFabric toolchain.
+
+        Do not include proprietary mission data, private spacecraft information, operational logs, export-controlled material or NDA-protected details.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the problem clearly.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Mission Model loading / validation
+        - Semantic lint rules
+        - Scenario loading / validation
+        - Scenario simulation
+        - JSON reports
+        - Documentation generation
+        - Generated artifacts
+        - Example missions
+        - CLI
+        - CI / tooling
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the minimal public or synthetic steps required to reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: command-output
+    attributes:
+      label: Command output or diagnostics
+      description: Paste only non-sensitive output.
+      render: text
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Python version, OrbitFabric version, OS and installation mode.
+      placeholder: |
+        Python:
+        OrbitFabric:
+        OS:
+        Install mode:
+  - type: checkboxes
+    id: clean-room
+    attributes:
+      label: Clean-room confirmation
+      options:
+        - label: This issue does not include proprietary, confidential, export-controlled or NDA-protected material.
+          required: true

--- a/.github/ISSUE_TEMPLATE/clean_room_concern.yml
+++ b/.github/ISSUE_TEMPLATE/clean_room_concern.yml
@@ -1,0 +1,53 @@
+name: Clean-room concern
+description: Report a possible clean-room, confidentiality or provenance concern
+title: "clean-room: "
+labels: ["clean-room"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for public, non-sensitive clean-room concerns.
+
+        Do not publish confidential, proprietary, export-controlled or NDA-protected details. If the concern is sensitive, contact the maintainer privately instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the concern without exposing sensitive details.
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Identify the file, page, example or discussion where the concern appears.
+    validations:
+      required: true
+  - type: dropdown
+    id: concern-type
+    attributes:
+      label: Concern type
+      options:
+        - Possible proprietary mission data
+        - Possible private spacecraft architecture
+        - Possible private packet format
+        - Possible real operational log
+        - Possible non-public payload detail
+        - Possible real bus map or pinout
+        - Possible employer-owned or customer-owned material
+        - Possible export-controlled or NDA-protected material
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-action
+    attributes:
+      label: Suggested action
+      description: Suggest whether the content should be removed, generalized, rewritten or reviewed privately.
+  - type: checkboxes
+    id: public-safety
+    attributes:
+      label: Public disclosure confirmation
+      options:
+        - label: This issue does not itself disclose confidential, proprietary, export-controlled or NDA-protected material.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/FAROTECH/orbitfabric/security
+    about: Please do not report security vulnerabilities through public issues.

--- a/.github/ISSUE_TEMPLATE/documentation_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.yml
@@ -1,0 +1,43 @@
+name: Documentation feedback
+description: Report unclear, missing or outdated documentation
+title: "docs: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: page
+    attributes:
+      label: Documentation page or section
+      description: Link or name the affected page, section or file.
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is unclear, missing or outdated?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Propose wording or structure if useful.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Minor wording issue
+        - Missing explanation
+        - Outdated release/version information
+        - Incorrect technical statement
+        - Misleading architectural boundary
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: clean-room
+    attributes:
+      label: Clean-room confirmation
+      options:
+        - label: This issue does not include proprietary, confidential, export-controlled or NDA-protected material.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Propose a focused OrbitFabric capability
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for focused feature proposals.
+
+        OrbitFabric grows through coherent vertical slices, not feature accumulation.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the requested capability.
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Related roadmap area
+      options:
+        - v0.7 Generated Runtime Skeletons
+        - v0.8 Ground Integration Artifacts
+        - v0.9 Plugin and Extensibility Layer
+        - v1.0 Stable Mission Data Contract
+        - Backlog / parking lot
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      multiple: true
+      options:
+        - Mission Model
+        - Lint rules
+        - Scenario simulation
+        - Documentation generation
+        - JSON reports
+        - Runtime skeleton generation
+        - Ground integration artifacts
+        - Plugin/extensibility layer
+        - Example missions
+        - CI / tooling
+        - Public documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: Engineering value
+      description: Explain what problem this solves and why it belongs in OrbitFabric.
+    validations:
+      required: true
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Architectural boundary
+      description: State what this feature should intentionally not implement.
+    validations:
+      required: true
+  - type: checkboxes
+    id: clean-room
+    attributes:
+      label: Clean-room confirmation
+      options:
+        - label: This request does not include proprietary, confidential, export-controlled or NDA-protected material.
+          required: true

--- a/.github/ISSUE_TEMPLATE/mission_model_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/mission_model_feedback.yml
@@ -1,0 +1,69 @@
+name: Mission Model feedback
+description: Suggest or discuss Mission Data Contract semantics
+title: "model: "
+labels: ["model", "feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for feedback on OrbitFabric Mission Model semantics.
+
+        Keep examples synthetic or based only on public information.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What Mission Model concept, field or relation should be discussed?
+    validations:
+      required: true
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Mission Model domain
+      multiple: true
+      options:
+        - spacecraft
+        - subsystems
+        - modes
+        - telemetry
+        - commands
+        - events
+        - faults
+        - packets
+        - policies
+        - payloads
+        - data_products
+        - contacts
+        - commandability
+        - scenarios
+        - data-flow evidence
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain the engineering reason for the suggested change or clarification.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed model shape or behavior
+      description: Include YAML only if it is synthetic or public-material-derived.
+      render: yaml
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Boundary
+      description: State what this suggestion should not turn OrbitFabric into.
+      placeholder: |
+        This should not introduce flight runtime behavior, real storage execution, real downlink scheduling, CCSDS/PUS/CFDP runtime behavior, or ground segment implementation.
+  - type: checkboxes
+    id: clean-room
+    attributes:
+      label: Clean-room confirmation
+      options:
+        - label: This issue does not include proprietary, confidential, export-controlled or NDA-protected material.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,112 @@
+## Summary
+
+Describe the purpose of this pull request.
+
+State the milestone or project area when relevant, for example:
+
+`v0.7 — Generated Runtime Skeletons`
+
+## Changes
+
+List the concrete changes introduced by this PR.
+
+- 
+- 
+- 
+
+## Affected Area
+
+Select all that apply:
+
+- [ ] Mission Model
+- [ ] Model loading / validation
+- [ ] Semantic lint rules
+- [ ] Scenario loading / validation
+- [ ] Scenario simulation
+- [ ] JSON reports
+- [ ] Documentation generation
+- [ ] Generated artifacts
+- [ ] Example missions
+- [ ] CI / tooling
+- [ ] Public documentation
+- [ ] Release alignment
+- [ ] Other
+
+## Mission Data Contract Impact
+
+Does this PR change Mission Data Contract semantics?
+
+- [ ] No
+- [ ] Yes
+
+If yes, describe the impact clearly.
+
+Examples:
+
+- new model field
+- new reference rule
+- new lint diagnostic
+- new generated artifact
+- changed JSON report structure
+- changed scenario expectation semantics
+
+## Architectural Boundary
+
+State what this PR intentionally does **not** implement.
+
+This section is required for any non-trivial change.
+
+Examples:
+
+- real flight runtime
+- real onboard storage runtime
+- real downlink queue execution
+- real contact scheduling
+- RF/link-budget behavior
+- CCSDS/PUS/CFDP runtime behavior
+- ground segment implementation
+- operator console
+- command authentication/authorization
+- runtime skeleton generation
+- flight-ready software
+
+## Clean-Room Confirmation
+
+By opening this PR, I confirm that this contribution does not include:
+
+- [ ] proprietary mission data
+- [ ] private spacecraft architecture
+- [ ] private packet formats
+- [ ] real operational logs
+- [ ] non-public payload details
+- [ ] real bus maps or pinouts
+- [ ] employer-owned or customer-owned code
+- [ ] export-controlled or NDA-protected material
+
+All examples are synthetic or derived only from public information.
+
+## Validation
+
+Select the checks that were run.
+
+- [ ] `ruff check .`
+- [ ] `pytest`
+- [ ] `mkdocs build --strict`
+- [ ] `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
+- [ ] `orbitfabric gen docs examples/demo-3u/mission/`
+- [ ] `orbitfabric gen data-flow examples/demo-3u/mission/ --output-file generated/docs/data_flow.md`
+- [ ] `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`
+- [ ] `orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml --json generated/reports/payload_data_flow_evidence_report.json --log generated/logs/payload_data_flow_evidence.log`
+
+If some checks were not run, explain why.
+
+## Generated Artifacts
+
+- [ ] This PR does not commit generated artifacts.
+- [ ] This PR intentionally updates generated artifacts.
+
+If generated artifacts are committed, explain why.
+
+## Notes for Review
+
+Add anything the reviewer should pay attention to.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,22 @@ jobs:
       - name: Generate demo mission docs
         run: orbitfabric gen docs examples/demo-3u/mission/
 
-      - name: Run demo scenario
+      - name: Generate data flow evidence docs
+        run: |
+          orbitfabric gen data-flow examples/demo-3u/mission/ \
+            --output-file generated/docs/data_flow.md
+
+      - name: Run battery-low demo scenario
         run: |
           orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
             --json generated/reports/battery_low_during_payload_report.json \
             --log generated/logs/battery_low_during_payload.log
+
+      - name: Run payload data flow evidence scenario
+        run: |
+          orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
+            --json generated/reports/payload_data_flow_evidence_report.json \
+            --log generated/logs/payload_data_flow_evidence.log
 
       - name: Build documentation site
         run: mkdocs build --strict

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+OrbitFabric is an open-source engineering project.
+
+All participants are expected to keep discussions technical, respectful and constructive.
+
+Unacceptable behavior includes harassment, personal attacks, discriminatory language, deliberate disruption, or publishing private, confidential, proprietary, export-controlled or NDA-protected information.
+
+Project maintainers may remove content, close discussions or restrict participation when behavior is inconsistent with these expectations.
+
+For project-specific contribution boundaries, see:
+
+```text
+CONTRIBUTING.md
+docs/CLEAN_ROOM_POLICY.md
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.4.0 — Contact Windows and Downlink Flow Contracts`.
+The current public baseline is `v0.6.0 — End-to-End Mission Data Flow Evidence`.
 
-The next development focus is `v0.5 — Commandability and Autonomy Contracts`.
+The next development focus is `v0.7 — Generated Runtime Skeletons`.
 
 The current baseline proves this Mission Data Chain:
 
@@ -23,6 +23,8 @@ Payload Contract
   -> Downlink Intent
   -> Contact Window Assumption
   -> Downlink Flow Contract
+  -> Commandability and Autonomy Contract
+  -> End-to-End Mission Data Flow Evidence
 ```
 
 Do not add large integrations before the contract model is coherent.
@@ -45,6 +47,8 @@ Out of scope for the current preview:
 - web UI;
 - database-backed telemetry archive;
 - real spacecraft data.
+
+The next milestone may generate runtime skeletons, but those skeletons must remain host-buildable integration starting points. They must not be presented as flight-ready software, a complete OBC framework or a replacement for cFS or F Prime.
 
 ---
 
@@ -100,7 +104,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.4.0
+orbitfabric 0.6.0
 ```
 
 ---
@@ -118,11 +122,21 @@ mkdocs build --strict
 Then verify the demo vertical slice:
 
 ```bash
-orbitfabric lint examples/demo-3u/mission/   --json generated/reports/lint_report.json
+orbitfabric lint examples/demo-3u/mission/ \
+  --json generated/reports/lint_report.json
 
 orbitfabric gen docs examples/demo-3u/mission/
 
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml   --json generated/reports/battery_low_during_payload_report.json   --log generated/logs/battery_low_during_payload.log
+orbitfabric gen data-flow examples/demo-3u/mission/ \
+  --output-file generated/docs/data_flow.md
+
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+
+orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
+  --json generated/reports/payload_data_flow_evidence_report.json \
+  --log generated/logs/payload_data_flow_evidence.log
 ```
 
 Expected result:
@@ -133,6 +147,7 @@ pytest        -> passing
 mkdocs        -> passing
 lint          -> Result: PASSED
 gen docs      -> Result: PASSED
+gen data-flow -> Result: PASSED
 sim           -> Result: PASSED
 ```
 
@@ -202,7 +217,7 @@ Good examples:
 ```text
 Add contact downlink consistency rules
 Generate contact downlink documentation
-Align public documentation with v0.4
+Align public documentation with v0.6
 Fix scenario command validation
 ```
 
@@ -222,9 +237,14 @@ misc
 A good pull request should include:
 
 - a clear description of the change;
+- the affected project area or milestone;
+- explicit Mission Data Contract impact;
+- an architectural boundary statement for non-trivial changes;
 - tests when behavior changes;
 - updated documentation when user-facing behavior changes;
 - confirmation that local checks pass;
 - no generated artifacts unless explicitly required.
 
 Generated outputs under `generated/` are reproducible artifacts and should normally not be committed.
+
+Use the repository pull request template and keep the `Architectural Boundary`, `Clean-Room Confirmation` and `Validation` sections meaningful.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+OrbitFabric is currently in pre-1.0 development.
+
+Only the latest public release and the current `main` branch are considered for security fixes.
+
+Older pre-1.0 snapshots are not maintained as security-supported baselines.
+
+## Reporting a Vulnerability
+
+Please do not report suspected security vulnerabilities through public issues.
+
+Use GitHub private vulnerability reporting when available, or contact the maintainers privately through a non-public channel.
+
+Do not include proprietary mission data, private spacecraft information, operational logs, credentials, tokens, export-controlled material or NDA-protected details in any report.
+
+## Scope
+
+OrbitFabric is a Mission Data Contract framework.
+
+It is not flight-ready onboard software, not a ground segment, not a command uplink service, not an authentication system and not an operational spacecraft control system.
+
+Security reports should focus on the OrbitFabric toolchain, model parsing, generated artifacts, dependency handling, repository workflows and documentation that could mislead users about operational readiness.


### PR DESCRIPTION
## Summary

This PR completes the GitHub community health setup for OrbitFabric and aligns the contribution flow with the current `v0.6.0 — End-to-End Mission Data Flow Evidence` baseline.

It adds project-specific community files, issue templates and a pull request template shaped around OrbitFabric's Mission Data Contract discipline.

## Changes

- Adds `CODE_OF_CONDUCT.md`.
- Adds `SECURITY.md`.
- Adds a project-specific pull request template.
- Adds issue templates for bugs, Mission Model feedback, feature requests, documentation feedback and clean-room concerns.
- Disables blank issues and routes security reports away from public issues.
- Updates `CONTRIBUTING.md` from the old v0.4/v0.5 focus to the current v0.6/v0.7 focus.
- Updates required contribution checks to include data-flow evidence generation and simulation.
- Extends CI to run the dedicated data-flow docs generator and the `payload_data_flow_evidence` scenario.

## Affected Area

- [ ] Mission Model
- [ ] Model loading / validation
- [ ] Semantic lint rules
- [ ] Scenario loading / validation
- [ ] Scenario simulation
- [ ] JSON reports
- [ ] Documentation generation
- [ ] Generated artifacts
- [ ] Example missions
- [x] CI / tooling
- [x] Public documentation
- [ ] Release alignment
- [x] Other

## Mission Data Contract Impact

Does this PR change Mission Data Contract semantics?

- [x] No
- [ ] Yes

This PR does not change model semantics, lint semantics, scenario semantics, JSON report structure or generated artifact formats.

## Architectural Boundary

This PR intentionally does **not** implement:

- new Mission Model fields;
- new lint diagnostics;
- new simulator behavior;
- runtime skeleton generation;
- real flight runtime;
- real onboard storage runtime;
- real downlink queue execution;
- real contact scheduling;
- RF/link-budget behavior;
- CCSDS/PUS/CFDP runtime behavior;
- ground segment implementation;
- flight-ready software.

The changes are limited to repository community health, contribution process alignment and CI coverage for the existing v0.6 evidence path.

## Clean-Room Confirmation

By opening this PR, I confirm that this contribution does not include:

- [x] proprietary mission data
- [x] private spacecraft architecture
- [x] private packet formats
- [x] real operational logs
- [x] non-public payload details
- [x] real bus maps or pinouts
- [x] employer-owned or customer-owned code
- [x] export-controlled or NDA-protected material

All examples are synthetic or derived only from public information.

## Validation

Expected CI validation:

- [x] `ruff check .`
- [x] `pytest`
- [x] `mkdocs build --strict`
- [x] `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
- [x] `orbitfabric gen docs examples/demo-3u/mission/`
- [x] `orbitfabric gen data-flow examples/demo-3u/mission/ --output-file generated/docs/data_flow.md`
- [x] `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`
- [x] `orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml --json generated/reports/payload_data_flow_evidence_report.json --log generated/logs/payload_data_flow_evidence.log`

I did not run local tests from this environment. CI should be treated as the execution authority for this PR.

## Generated Artifacts

- [x] This PR does not commit generated artifacts.
- [ ] This PR intentionally updates generated artifacts.

## Notes for Review

Review focus:

- issue templates are intentionally OrbitFabric-specific rather than generic;
- the pull request template formalizes the structure already used in recent project PRs;
- `CONTRIBUTING.md` now matches the v0.6 baseline and v0.7 next milestone;
- CI now verifies the v0.6 data-flow evidence path explicitly.