### PR TITLE
feat: add runtime contract model

### DIFF
--- a/src/orbitfabric/gen/runtime/__init__.py
+++ b/src/orbitfabric/gen/runtime/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from orbitfabric.gen.runtime.builder import build_runtime_contract
+from orbitfabric.gen.runtime.contract import RuntimeContract
+
+__all__ = ["RuntimeContract", "build_runtime_contract"]

--- a/src/orbitfabric/gen/runtime/builder.py
+++ b/src/orbitfabric/gen/runtime/builder.py
@@ -11,7 +11,6 @@ from orbitfabric.gen.runtime.contract import (
 from orbitfabric.gen.runtime.naming import to_pascal_case
 from orbitfabric.model.mission import (
     Command,
-    CommandArgument,
     DataProductContract,
     MissionModel,
 )

--- a/src/orbitfabric/gen/runtime/builder.py
+++ b/src/orbitfabric/gen/runtime/builder.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from orbitfabric.gen.runtime.contract import (
+    RuntimeArgument,
+    RuntimeCommand,
+    RuntimeContract,
+    RuntimeElement,
+)
+from orbitfabric.gen.runtime.naming import to_pascal_case
+from orbitfabric.model.mission import (
+    Command,
+    CommandArgument,
+    DataProductContract,
+    MissionModel,
+)
+
+
+def build_runtime_contract(
+    model: MissionModel,
+    *,
+    generation_profile: str = "cpp17",
+) -> RuntimeContract:
+    """Build the runtime-facing contract surface from a validated Mission Model."""
+    return RuntimeContract(
+        mission_id=model.spacecraft.id,
+        mission_name=model.spacecraft.name,
+        model_version=model.spacecraft.model_version,
+        generation_profile=generation_profile,
+        modes=_mode_elements(model),
+        telemetry=_telemetry_elements(model),
+        commands=_command_elements(model),
+        events=_event_elements(model),
+        faults=_fault_elements(model),
+        packets=_packet_elements(model),
+        payloads=_payload_elements(model),
+        data_products=_data_product_elements(model),
+        storage_policies=_storage_policy_elements(model.data_products),
+        downlink_policies=_downlink_policy_elements(model.data_products),
+    )
+
+
+def _mode_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=mode_id,
+            symbol_name=to_pascal_case(mode_id),
+            numeric_id=index,
+            description=mode.description,
+            metadata={"initial": mode.initial},
+        )
+        for index, (mode_id, mode) in enumerate(sorted(model.modes.items()), start=1)
+    )
+
+
+def _telemetry_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=item.id,
+            symbol_name=to_pascal_case(item.id),
+            numeric_id=index,
+            description=item.description,
+            metadata={
+                "type": item.type,
+                "unit": item.unit,
+                "source": item.source,
+                "criticality": item.criticality,
+                "persistence": item.persistence,
+                "downlink_priority": item.downlink_priority,
+            },
+        )
+        for index, item in enumerate(sorted(model.telemetry, key=lambda item: item.id), start=1)
+    )
+
+
+def _command_elements(model: MissionModel) -> tuple[RuntimeCommand, ...]:
+    return tuple(
+        RuntimeCommand(
+            model_id=command.id,
+            symbol_name=to_pascal_case(command.id),
+            numeric_id=index,
+            description=command.description,
+            metadata={
+                "target": command.target,
+                "allowed_modes": tuple(command.allowed_modes),
+                "requires_ack": command.requires_ack,
+                "timeout_ms": command.timeout_ms,
+                "risk": command.risk,
+                "emits": tuple(command.emits),
+            },
+            arguments=_runtime_arguments(command),
+        )
+        for index, command in enumerate(sorted(model.commands, key=lambda item: item.id), start=1)
+    )
+
+
+def _runtime_arguments(command: Command) -> tuple[RuntimeArgument, ...]:
+    return tuple(
+        RuntimeArgument(
+            model_id=argument.name,
+            symbol_name=to_pascal_case(argument.name),
+            value_type=argument.type,
+            minimum=argument.min,
+            maximum=argument.max,
+            enum_values=tuple(argument.enum or ()),
+            default=argument.default,
+            description=argument.description,
+        )
+        for argument in command.arguments
+    )
+
+
+def _event_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=event.id,
+            symbol_name=to_pascal_case(event.id),
+            numeric_id=index,
+            description=event.description,
+            metadata={
+                "source": event.source,
+                "severity": event.severity,
+                "downlink_priority": event.downlink_priority,
+                "persistence": event.persistence,
+            },
+        )
+        for index, event in enumerate(sorted(model.events, key=lambda item: item.id), start=1)
+    )
+
+
+def _fault_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=fault.id,
+            symbol_name=to_pascal_case(fault.id),
+            numeric_id=index,
+            description=fault.description,
+            metadata={
+                "source": fault.source,
+                "severity": fault.severity,
+                "emits": tuple(fault.emits),
+            },
+        )
+        for index, fault in enumerate(sorted(model.faults, key=lambda item: item.id), start=1)
+    )
+
+
+def _packet_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=packet.id,
+            symbol_name=to_pascal_case(packet.id),
+            numeric_id=index,
+            description=packet.description,
+            metadata={
+                "name": packet.name,
+                "type": packet.type,
+                "max_payload_bytes": packet.max_payload_bytes,
+                "period": packet.period,
+                "telemetry": tuple(packet.telemetry),
+            },
+        )
+        for index, packet in enumerate(sorted(model.packets, key=lambda item: item.id), start=1)
+    )
+
+
+def _payload_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=payload.id,
+            symbol_name=to_pascal_case(payload.id),
+            numeric_id=index,
+            description=payload.description,
+            metadata={
+                "subsystem": payload.subsystem,
+                "profile": payload.profile,
+                "initial_state": payload.lifecycle.initial_state,
+                "states": tuple(payload.lifecycle.states),
+            },
+        )
+        for index, payload in enumerate(sorted(model.payloads, key=lambda item: item.id), start=1)
+    )
+
+
+def _data_product_elements(model: MissionModel) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=data_product.id,
+            symbol_name=to_pascal_case(data_product.id),
+            numeric_id=index,
+            description=data_product.description,
+            metadata={
+                "producer": data_product.producer,
+                "producer_type": data_product.producer_type,
+                "type": data_product.type,
+                "estimated_size_bytes": data_product.estimated_size_bytes,
+                "priority": data_product.priority,
+                "payload": data_product.payload,
+                "storage_policy": _storage_policy_id(data_product),
+                "downlink_policy": _downlink_policy_id(data_product),
+            },
+        )
+        for index, data_product in enumerate(
+            sorted(model.data_products, key=lambda item: item.id),
+            start=1,
+        )
+    )
+
+
+def _storage_policy_elements(
+    data_products: Iterable[DataProductContract],
+) -> tuple[RuntimeElement, ...]:
+    policy_ids = sorted(
+        {
+            policy_id
+            for data_product in data_products
+            if (policy_id := _storage_policy_id(data_product)) is not None
+        }
+    )
+    return _policy_elements(policy_ids)
+
+
+def _downlink_policy_elements(
+    data_products: Iterable[DataProductContract],
+) -> tuple[RuntimeElement, ...]:
+    policy_ids = sorted(
+        {
+            policy_id
+            for data_product in data_products
+            if (policy_id := _downlink_policy_id(data_product)) is not None
+        }
+    )
+    return _policy_elements(policy_ids)
+
+
+def _policy_elements(policy_ids: list[str]) -> tuple[RuntimeElement, ...]:
+    return tuple(
+        RuntimeElement(
+            model_id=policy_id,
+            symbol_name=to_pascal_case(policy_id),
+            numeric_id=index,
+        )
+        for index, policy_id in enumerate(policy_ids, start=1)
+    )
+
+
+def _storage_policy_id(data_product: DataProductContract) -> str | None:
+    if data_product.storage is None:
+        return None
+
+    return data_product.storage.storage_class
+
+
+def _downlink_policy_id(data_product: DataProductContract) -> str | None:
+    if data_product.downlink is None or data_product.downlink.policy is None:
+        return None
+
+    return data_product.downlink.policy

--- a/src/orbitfabric/gen/runtime/contract.py
+++ b/src/orbitfabric/gen/runtime/contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RuntimeArgument:
+    """Command argument exposed through the runtime-facing contract."""
+
+    model_id: str
+    symbol_name: str
+    value_type: str
+    minimum: float | int | None = None
+    maximum: float | int | None = None
+    enum_values: tuple[str, ...] = ()
+    default: Any | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeElement:
+    """Generic contract element exported to runtime-facing artifacts."""
+
+    model_id: str
+    symbol_name: str
+    numeric_id: int
+    description: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RuntimeCommand(RuntimeElement):
+    """Command element with typed arguments."""
+
+    arguments: tuple[RuntimeArgument, ...] = ()
+
+
+@dataclass(frozen=True)
+class RuntimeContract:
+    """Software-facing contract surface derived from a validated Mission Model."""
+
+    mission_id: str
+    mission_name: str
+    model_version: str
+    generation_profile: str
+    modes: tuple[RuntimeElement, ...] = ()
+    telemetry: tuple[RuntimeElement, ...] = ()
+    commands: tuple[RuntimeCommand, ...] = ()
+    events: tuple[RuntimeElement, ...] = ()
+    faults: tuple[RuntimeElement, ...] = ()
+    packets: tuple[RuntimeElement, ...] = ()
+    payloads: tuple[RuntimeElement, ...] = ()
+    data_products: tuple[RuntimeElement, ...] = ()
+    storage_policies: tuple[RuntimeElement, ...] = ()
+    downlink_policies: tuple[RuntimeElement, ...] = ()

--- a/src/orbitfabric/gen/runtime/naming.py
+++ b/src/orbitfabric/gen/runtime/naming.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import re
+
+_IDENTIFIER_PARTS = re.compile(r"[A-Za-z0-9]+")
+
+
+def to_pascal_case(model_id: str) -> str:
+    """Convert a Mission Model identifier to a deterministic PascalCase symbol."""
+    parts = _identifier_parts(model_id)
+    if not parts:
+        return "Unnamed"
+
+    return "".join(_pascal_part(part) for part in parts)
+
+
+def to_camel_case(model_id: str) -> str:
+    """Convert a Mission Model identifier to a deterministic camelCase symbol."""
+    pascal = to_pascal_case(model_id)
+    return pascal[:1].lower() + pascal[1:]
+
+
+def _identifier_parts(model_id: str) -> list[str]:
+    return _IDENTIFIER_PARTS.findall(model_id)
+
+
+def _pascal_part(part: str) -> str:
+    if not part:
+        return ""
+
+    if part[0].isdigit():
+        part = f"N{part}"
+
+    if part.isupper() or part.islower():
+        return part[:1].upper() + part[1:].lower()
+
+    return part[:1].upper() + part[1:]

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -14,7 +14,7 @@ def test_build_runtime_contract_from_demo_mission() -> None:
     contract = build_runtime_contract(model)
 
     assert contract.mission_id == "demo-3u"
-    assert contract.mission_name == "Demo 3U Mission"
+    assert contract.mission_name == "Demo 3U Spacecraft"
     assert contract.model_version == "0.1.0"
     assert contract.generation_profile == "cpp17"
     assert len(contract.modes) == len(model.modes)

--- a/tests/test_runtime_contract.py
+++ b/tests/test_runtime_contract.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.gen.runtime import build_runtime_contract
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_build_runtime_contract_from_demo_mission() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_runtime_contract(model)
+
+    assert contract.mission_id == "demo-3u"
+    assert contract.mission_name == "Demo 3U Mission"
+    assert contract.model_version == "0.1.0"
+    assert contract.generation_profile == "cpp17"
+    assert len(contract.modes) == len(model.modes)
+    assert len(contract.telemetry) == len(model.telemetry)
+    assert len(contract.commands) == len(model.commands)
+    assert len(contract.events) == len(model.events)
+    assert len(contract.faults) == len(model.faults)
+    assert len(contract.packets) == len(model.packets)
+    assert len(contract.payloads) == len(model.payloads)
+    assert len(contract.data_products) == len(model.data_products)
+
+
+def test_runtime_contract_uses_deterministic_numeric_ids() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_runtime_contract(model)
+
+    command_ids = [command.model_id for command in contract.commands]
+    command_numeric_ids = [command.numeric_id for command in contract.commands]
+
+    assert command_ids == sorted(command_ids)
+    assert command_numeric_ids == list(range(1, len(contract.commands) + 1))
+
+
+def test_runtime_contract_exports_command_arguments() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_runtime_contract(model)
+
+    start_command = next(
+        command
+        for command in contract.commands
+        if command.model_id == "payload.start_acquisition"
+    )
+
+    assert start_command.symbol_name == "PayloadStartAcquisition"
+    assert len(start_command.arguments) == 1
+
+    argument = start_command.arguments[0]
+
+    assert argument.model_id == "duration_s"
+    assert argument.symbol_name == "DurationS"
+    assert argument.value_type == "uint16"
+    assert argument.minimum == 1
+    assert argument.maximum == 600
+
+
+def test_runtime_contract_exports_data_product_policies() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_runtime_contract(model)
+
+    data_product = next(
+        item
+        for item in contract.data_products
+        if item.model_id == "payload.radiation_histogram"
+    )
+
+    assert data_product.symbol_name == "PayloadRadiationHistogram"
+    assert data_product.metadata["storage_policy"] == "science"
+    assert data_product.metadata["downlink_policy"] == "next_available_contact"
+
+    assert [item.model_id for item in contract.storage_policies] == ["science"]
+    assert [item.model_id for item in contract.downlink_policies] == [
+        "next_available_contact"
+    ]
+
+
+def test_runtime_contract_supports_explicit_generation_profile() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_runtime_contract(model, generation_profile="test-profile")
+
+    assert contract.generation_profile == "test-profile"

--- a/tests/test_runtime_naming.py
+++ b/tests/test_runtime_naming.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from orbitfabric.gen.runtime.naming import to_camel_case, to_pascal_case
+
+
+def test_pascal_case_from_model_ids() -> None:
+    assert to_pascal_case("payload.start_acquisition") == "PayloadStartAcquisition"
+    assert to_pascal_case("payload.radiation_histogram") == "PayloadRadiationHistogram"
+    assert to_pascal_case("eps.battery_warning") == "EpsBatteryWarning"
+    assert to_pascal_case("SAFE") == "Safe"
+
+
+def test_pascal_case_prefixes_numeric_leading_parts() -> None:
+    assert to_pascal_case("3u.demo") == "N3uDemo"
+
+
+def test_pascal_case_fallback_for_empty_symbol() -> None:
+    assert to_pascal_case("...") == "Unnamed"
+
+
+def test_camel_case_from_model_ids() -> None:
+    assert to_camel_case("payload.start_acquisition") == "payloadStartAcquisition"
+    assert to_camel_case("3u.demo") == "n3uDemo"


### PR DESCRIPTION
## Summary

This PR introduces the first implementation slice for OrbitFabric v0.7.0: the `RuntimeContract` intermediate model.

It adds a runtime generation package that derives a software-facing contract surface from the already validated `MissionModel`.

This is intentionally not a CLI or C++ generator PR.

## Changes

- Add `src/orbitfabric/gen/runtime/`
- Add deterministic runtime naming rules
- Add `RuntimeContract`, `RuntimeElement`, `RuntimeCommand` and `RuntimeArgument`
- Add `build_runtime_contract(model)`
- Map validated Mission Model domains into runtime-facing contract elements:
  - modes
  - telemetry
  - commands and command arguments
  - events
  - faults
  - packets
  - payloads
  - data products
  - storage policy identifiers
  - downlink policy identifiers
- Add tests for naming and contract construction

## Boundary

This PR follows ADR-0011.

It does not generate runtime code.
It does not add `orbitfabric gen runtime` yet.
It does not introduce flight behavior, dispatch, registries, adapter interfaces, CMake output or C++ files.

The goal is only to establish the intermediate model that future generators will consume.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```

Additional focused checks:

```bash
pytest tests/test_runtime_naming.py tests/test_runtime_contract.py
```

## Target branch

This PR targets:

```text
release/v0.7.0-runtime-skeletons
```

not `main`.
