### PR TITLE
feat: add minimal runtime generation CLI

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -8,6 +8,7 @@ import typer
 from orbitfabric import __version__
 from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
 from orbitfabric.gen.docs import generate_markdown_docs
+from orbitfabric.gen.runtime import build_runtime_contract, write_runtime_contract_manifest
 from orbitfabric.lint.engine import LintEngine
 from orbitfabric.lint.finding import LintReport
 from orbitfabric.lint.json_report import write_lint_report_json
@@ -196,6 +197,74 @@ def gen_data_flow(
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")
     typer.echo(f"Generated file: {generated_file}")
+    typer.echo("\nResult: PASSED")
+
+
+@gen_app.command("runtime")
+def gen_runtime(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory used to generate runtime-facing artifacts.",
+        ),
+    ],
+    output_dir: Annotated[
+        Path,
+        typer.Option(
+            "--output-dir",
+            help="Directory where runtime generation artifacts will be written.",
+        ),
+    ] = Path("generated/runtime"),
+    profile: Annotated[
+        str,
+        typer.Option(
+            "--profile",
+            help="Runtime generation profile. Currently only 'cpp17' is supported.",
+        ),
+    ] = "cpp17",
+) -> None:
+    """Generate runtime-facing contract artifacts from a Mission Model."""
+    typer.echo(f"OrbitFabric Runtime Generator {__version__}")
+
+    if profile != "cpp17":
+        typer.echo(f"\nUnsupported runtime generation profile: {profile}")
+        typer.echo("Supported profiles: cpp17")
+        raise typer.Exit(code=1)
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    report = LintEngine().run(model)
+    if report.has_errors:
+        _print_loaded_model_summary(model)
+        _print_lint_report(report)
+        typer.echo("\nRuntime generation aborted because lint errors exist.")
+        raise typer.Exit(code=1)
+
+    contract = build_runtime_contract(model, generation_profile=profile)
+    output_file = output_dir / profile / "runtime_contract_manifest.json"
+    generated_file = write_runtime_contract_manifest(contract, output_file)
+
+    typer.echo(f"\nMission: {model.spacecraft.id}")
+    typer.echo(f"Model version: {model.spacecraft.model_version}")
+    typer.echo(f"Profile: {profile}")
+    typer.echo(f"Generated file: {generated_file}")
+    typer.echo("\nRuntime contract counts:")
+    typer.echo(f"  modes: {len(contract.modes)}")
+    typer.echo(f"  telemetry: {len(contract.telemetry)}")
+    typer.echo(f"  commands: {len(contract.commands)}")
+    typer.echo(f"  events: {len(contract.events)}")
+    typer.echo(f"  faults: {len(contract.faults)}")
+    typer.echo(f"  packets: {len(contract.packets)}")
+    typer.echo(f"  payloads: {len(contract.payloads)}")
+    typer.echo(f"  data products: {len(contract.data_products)}")
     typer.echo("\nResult: PASSED")
 
 

--- a/src/orbitfabric/gen/runtime/__init__.py
+++ b/src/orbitfabric/gen/runtime/__init__.py
@@ -2,5 +2,14 @@ from __future__ import annotations
 
 from orbitfabric.gen.runtime.builder import build_runtime_contract
 from orbitfabric.gen.runtime.contract import RuntimeContract
+from orbitfabric.gen.runtime.manifest import (
+    runtime_contract_manifest,
+    write_runtime_contract_manifest,
+)
 
-__all__ = ["RuntimeContract", "build_runtime_contract"]
+__all__ = [
+    "RuntimeContract",
+    "build_runtime_contract",
+    "runtime_contract_manifest",
+    "write_runtime_contract_manifest",
+]

--- a/src/orbitfabric/gen/runtime/manifest.py
+++ b/src/orbitfabric/gen/runtime/manifest.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.gen.runtime.contract import RuntimeContract
+
+
+def runtime_contract_manifest(contract: RuntimeContract) -> dict[str, Any]:
+    """Return a deterministic JSON-serializable RuntimeContract manifest."""
+    return {
+        "manifest_version": "0.1",
+        "kind": "orbitfabric.runtime_contract_manifest",
+        "mission": {
+            "id": contract.mission_id,
+            "name": contract.mission_name,
+            "model_version": contract.model_version,
+        },
+        "generation": {
+            "profile": contract.generation_profile,
+            "generated_artifacts_are_disposable": True,
+            "contains_flight_runtime": False,
+        },
+        "counts": {
+            "modes": len(contract.modes),
+            "telemetry": len(contract.telemetry),
+            "commands": len(contract.commands),
+            "events": len(contract.events),
+            "faults": len(contract.faults),
+            "packets": len(contract.packets),
+            "payloads": len(contract.payloads),
+            "data_products": len(contract.data_products),
+            "storage_policies": len(contract.storage_policies),
+            "downlink_policies": len(contract.downlink_policies),
+        },
+        "contract": asdict(contract),
+    }
+
+
+def write_runtime_contract_manifest(
+    contract: RuntimeContract,
+    output_file: Path,
+) -> Path:
+    """Write a deterministic RuntimeContract manifest JSON file."""
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    manifest = runtime_contract_manifest(contract)
+    output_file.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_file

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -94,6 +95,60 @@ def test_gen_data_flow_docs_writes_markdown(tmp_path: Path) -> None:
     assert "`payload.radiation_histogram`" in content
     assert "`science_next_available_contact`" in content
     assert "`demo_contact_001`" in content
+
+
+def test_gen_runtime_writes_manifest(tmp_path: Path) -> None:
+    output_dir = tmp_path / "runtime"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "runtime",
+            "examples/demo-3u/mission",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    output_file = output_dir / "cpp17" / "runtime_contract_manifest.json"
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Runtime Generator {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Profile: cpp17" in result.output
+    assert f"Generated file: {output_file}" in result.output
+    assert "Runtime contract counts:" in result.output
+    assert "Result: PASSED" in result.output
+    assert output_file.exists()
+
+    manifest = json.loads(output_file.read_text(encoding="utf-8"))
+    assert manifest["kind"] == "orbitfabric.runtime_contract_manifest"
+    assert manifest["generation"]["profile"] == "cpp17"
+    assert manifest["generation"]["contains_flight_runtime"] is False
+    assert manifest["contract"]["mission_id"] == "demo-3u"
+
+
+def test_gen_runtime_rejects_unsupported_profile(tmp_path: Path) -> None:
+    output_dir = tmp_path / "runtime"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "runtime",
+            "examples/demo-3u/mission",
+            "--output-dir",
+            str(output_dir),
+            "--profile",
+            "c99",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported runtime generation profile: c99" in result.output
+    assert "Supported profiles: cpp17" in result.output
+    assert not output_dir.exists()
 
 
 def test_inspect_mission_loads_demo_mission() -> None:

--- a/tests/test_runtime_manifest.py
+++ b/tests/test_runtime_manifest.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orbitfabric.gen.runtime import build_runtime_contract, runtime_contract_manifest
+from orbitfabric.gen.runtime.manifest import write_runtime_contract_manifest
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_runtime_contract_manifest_shape() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_runtime_contract(model)
+
+    manifest = runtime_contract_manifest(contract)
+
+    assert manifest["manifest_version"] == "0.1"
+    assert manifest["kind"] == "orbitfabric.runtime_contract_manifest"
+    assert manifest["mission"]["id"] == "demo-3u"
+    assert manifest["generation"]["profile"] == "cpp17"
+    assert manifest["generation"]["generated_artifacts_are_disposable"] is True
+    assert manifest["generation"]["contains_flight_runtime"] is False
+    assert manifest["counts"]["commands"] == len(contract.commands)
+    assert manifest["contract"]["mission_id"] == "demo-3u"
+
+
+def test_write_runtime_contract_manifest_is_deterministic(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_runtime_contract(model)
+
+    output_file = tmp_path / "runtime_contract_manifest.json"
+
+    write_runtime_contract_manifest(contract, output_file)
+    first_content = output_file.read_text(encoding="utf-8")
+
+    write_runtime_contract_manifest(contract, output_file)
+    second_content = output_file.read_text(encoding="utf-8")
+
+    assert first_content == second_content
+
+    parsed = json.loads(first_content)
+    assert parsed["mission"]["name"] == "Demo 3U Spacecraft"
+    assert parsed["counts"]["data_products"] == 1


### PR DESCRIPTION
## Summary

This PR introduces the first user-facing v0.7 runtime generation command:

```bash
orbitfabric gen runtime examples/demo-3u/mission/
```

The command currently generates a deterministic `RuntimeContract` manifest JSON file.

This is intentionally a minimal CLI slice. It does not generate C++ headers yet.

## Changes

- Add runtime contract manifest generation
- Add `orbitfabric gen runtime`
- Support the initial `cpp17` generation profile
- Write:

```text
generated/runtime/cpp17/runtime_contract_manifest.json
```

- Add manifest determinism tests
- Add CLI tests for runtime generation and unsupported profiles

## Boundary

This PR follows ADR-0011.

It does not introduce generated C++ code.
It does not introduce flight software behavior.
It does not introduce dispatch, registries, adapter interfaces, CMake output or runtime execution.

The generated manifest is a contract evidence artifact used to stabilize the RuntimeContract-to-generator boundary before adding the C++17 generator.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```

Focused checks:

```bash
pytest tests/test_runtime_manifest.py tests/test_cli.py
orbitfabric gen runtime examples/demo-3u/mission/
```

## Target branch

This PR targets:

```text
release/v0.7.0-runtime-skeletons
```

not `main`.
