### PR TITLE
docs: document v0.7 runtime contract bindings

### DIFF
--- a/docs/reference/runtime-contract-bindings.md
+++ b/docs/reference/runtime-contract-bindings.md
@@ -1,0 +1,314 @@
+# Runtime Contract Bindings
+
+Status: Introduced in v0.7.0  
+Scope: Generated Runtime-Facing Contract Bindings
+
+---
+
+## Purpose
+
+Runtime Contract Bindings are generated software-facing artifacts derived from the validated OrbitFabric Mission Model.
+
+They provide a deterministic boundary that implementation code can include, compile and implement against.
+
+They do not implement onboard behavior.
+
+The intended flow is:
+
+```text
+Mission Model
+        -> validation and linting
+        -> RuntimeContract
+        -> generated C++17 contract bindings
+        -> host-build smoke validation
+        -> user implementation outside generated/
+```
+
+---
+
+## Boundary
+
+Runtime Contract Bindings are contract-facing artifacts.
+
+They are intended to expose:
+
+```text
+stable identifiers
+typed command argument structs
+static metadata registries
+abstract integration interfaces
+host-build smoke files
+```
+
+They are not intended to expose:
+
+```text
+runtime loops
+command queues
+command dispatch implementation
+scheduler behavior
+HAL or driver abstractions
+RTOS integration
+binary serialization
+CCSDS/PUS/CFDP behavior
+flight software behavior
+```
+
+Generated files are disposable and reproducible.
+
+User code must live outside `generated/`.
+
+---
+
+## Command
+
+Runtime bindings are generated with:
+
+```bash
+orbitfabric gen runtime examples/demo-3u/mission/
+```
+
+By default, the generator writes to:
+
+```text
+generated/runtime/cpp17/
+```
+
+The currently supported generation profile is:
+
+```text
+cpp17
+```
+
+---
+
+## Generated output
+
+The C++17 profile generates:
+
+```text
+generated/runtime/cpp17/runtime_contract_manifest.json
+generated/runtime/cpp17/include/orbitfabric/generated/mission_ids.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/mission_enums.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/mission_registries.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/command_args.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/adapter_interfaces.hpp
+generated/runtime/cpp17/CMakeLists.txt
+generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
+```
+
+These files are generated artifacts.
+
+They are not committed as source files in the repository.
+
+---
+
+## RuntimeContract manifest
+
+The runtime contract manifest is a JSON representation of the software-facing contract surface.
+
+It records:
+
+```text
+mission identity
+generation profile
+contract counts
+modes
+telemetry
+commands
+events
+faults
+packets
+payloads
+data products
+storage policies
+downlink policies
+```
+
+It also records that the generated output:
+
+```text
+contains_flight_runtime = false
+generated_artifacts_are_disposable = true
+```
+
+---
+
+## Identifier headers
+
+`mission_ids.hpp` contains deterministic strongly typed identifiers such as:
+
+```text
+ModeId
+TelemetryId
+CommandId
+EventId
+FaultId
+PacketId
+PayloadId
+DataProductId
+StoragePolicyId
+DownlinkPolicyId
+```
+
+Each enum reserves:
+
+```cpp
+Invalid = 0
+```
+
+Real identifiers are derived deterministically from the RuntimeContract.
+
+---
+
+## Runtime enums
+
+`mission_enums.hpp` contains runtime-facing value enums derived from the contract surface.
+
+For example:
+
+```text
+RuntimeValueType
+```
+
+This is metadata for generated contract bindings.
+
+It is not a serializer, decoder or telemetry runtime.
+
+---
+
+## Static registries
+
+`mission_registries.hpp` contains static descriptor arrays for contract metadata.
+
+The generated registries include:
+
+```text
+TelemetryRegistry
+CommandRegistry
+EventRegistry
+FaultRegistry
+DataProductRegistry
+```
+
+These registries expose metadata such as model IDs, symbol names, value types, units, sources, severities, command targets and data product attributes.
+
+They do not read sensors, execute commands, report events, manage faults or move data.
+
+---
+
+## Command argument structs
+
+`command_args.hpp` contains one typed argument struct per command.
+
+For example:
+
+```cpp
+struct PayloadStartAcquisitionArgs {
+    std::uint16_t duration_s;
+};
+```
+
+These structs provide a deterministic contract-facing shape for command arguments.
+
+They do not parse packets, validate command authorization, enqueue commands or execute command behavior.
+
+---
+
+## Adapter interfaces
+
+`adapter_interfaces.hpp` contains abstract interfaces that implementation code may implement outside `generated/`.
+
+The generated interfaces include:
+
+```text
+ICommandHandler
+ITelemetrySink
+IEventReporter
+IFaultReporter
+```
+
+For example:
+
+```cpp
+class ICommandHandler {
+public:
+    virtual ~ICommandHandler() = default;
+
+    virtual CommandResult handle_payload_start_acquisition(
+        const PayloadStartAcquisitionArgs& args
+    ) = 0;
+};
+```
+
+These are integration boundaries only.
+
+They are not concrete handlers, dispatchers, queues, schedulers or runtime services.
+
+---
+
+## Host-build smoke validation
+
+The C++17 profile also generates:
+
+```text
+CMakeLists.txt
+src/orbitfabric_runtime_contract_smoke.cpp
+```
+
+This allows the generated contract bindings to be validated with a host-side C++17 build:
+
+```bash
+cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
+cmake --build generated/runtime/cpp17/build
+```
+
+This confirms that the emitted contract-binding surface is syntactically valid and buildable as C++17.
+
+It does not validate flight behavior.
+
+---
+
+## Non-goals
+
+Runtime Contract Bindings intentionally do not implement:
+
+```text
+flight runtime
+onboard application framework
+command dispatch runtime
+command queue
+command validation runtime
+telemetry polling runtime
+event routing runtime
+fault manager runtime
+scheduler
+HAL
+drivers
+RTOS abstraction
+Linux daemon
+binary serialization
+CCSDS/PUS/CFDP mapping
+storage runtime
+downlink runtime
+user-code merge
+protected regions
+```
+
+These are outside the v0.7.0 boundary.
+
+---
+
+## Architectural meaning
+
+Runtime Contract Bindings are the first software-facing output of OrbitFabric.
+
+They make the Mission Model visible to implementation code without turning OrbitFabric into flight software.
+
+The key architectural rule remains:
+
+```text
+generated code is disposable;
+user code lives outside generated/;
+integration happens through interfaces.
+```

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,283 @@
+# OrbitFabric v0.7.0 — Generated Runtime Skeletons
+
+Status: Planned release  
+Scope: Generated Runtime-Facing Contract Bindings
+
+---
+
+## Summary
+
+OrbitFabric v0.7.0 introduces the first generated runtime-facing contract binding slice.
+
+This release turns the validated Mission Model into deterministic C++17 artifacts that implementation code can include, compile and implement against.
+
+The feature remains deliberately narrow.
+
+It does not generate onboard behavior, runtime loops, schedulers, command queues, HAL code, drivers, RTOS abstractions or flight-ready software.
+
+It generates the contract-aligned software boundary that onboard or host-side implementation code may implement outside `generated/`.
+
+---
+
+## Architectural meaning
+
+v0.7.0 is the first OrbitFabric release where the Mission Model produces a software-facing boundary.
+
+The intended chain is:
+
+```text
+Mission Model
+        -> validation and linting
+        -> RuntimeContract
+        -> C++17 runtime-facing contract bindings
+        -> host-build smoke validation
+        -> user implementation outside generated/
+```
+
+The important rule is:
+
+```text
+generated code is disposable;
+user code lives outside generated/;
+integration happens through interfaces.
+```
+
+---
+
+## Added
+
+v0.7.0 adds:
+
+```text
+RuntimeContract intermediate model
+orbitfabric gen runtime command
+runtime_contract_manifest.json
+C++17 mission identifier headers
+C++17 runtime value enums
+C++17 static metadata registries
+C++17 command argument structs
+C++17 abstract adapter interfaces
+C++17 host-build smoke CMake target
+host-build smoke source including all generated headers
+```
+
+---
+
+## Runtime generator command
+
+Runtime bindings are generated with:
+
+```bash
+orbitfabric gen runtime examples/demo-3u/mission/
+```
+
+The default output is:
+
+```text
+generated/runtime/cpp17/
+```
+
+The current supported profile is:
+
+```text
+cpp17
+```
+
+---
+
+## Generated artifacts
+
+The C++17 profile generates:
+
+```text
+generated/runtime/cpp17/runtime_contract_manifest.json
+generated/runtime/cpp17/include/orbitfabric/generated/mission_ids.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/mission_enums.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/mission_registries.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/command_args.hpp
+generated/runtime/cpp17/include/orbitfabric/generated/adapter_interfaces.hpp
+generated/runtime/cpp17/CMakeLists.txt
+generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
+```
+
+These files are generated artifacts.
+
+They are reproducible and disposable.
+
+They are not committed as source files.
+
+---
+
+## RuntimeContract manifest
+
+The manifest records the software-facing contract surface produced from the Mission Model.
+
+It includes mission identity, generation profile, contract counts and the generated contract domains.
+
+It also records:
+
+```text
+contains_flight_runtime = false
+generated_artifacts_are_disposable = true
+```
+
+---
+
+## C++17 identifiers and registries
+
+The generated C++17 headers expose deterministic identifiers and metadata registries for:
+
+```text
+modes
+telemetry
+commands
+events
+faults
+packets
+payloads
+data products
+storage policies
+downlink policies
+```
+
+The registries make the contract surface inspectable from C++17 without implementing any runtime behavior.
+
+---
+
+## Command argument structs
+
+Commands receive generated typed argument structs.
+
+For example:
+
+```cpp
+struct PayloadStartAcquisitionArgs {
+    std::uint16_t duration_s;
+};
+```
+
+These structs define the command argument shape.
+
+They do not parse packets, validate permissions, enqueue commands or execute command behavior.
+
+---
+
+## Adapter interfaces
+
+v0.7.0 generates abstract interfaces such as:
+
+```text
+ICommandHandler
+ITelemetrySink
+IEventReporter
+IFaultReporter
+```
+
+These interfaces are contract-facing integration boundaries only.
+
+User implementations must live outside `generated/`.
+
+---
+
+## Host-build smoke validation
+
+The generated C++17 surface can be validated with:
+
+```bash
+cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
+cmake --build generated/runtime/cpp17/build
+```
+
+This validates that the generated headers are buildable as C++17 on the host.
+
+It does not validate flight behavior.
+
+---
+
+## Validation baseline
+
+The release baseline is:
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+
+orbitfabric lint examples/demo-3u/mission/ \
+  --json generated/reports/lint_report.json
+
+orbitfabric gen docs examples/demo-3u/mission/
+
+orbitfabric gen data-flow examples/demo-3u/mission/ \
+  --output-file generated/docs/data_flow.md
+
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+
+orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
+  --json generated/reports/payload_data_flow_evidence_report.json \
+  --log generated/logs/payload_data_flow_evidence.log
+
+orbitfabric gen runtime examples/demo-3u/mission/
+
+cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
+cmake --build generated/runtime/cpp17/build
+```
+
+Expected result:
+
+```text
+all checks passing
+lint result: PASSED
+docs generation: PASSED
+scenario result: PASSED
+runtime generation: PASSED
+C++17 host-build smoke: PASSED
+```
+
+---
+
+## Non-goals
+
+v0.7.0 intentionally does not introduce:
+
+```text
+flight runtime
+onboard application framework
+runtime loop
+command dispatch runtime
+command queue
+command validation runtime
+telemetry polling runtime
+event routing runtime
+fault manager runtime
+scheduler
+HAL
+drivers
+RTOS abstraction
+Linux daemon
+binary serialization
+CCSDS/PUS/CFDP mapping
+storage runtime
+downlink runtime
+user-code merge
+protected regions
+flight-ready software
+```
+
+These are not missing pieces of v0.7.0.
+
+They remain intentionally outside the generated runtime skeleton boundary.
+
+---
+
+## Final position
+
+OrbitFabric v0.7.0 remains a Mission Data Contract framework.
+
+Generated Runtime Skeletons are runtime-facing contract bindings.
+
+They are not flight software.
+
+They provide a reproducible, host-buildable software boundary derived from the Mission Model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,12 +29,14 @@ nav:
       - Contact and Downlink Contract Model: reference/contact-downlink-contract-model.md
       - Commandability and Autonomy Contract Model: reference/commandability-contract-model.md
       - Data Flow Evidence: reference/data-flow-evidence.md
+      - Runtime Contract Bindings: reference/runtime-contract-bindings.md
   - Releases:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
       - v0.4.0 Contact Windows and Downlink Flow Contracts: releases/v0.4.0.md
       - v0.5.0 Commandability and Autonomy Contracts: releases/v0.5.0.md
       - v0.6.0 End-to-End Mission Data Flow Evidence: releases/v0.6.0.md
+      - v0.7.0 Generated Runtime Skeletons: releases/v0.7.0.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 


### PR DESCRIPTION
## Summary

Document the v0.7 Generated Runtime Skeletons scope and generated runtime-facing contract bindings.

This PR adds:

```text
docs/reference/runtime-contract-bindings.md
docs/releases/v0.7.0.md
```

It also adds both pages to the MkDocs navigation.

## Changes

- Add Runtime Contract Bindings reference page
- Add v0.7.0 release notes
- Document generated C++17 output paths
- Document `orbitfabric gen runtime`
- Document the host-build CMake smoke validation flow
- Re-state the non-flight-runtime boundary for v0.7.0
- Add the new reference and release pages to `mkdocs.yml`

## Affected Area

Select all that apply:

- [ ] Mission Model
- [ ] Model loading / validation
- [ ] Semantic lint rules
- [ ] Scenario loading / validation
- [ ] Scenario simulation
- [ ] JSON reports
- [x] Documentation generation
- [ ] Generated artifacts
- [ ] Example missions
- [ ] CI / tooling
- [x] Public documentation
- [x] Release alignment
- [ ] Other

## Mission Data Contract Impact

Does this PR change Mission Data Contract semantics?

- [x] No
- [ ] Yes

This PR only documents the v0.7 runtime-facing contract binding surface.

It does not change Mission Model semantics, validation semantics, lint rules, runtime generation behavior or generated artifacts.

## Architectural Boundary

This PR intentionally does **not** implement:

- real flight runtime
- command dispatch runtime
- concrete command handlers
- command queues
- command validation runtime
- telemetry polling runtime
- event routing runtime
- fault manager runtime
- onboard scheduler
- HAL
- drivers
- RTOS abstraction
- binary serialization
- CCSDS/PUS/CFDP behavior
- user-code merge or protected regions
- flight-ready software

The documentation explicitly describes Runtime Contract Bindings as generated, disposable, host-buildable contract artifacts.

## Clean-Room Confirmation

By opening this PR, I confirm that this contribution does not include:

- [x] proprietary mission data
- [x] private spacecraft architecture
- [x] private packet formats
- [x] real operational logs
- [x] non-public payload details
- [x] real bus maps or pinouts
- [x] employer-owned or customer-owned code
- [x] export-controlled or NDA-protected material

All examples are synthetic or derived only from public OrbitFabric demo material.

## Validation

Select the checks that were run.

- [x] `ruff check .`
- [x] `pytest`
- [x] `mkdocs build --strict`
- [ ] `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
- [ ] `orbitfabric gen docs examples/demo-3u/mission/`
- [ ] `orbitfabric gen data-flow examples/demo-3u/mission/ --output-file generated/docs/data_flow.md`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml --json generated/reports/payload_data_flow_evidence_report.json --log generated/logs/payload_data_flow_evidence.log`

Recommended focused check before merge:

```bash
mkdocs build --strict
```

Checks are intentionally left unchecked until they are executed locally and by CI.

## Generated Artifacts

- [x] This PR does not commit generated artifacts.
- [ ] This PR intentionally updates generated artifacts.

## Notes for Review

Pay particular attention to:

- v0.7.0 being described as runtime-facing contract bindings, not flight software;
- generated code being described as disposable;
- user implementation staying outside `generated/`;
- host-build smoke validation being described as compile-level validation only;
- `mkdocs.yml` navigation consistency.
