### PR TITLE
docs: define v0.8.0 ground integration boundary

### DIFF
--- a/docs/adr/ADR-0012-ground-integration-artifacts-boundary.md
+++ b/docs/adr/ADR-0012-ground-integration-artifacts-boundary.md
@@ -1,0 +1,542 @@
+# ADR-0012 - Ground Integration Artifacts Boundary
+
+Status: Accepted for v0.8.0 planning  
+Date: 2026-05-11
+
+---
+
+## Context
+
+OrbitFabric is a model-first Mission Data Contract framework for small spacecraft.
+
+The v0.7.0 baseline introduced Generated Runtime Skeletons, defined precisely as runtime-facing contract bindings.
+
+That milestone created a controlled software-facing generation path:
+
+```text
+Mission Model
+        -> validation and linting
+        -> RuntimeContract
+        -> generated runtime-facing contract bindings
+        -> host-build smoke validation
+        -> user implementation outside generated/
+```
+
+The next roadmap step is `v0.8.0 - Ground Integration Artifacts`.
+
+This step is architecturally sensitive.
+
+Ground-side terminology can easily imply a live ground segment, a mission control system, a telemetry archive, a telecommand uplink service, a decoder, a database, a Yamcs integration, an OpenC3 integration or an XTCE-compliant mission database.
+
+OrbitFabric must not make those claims in v0.8.0.
+
+The source of truth must remain the Mission Model.
+
+Generated ground artifacts must be downstream, reproducible, inspectable and disposable.
+
+---
+
+## Decision
+
+OrbitFabric v0.8.0 introduces Ground Integration Artifacts as deterministic, inspectable, tool-neutral ground-facing contract exports derived from the validated Mission Model.
+
+The preferred architectural interpretation is:
+
+```text
+Mission Model
+        -> validated MissionModel
+        -> GroundContract intermediate model
+        -> generic ground-facing dictionaries
+        -> JSON / Markdown / CSV exports
+```
+
+The forbidden interpretation is:
+
+```text
+Mission Model
+        -> generated ground segment
+        -> generated mission control system
+        -> generated operator console
+        -> generated telemetry archive
+        -> generated command uplink service
+        -> generated Yamcs/OpenC3/XTCE integration
+```
+
+The preferred internal term is:
+
+```text
+Ground-facing mission data package
+```
+
+The public milestone name remains:
+
+```text
+Ground Integration Artifacts
+```
+
+---
+
+## Core Principle
+
+OrbitFabric v0.8.0 does not implement ground behavior.
+
+It generates the contract-aligned ground-facing data package that ground software teams can review, adapt or consume outside OrbitFabric.
+
+This principle is mandatory.
+
+Every v0.8.0 feature must be evaluated against it.
+
+---
+
+## GroundContract Intermediate Model
+
+v0.8.0 introduces a GroundContract intermediate model.
+
+Ground-facing generators must not read raw YAML in scattered places.
+
+The required dependency direction is:
+
+```text
+CLI
+        -> Mission Model loading and validation
+        -> GroundContract builder
+        -> profile-specific ground exporter
+        -> generated files
+```
+
+The disallowed dependency direction is:
+
+```text
+profile-specific ground exporter
+        -> raw YAML files
+        -> simulator internals
+        -> runtime generator internals
+        -> generated runtime files
+```
+
+GroundContract is not a replacement for RuntimeContract.
+
+RuntimeContract is software-facing.
+
+GroundContract is ground-facing.
+
+Both are derived from the validated Mission Model.
+
+Neither is the source of truth.
+
+---
+
+## Initial Generation Profile
+
+The first supported ground generation profile is:
+
+```text
+generic
+```
+
+The generated output root is:
+
+```text
+generated/ground/generic/
+```
+
+The planned v0.8.0 output is:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+The `generic` profile is deliberately tool-neutral.
+
+It is not a Yamcs profile.
+
+It is not an OpenC3 profile.
+
+It is not an XTCE profile.
+
+Tool-specific profiles may be considered only after their semantics are implemented and tested explicitly.
+
+---
+
+## Generated Artifact Semantics
+
+Generated ground artifacts are reproducible outputs.
+
+They are not the source of truth.
+
+The source of truth remains:
+
+```text
+mission/*.yaml
+```
+
+Generated artifacts are disposable.
+
+They may be overwritten on every generation.
+
+User integration code, ground adapters, database imports, operator displays, decoder implementations and ground runtime configuration must live outside the generated OrbitFabric output tree unless they are explicitly generated as future tool-specific profiles.
+
+---
+
+## Dictionary Scope
+
+The v0.8.0 ground-facing package may include dictionaries for:
+
+```text
+telemetry
+commands
+events
+faults
+data products
+packets
+```
+
+These dictionaries expose contract metadata already declared in the Mission Model.
+
+They do not introduce new ground behavior.
+
+They do not reinterpret the Mission Model.
+
+They do not infer protocol-specific semantics that are not declared.
+
+---
+
+## Telemetry Dictionary Boundary
+
+Telemetry dictionary artifacts may expose:
+
+```text
+telemetry identity
+name
+type
+unit
+source subsystem
+sampling declaration
+criticality
+persistence
+downlink priority
+limits
+enum values
+quality policy
+description
+```
+
+They must not implement:
+
+```text
+telemetry decoding runtime
+sensor reading
+packet parsing
+raw-to-engineering conversion
+calibration curves
+archive storage
+alarm runtime
+operator display generation
+```
+
+---
+
+## Command Dictionary Boundary
+
+Command dictionary artifacts may expose:
+
+```text
+command identity
+target subsystem
+arguments
+argument type and constraints
+allowed modes
+preconditions
+ack requirement
+timeout
+risk
+emitted events
+expected effects
+related data products when declared
+```
+
+They must not implement:
+
+```text
+telecommand uplink
+command encoding
+command authentication
+command authorization
+command queueing
+operator workflow
+transport sessions
+runtime ACK handling
+retry behavior
+```
+
+The existing command `risk` field may be exported because it is already part of the Mission Model.
+
+No new security model is introduced in v0.8.0.
+
+---
+
+## Event and Fault Dictionary Boundary
+
+Event and fault dictionary artifacts may expose:
+
+```text
+event identity
+source
+severity
+persistence
+downlink priority
+fault identity
+fault condition metadata
+emitted events
+recovery intent metadata
+```
+
+They must not implement:
+
+```text
+event routing runtime
+fault detection runtime
+fault recovery runtime
+FDIR implementation
+operator alarm engine
+```
+
+---
+
+## Data Product Dictionary Boundary
+
+Data product dictionary artifacts may expose:
+
+```text
+data product identity
+producer
+producer type
+product type
+estimated size
+priority
+payload reference
+storage intent
+downlink intent
+retention intent
+overflow policy
+```
+
+They must not implement:
+
+```text
+payload file creation
+payload data processing
+compression
+onboard storage writes
+retention execution
+downlink queues
+contact scheduling
+ground file ingestion
+science processing pipeline
+```
+
+---
+
+## Packet Dictionary Boundary
+
+The current Mission Model supports packet membership dictionaries.
+
+A packet dictionary may expose:
+
+```text
+packet identity
+packet name
+abstract packet type
+maximum payload size
+period
+telemetry membership
+```
+
+It must not be described as a complete decoder specification.
+
+The current Mission Model does not define:
+
+```text
+byte offsets
+bit offsets
+endianness
+scaling rules
+calibration curves
+APID / VCID mapping
+CCSDS headers
+PUS service/subservice mapping
+framing
+transport
+```
+
+Therefore v0.8.0 must not generate binary packet decoders or claim CCSDS/PUS/CFDP behavior.
+
+---
+
+## Manifest Boundary Flags
+
+The generated ground manifest must explicitly state what it does not contain.
+
+The manifest should include boundary flags such as:
+
+```json
+{
+  "kind": "orbitfabric.ground_contract_manifest",
+  "manifest_version": "0.1",
+  "generation": {
+    "profile": "generic",
+    "generated_artifacts_are_disposable": true,
+    "contains_ground_runtime": false,
+    "contains_operator_console": false,
+    "contains_transport": false,
+    "contains_database": false,
+    "claims_yamcs_compatibility": false,
+    "claims_openc3_compatibility": false,
+    "claims_xtce_compliance": false
+  }
+}
+```
+
+These flags are part of the public boundary of v0.8.0.
+
+---
+
+## Non-Goals
+
+v0.8.0 must not introduce:
+
+```text
+live ground segment
+mission control system
+operator console
+telemetry archive
+telemetry database
+command uplink service
+telecommand transport
+telemetry downlink runtime
+network/session/routing behavior
+command authentication or authorization
+security enforcement
+Yamcs integration
+OpenC3 integration
+XTCE compliance
+CCSDS/PUS/CFDP implementation
+binary packet decoder
+binary telecommand encoder
+offset/bitfield layout model
+calibration model
+RF/link-budget behavior
+pass scheduling
+station automation
+```
+
+These are not missing features of v0.8.0.
+
+They are intentionally outside the milestone boundary.
+
+---
+
+## Relationship with Security Assumptions
+
+v0.8.0 must not introduce the future Security Assumptions / Command Criticality Contracts layer.
+
+The existing command `risk` metadata may be exported in command dictionaries.
+
+That export does not imply authentication, authorization, access control, audit runtime, cryptography, key management or security enforcement.
+
+Security assumptions remain tracked separately.
+
+---
+
+## Testing Direction
+
+v0.8.0 should include tests for:
+
+```text
+GroundContract construction
+deterministic ordering
+deterministic JSON output
+manifest boundary flags
+telemetry dictionary content
+command dictionary content
+event dictionary content
+fault dictionary content
+data product dictionary content
+packet dictionary content
+CSV headers and row stability
+Markdown boundary statement
+CLI success path
+CLI abort on lint errors
+unsupported profile failure
+```
+
+The required local checks remain:
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+```
+
+---
+
+## Consequences
+
+This decision creates a controlled bridge from Mission Data Contracts to ground-facing integration artifacts.
+
+It makes OrbitFabric useful to ground software teams without turning OrbitFabric into their ground system.
+
+It enables future tool-specific exporters only after the generic contract package is stable.
+
+It also creates a clear review boundary for v0.8.0 work:
+
+```text
+Does this artifact expose ground-facing contract metadata?
+Or does it implement ground behavior?
+```
+
+Only the first category belongs in v0.8.0.
+
+---
+
+## Acceptance Criteria for This Decision
+
+This ADR is satisfied when:
+
+- Ground Integration Artifacts are defined as ground-facing contract exports;
+- GroundContract is selected as the mandatory intermediate model;
+- the `generic` profile is the only v0.8.0 ground profile;
+- generated artifacts are deterministic, inspectable and disposable;
+- the generated manifest declares the ground-runtime boundary;
+- tool-specific compatibility claims are excluded from v0.8.0;
+- packet outputs are bounded to packet membership dictionaries;
+- decoder, transport, database and console behavior are excluded;
+- security enforcement is excluded;
+- testing expectations are documented.
+
+---
+
+## Final Position
+
+Ground Integration Artifacts are valuable only if they preserve OrbitFabric's identity.
+
+The v0.8.0 milestone generates the ground-facing mission data package derived from the Mission Model.
+
+It does not generate the ground system that consumes that package.

--- a/docs/reference/ground-integration-artifacts.md
+++ b/docs/reference/ground-integration-artifacts.md
@@ -1,0 +1,384 @@
+# Ground Integration Artifacts
+
+Status: Planned for v0.8.0  
+Scope: Ground-facing Mission Data Contract exports
+
+---
+
+## Purpose
+
+Ground Integration Artifacts are generated ground-facing outputs derived from the validated OrbitFabric Mission Model.
+
+Their purpose is to help ground software teams review, adapt and integrate the mission data contract before configuring or implementing their actual ground system.
+
+They are not a ground segment.
+
+They are not a mission control system.
+
+They are not an operator console.
+
+They are not a telemetry archive.
+
+They are not a command uplink service.
+
+They are not a Yamcs, OpenC3 or XTCE integration.
+
+---
+
+## Intended Flow
+
+The intended v0.8.0 flow is:
+
+```text
+Mission Model
+        -> validation and linting
+        -> GroundContract
+        -> generic ground-facing dictionaries
+        -> JSON / Markdown / CSV exports
+        -> downstream ground-system integration outside OrbitFabric
+```
+
+The source of truth remains the Mission Model.
+
+Generated ground artifacts are reproducible and disposable.
+
+---
+
+## Target User
+
+The primary target user is not the operator of a physical ground station antenna.
+
+The primary target user is a ground segment software engineer, mission control engineer, ground system integrator or test engineer who needs a clear and machine-readable description of the mission data contract.
+
+Typical questions include:
+
+```text
+What telemetry can arrive from the spacecraft?
+What commands can be issued?
+What command arguments and constraints are declared?
+Which events and faults may be reported?
+Which data products are expected?
+Which packet memberships are declared?
+Which priority, persistence, storage and downlink intent metadata exists?
+Which assumptions remain external implementation concerns?
+```
+
+---
+
+## Generated Package
+
+The planned generic output package is:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+This package is intended for engineering review and downstream integration.
+
+It is not intended to be executed.
+
+---
+
+## GroundContract
+
+GroundContract is the planned v0.8.0 intermediate model for ground-facing generation.
+
+It is derived from the validated Mission Model.
+
+It is not loaded from generated runtime files.
+
+It is not the source of truth.
+
+The dependency direction is:
+
+```text
+MissionModel
+        -> GroundContract builder
+        -> generic ground exporter
+        -> generated package
+```
+
+GroundContract exists to prevent ground exporters from directly reading raw YAML or reinterpreting unrelated generator outputs.
+
+---
+
+## Generic Profile
+
+The first ground generation profile is:
+
+```text
+generic
+```
+
+The generic profile is tool-neutral.
+
+It does not claim compatibility with any ground framework.
+
+Future tool-specific profiles may be considered only when their outputs are implemented and tested explicitly.
+
+---
+
+## Telemetry Dictionary
+
+The telemetry dictionary may expose:
+
+```text
+id
+name
+type
+unit
+source
+sampling
+criticality
+persistence
+downlink_priority
+limits
+enum
+quality
+description
+```
+
+It does not implement telemetry decoding, telemetry polling, alarm runtime, archive storage or operator displays.
+
+---
+
+## Command Dictionary
+
+The command dictionary may expose:
+
+```text
+id
+target
+description
+arguments
+allowed_modes
+preconditions
+requires_ack
+timeout_ms
+risk
+emits
+expected_effects
+```
+
+It does not implement command encoding, command uplink, authentication, authorization, queuing, routing, retry logic or runtime ACK handling.
+
+The existing command `risk` metadata may be exported because it is already part of the Mission Model.
+
+This does not create a security model.
+
+---
+
+## Event Dictionary
+
+The event dictionary may expose:
+
+```text
+id
+source
+severity
+description
+downlink_priority
+persistence
+```
+
+It does not implement event routing, event storage, alerting or operator notification behavior.
+
+---
+
+## Fault Dictionary
+
+The fault dictionary may expose:
+
+```text
+id
+source
+severity
+description
+condition
+emits
+recovery
+```
+
+It does not implement fault detection, FDIR, safing behavior, command dispatch or ground alarm handling.
+
+---
+
+## Data Product Dictionary
+
+The data product dictionary may expose:
+
+```text
+id
+producer
+producer_type
+type
+estimated_size_bytes
+priority
+payload
+storage
+downlink
+description
+```
+
+It does not implement payload processing, file creation, compression, storage, retention, downlink execution or ground ingestion.
+
+---
+
+## Packet Dictionary
+
+The packet dictionary may expose:
+
+```text
+id
+name
+type
+max_payload_bytes
+period
+telemetry
+description
+```
+
+This is a packet membership dictionary.
+
+It is not a binary decoder specification.
+
+The current Mission Model does not define byte offsets, bit offsets, endianness, scaling rules, calibration curves, APID, VCID, CCSDS headers, PUS service/subservice fields, framing or transport.
+
+Therefore v0.8.0 must not claim decoder generation, CCSDS compliance, PUS compliance or CFDP behavior.
+
+---
+
+## Manifest
+
+The generated manifest should explicitly describe the generated package and its boundary.
+
+Expected boundary flags include:
+
+```json
+{
+  "kind": "orbitfabric.ground_contract_manifest",
+  "manifest_version": "0.1",
+  "generation": {
+    "profile": "generic",
+    "generated_artifacts_are_disposable": true,
+    "contains_ground_runtime": false,
+    "contains_operator_console": false,
+    "contains_transport": false,
+    "contains_database": false,
+    "claims_yamcs_compatibility": false,
+    "claims_openc3_compatibility": false,
+    "claims_xtce_compliance": false
+  }
+}
+```
+
+These flags are deliberate.
+
+They prevent generated dictionaries from being mistaken for live ground software.
+
+---
+
+## CLI
+
+The planned CLI command is:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+Default output:
+
+```text
+generated/ground/generic/
+```
+
+Only the `generic` profile is planned for v0.8.0.
+
+---
+
+## Non-Goals
+
+Ground Integration Artifacts do not implement:
+
+```text
+live ground segment
+mission control system
+operator console
+telemetry archive
+telemetry database
+command uplink service
+telecommand transport
+telemetry downlink runtime
+network/session/routing behavior
+command authentication or authorization
+security enforcement
+Yamcs integration
+OpenC3 integration
+XTCE compliance
+CCSDS/PUS/CFDP implementation
+binary packet decoder
+binary telecommand encoder
+offset/bitfield layout model
+calibration model
+RF/link-budget behavior
+pass scheduling
+station automation
+```
+
+These are not missing pieces of v0.8.0.
+
+They are intentionally outside scope.
+
+---
+
+## Relationship with RuntimeContract
+
+RuntimeContract and GroundContract serve different consumers.
+
+```text
+RuntimeContract -> software-facing contract bindings
+GroundContract  -> ground-facing contract dictionaries
+```
+
+Both derive from the validated Mission Model.
+
+Neither should read from the other's generated artifacts.
+
+Neither should bypass Mission Model validation.
+
+---
+
+## Relationship with Security Assumptions
+
+v0.8.0 may export existing command `risk` metadata.
+
+It must not introduce security assumptions, command authorization, authentication, audit runtime, cryptography, key management or enforcement behavior.
+
+Security assumptions are a separate future contract-model topic.
+
+---
+
+## Architectural Meaning
+
+Ground Integration Artifacts make OrbitFabric useful to ground software teams without making OrbitFabric a ground system.
+
+They provide a deterministic, reviewable and machine-readable mission data contract package.
+
+The downstream ground system remains responsible for real decoding, storage, displays, transport, operator workflow, security and live operations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Commandability and Autonomy Contract Model: reference/commandability-contract-model.md
       - Data Flow Evidence: reference/data-flow-evidence.md
       - Runtime Contract Bindings: reference/runtime-contract-bindings.md
+      - Ground Integration Artifacts: reference/ground-integration-artifacts.md
   - Releases:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
@@ -52,6 +53,7 @@ nav:
       - ADR-0009 Contact Windows and Downlink Flow Contracts: adr/ADR-0009-contact-windows-and-downlink-flow-contracts.md
       - ADR-0010 Commandability and Autonomy Contracts: adr/ADR-0010-commandability-and-autonomy-contracts.md
       - ADR-0011 Generated Runtime Skeleton Boundary: adr/ADR-0011-generated-runtime-skeleton-boundary.md
+      - ADR-0012 Ground Integration Artifacts Boundary: adr/ADR-0012-ground-integration-artifacts-boundary.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

Define the architectural boundary for the upcoming `v0.8.0 — Ground Integration Artifacts` milestone before introducing any implementation code.

This PR adds the documentation foundation for the first ground-facing OrbitFabric generation layer.

## Added

- `docs/adr/ADR-0012-ground-integration-artifacts-boundary.md`
- `docs/reference/ground-integration-artifacts.md`
- MkDocs navigation entries for the new ADR and reference page

## Architectural position

This PR defines Ground Integration Artifacts as deterministic, inspectable, tool-neutral ground-facing contract exports derived from the validated Mission Model.

The intended v0.8.0 chain is:

```text
Mission Model
        -> validation and linting
        -> GroundContract
        -> generic ground-facing dictionaries
        -> JSON / Markdown / CSV exports
```

## Boundary

This PR explicitly states that v0.8.0 must not implement:

- live ground segment
- mission control system
- operator console
- telemetry archive or database
- command uplink service
- telemetry downlink runtime
- transport/session/routing behavior
- command authentication or authorization
- security enforcement
- Yamcs/OpenC3/XTCE compatibility
- CCSDS/PUS/CFDP behavior
- binary packet decoder
- binary telecommand encoder
- RF/link-budget behavior
- pass scheduling
- station automation

## Why this is first

The v0.8.0 milestone is semantically sensitive.

Before adding `GroundContract`, CLI commands or generators, OrbitFabric needs a public and reviewable boundary that prevents ground integration artifacts from being mistaken for a ground segment.

## Related issue

Closes part of #123.

## Validation

Documentation-only PR.

Expected validation:

```bash
mkdocs build --strict
```

No source code, generated artifacts or tests are changed in this PR.
