### PR TITLE
feat: add ground contract core

### DIFF
--- a/src/orbitfabric/gen/ground/__init__.py
+++ b/src/orbitfabric/gen/ground/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from orbitfabric.gen.ground.builder import build_ground_contract
+from orbitfabric.gen.ground.contract import GroundContract
+
+__all__ = [
+    "GroundContract",
+    "build_ground_contract",
+]

--- a/src/orbitfabric/gen/ground/builder.py
+++ b/src/orbitfabric/gen/ground/builder.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from orbitfabric.gen.ground.contract import (
+    GroundCommand,
+    GroundCommandArgument,
+    GroundContract,
+    GroundDataProduct,
+    GroundEvent,
+    GroundFault,
+    GroundPacket,
+    GroundTelemetryItem,
+)
+from orbitfabric.model.mission import Command, MissionModel
+
+
+def build_ground_contract(
+    model: MissionModel,
+    *,
+    generation_profile: str = "generic",
+) -> GroundContract:
+    """Build the ground-facing contract surface from a validated Mission Model."""
+    return GroundContract(
+        mission_id=model.spacecraft.id,
+        mission_name=model.spacecraft.name,
+        model_version=model.spacecraft.model_version,
+        generation_profile=generation_profile,
+        telemetry=_telemetry_items(model),
+        commands=_commands(model),
+        events=_events(model),
+        faults=_faults(model),
+        data_products=_data_products(model),
+        packets=_packets(model),
+    )
+
+
+def _telemetry_items(model: MissionModel) -> tuple[GroundTelemetryItem, ...]:
+    return tuple(
+        GroundTelemetryItem(
+            model_id=item.id,
+            name=item.name,
+            value_type=item.type,
+            unit=item.unit,
+            source=item.source,
+            sampling=item.sampling,
+            criticality=item.criticality,
+            persistence=item.persistence,
+            downlink_priority=item.downlink_priority,
+            limits=_clean_model_dump(item.limits),
+            enum_values=tuple(item.enum or ()),
+            quality=_clean_model_dump(item.quality),
+            description=item.description,
+        )
+        for item in sorted(model.telemetry, key=lambda item: item.id)
+    )
+
+
+def _commands(model: MissionModel) -> tuple[GroundCommand, ...]:
+    return tuple(
+        GroundCommand(
+            model_id=command.id,
+            target=command.target,
+            description=command.description,
+            arguments=_command_arguments(command),
+            allowed_modes=tuple(command.allowed_modes),
+            preconditions=_clean_value(command.preconditions),
+            requires_ack=command.requires_ack,
+            timeout_ms=command.timeout_ms,
+            risk=command.risk,
+            emits=tuple(command.emits),
+            expected_effects=_clean_dict(command.expected_effects),
+        )
+        for command in sorted(model.commands, key=lambda item: item.id)
+    )
+
+
+def _command_arguments(command: Command) -> tuple[GroundCommandArgument, ...]:
+    return tuple(
+        GroundCommandArgument(
+            name=argument.name,
+            value_type=argument.type,
+            minimum=argument.min,
+            maximum=argument.max,
+            enum_values=tuple(argument.enum or ()),
+            default=argument.default,
+            description=argument.description,
+        )
+        for argument in command.arguments
+    )
+
+
+def _events(model: MissionModel) -> tuple[GroundEvent, ...]:
+    return tuple(
+        GroundEvent(
+            model_id=event.id,
+            source=event.source,
+            severity=event.severity,
+            description=event.description,
+            downlink_priority=event.downlink_priority,
+            persistence=event.persistence,
+        )
+        for event in sorted(model.events, key=lambda item: item.id)
+    )
+
+
+def _faults(model: MissionModel) -> tuple[GroundFault, ...]:
+    return tuple(
+        GroundFault(
+            model_id=fault.id,
+            source=fault.source,
+            severity=fault.severity,
+            description=fault.description,
+            condition=_clean_model_dump(fault.condition),
+            emits=tuple(fault.emits),
+            recovery=_clean_model_dump(fault.recovery),
+        )
+        for fault in sorted(model.faults, key=lambda item: item.id)
+    )
+
+
+def _data_products(model: MissionModel) -> tuple[GroundDataProduct, ...]:
+    return tuple(
+        GroundDataProduct(
+            model_id=data_product.id,
+            producer=data_product.producer,
+            producer_type=data_product.producer_type,
+            type=data_product.type,
+            estimated_size_bytes=data_product.estimated_size_bytes,
+            priority=data_product.priority,
+            payload=data_product.payload,
+            storage=_clean_model_dump(data_product.storage),
+            downlink=_clean_model_dump(data_product.downlink),
+            description=data_product.description,
+        )
+        for data_product in sorted(model.data_products, key=lambda item: item.id)
+    )
+
+
+def _packets(model: MissionModel) -> tuple[GroundPacket, ...]:
+    return tuple(
+        GroundPacket(
+            model_id=packet.id,
+            name=packet.name,
+            type=packet.type,
+            max_payload_bytes=packet.max_payload_bytes,
+            period=packet.period,
+            telemetry=tuple(packet.telemetry),
+            description=packet.description,
+        )
+        for packet in sorted(model.packets, key=lambda item: item.id)
+    )
+
+
+def _clean_model_dump(value: BaseModel | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+
+    dumped = value.model_dump(by_alias=True)
+    return _clean_dict(dumped)
+
+
+def _clean_dict(value: dict[str, Any]) -> dict[str, Any]:
+    cleaned = _clean_value(value)
+    if isinstance(cleaned, dict):
+        return cleaned
+    return {}
+
+
+def _clean_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return _clean_model_dump(value)
+
+    if isinstance(value, dict):
+        return {
+            key: cleaned
+            for key, item in value.items()
+            if (cleaned := _clean_value(item)) is not None
+        }
+
+    if isinstance(value, list):
+        return [_clean_value(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(_clean_value(item) for item in value)
+
+    return value

--- a/src/orbitfabric/gen/ground/contract.py
+++ b/src/orbitfabric/gen/ground/contract.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GroundCommandArgument:
+    """Command argument exposed through the ground-facing contract."""
+
+    name: str
+    value_type: str
+    minimum: float | int | None = None
+    maximum: float | int | None = None
+    enum_values: tuple[str, ...] = ()
+    default: Any | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class GroundTelemetryItem:
+    """Telemetry item exported to ground-facing dictionaries."""
+
+    model_id: str
+    name: str
+    value_type: str
+    unit: str
+    source: str
+    sampling: str
+    criticality: str
+    persistence: str
+    downlink_priority: str
+    limits: dict[str, Any] = field(default_factory=dict)
+    enum_values: tuple[str, ...] = ()
+    quality: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class GroundCommand:
+    """Command exported to ground-facing dictionaries."""
+
+    model_id: str
+    target: str
+    description: str
+    arguments: tuple[GroundCommandArgument, ...]
+    allowed_modes: tuple[str, ...]
+    preconditions: Any | None
+    requires_ack: bool
+    timeout_ms: int | None
+    risk: str
+    emits: tuple[str, ...] = ()
+    expected_effects: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GroundEvent:
+    """Event exported to ground-facing dictionaries."""
+
+    model_id: str
+    source: str
+    severity: str
+    description: str
+    downlink_priority: str | None = None
+    persistence: str | None = None
+
+
+@dataclass(frozen=True)
+class GroundFault:
+    """Fault exported to ground-facing dictionaries."""
+
+    model_id: str
+    source: str
+    severity: str
+    description: str
+    condition: dict[str, Any]
+    emits: tuple[str, ...] = ()
+    recovery: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GroundDataProduct:
+    """Data product exported to ground-facing dictionaries."""
+
+    model_id: str
+    producer: str
+    producer_type: str
+    type: str
+    estimated_size_bytes: int
+    priority: str
+    payload: str | None = None
+    storage: dict[str, Any] = field(default_factory=dict)
+    downlink: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class GroundPacket:
+    """Packet membership exported to ground-facing dictionaries."""
+
+    model_id: str
+    name: str
+    type: str
+    max_payload_bytes: int
+    period: str | None
+    telemetry: tuple[str, ...]
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class GroundContract:
+    """Ground-facing contract surface derived from a validated Mission Model."""
+
+    mission_id: str
+    mission_name: str
+    model_version: str
+    generation_profile: str
+    telemetry: tuple[GroundTelemetryItem, ...] = ()
+    commands: tuple[GroundCommand, ...] = ()
+    events: tuple[GroundEvent, ...] = ()
+    faults: tuple[GroundFault, ...] = ()
+    data_products: tuple[GroundDataProduct, ...] = ()
+    packets: tuple[GroundPacket, ...] = ()

--- a/tests/test_ground_contract.py
+++ b/tests/test_ground_contract.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.gen.ground import build_ground_contract
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_build_ground_contract_from_demo_mission() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model)
+
+    assert contract.mission_id == "demo-3u"
+    assert contract.mission_name == "Demo 3U Spacecraft"
+    assert contract.model_version == "0.1.0"
+    assert contract.generation_profile == "generic"
+    assert len(contract.telemetry) == len(model.telemetry)
+    assert len(contract.commands) == len(model.commands)
+    assert len(contract.events) == len(model.events)
+    assert len(contract.faults) == len(model.faults)
+    assert len(contract.data_products) == len(model.data_products)
+    assert len(contract.packets) == len(model.packets)
+
+
+def test_ground_contract_uses_deterministic_ordering() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model)
+
+    assert [item.model_id for item in contract.telemetry] == sorted(
+        item.id for item in model.telemetry
+    )
+    assert [item.model_id for item in contract.commands] == sorted(
+        item.id for item in model.commands
+    )
+    assert [item.model_id for item in contract.events] == sorted(
+        item.id for item in model.events
+    )
+    assert [item.model_id for item in contract.faults] == sorted(
+        item.id for item in model.faults
+    )
+    assert [item.model_id for item in contract.data_products] == sorted(
+        item.id for item in model.data_products
+    )
+    assert [item.model_id for item in contract.packets] == sorted(
+        item.id for item in model.packets
+    )
+
+
+def test_ground_contract_exports_telemetry_metadata() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model)
+
+    telemetry = next(
+        item for item in contract.telemetry if item.model_id == "eps.battery.voltage"
+    )
+
+    assert telemetry.name == "Battery Voltage"
+    assert telemetry.value_type == "float32"
+    assert telemetry.unit == "V"
+    assert telemetry.source == "eps"
+    assert telemetry.sampling == "1Hz"
+    assert telemetry.criticality == "high"
+    assert telemetry.persistence == "store_and_downlink"
+    assert telemetry.downlink_priority == "high"
+    assert telemetry.limits["warning_low"] == 6.8
+    assert telemetry.limits["critical_low"] == 6.4
+    assert telemetry.quality == {"required": True, "default": "good"}
+
+
+def test_ground_contract_exports_command_metadata() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model)
+
+    command = next(
+        item for item in contract.commands if item.model_id == "payload.start_acquisition"
+    )
+
+    assert command.target == "payload"
+    assert command.allowed_modes == ("NOMINAL",)
+    assert command.requires_ack is True
+    assert command.timeout_ms == 1000
+    assert command.risk == "medium"
+    assert command.emits == ("payload.acquisition_started",)
+    assert command.expected_effects["data_products"] == [
+        "payload.radiation_histogram"
+    ]
+    assert command.preconditions == {
+        "payload_lifecycle": {
+            "payload": "demo_iod_payload",
+            "state": "READY",
+        }
+    }
+    assert len(command.arguments) == 1
+
+    argument = command.arguments[0]
+    assert argument.name == "duration_s"
+    assert argument.value_type == "uint16"
+    assert argument.minimum == 1
+    assert argument.maximum == 600
+
+
+def test_ground_contract_exports_event_fault_data_product_and_packet_metadata() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model)
+
+    event = next(item for item in contract.events if item.model_id == "eps.battery_low")
+    assert event.source == "eps"
+    assert event.severity == "warning"
+    assert event.downlink_priority == "high"
+    assert event.persistence == "store_and_downlink"
+
+    fault = next(
+        item for item in contract.faults if item.model_id == "eps.battery_low_fault"
+    )
+    assert fault.source == "eps"
+    assert fault.severity == "warning"
+    assert fault.condition["telemetry"] == "eps.battery.voltage"
+    assert fault.condition["value"] == 6.8
+    assert fault.emits == ("eps.battery_low",)
+    assert fault.recovery == {
+        "mode_transition": "DEGRADED",
+        "auto_commands": ["payload.stop_acquisition"],
+    }
+
+    data_product = next(
+        item
+        for item in contract.data_products
+        if item.model_id == "payload.radiation_histogram"
+    )
+    assert data_product.producer == "demo_iod_payload"
+    assert data_product.producer_type == "payload"
+    assert data_product.type == "histogram"
+    assert data_product.estimated_size_bytes == 4096
+    assert data_product.priority == "high"
+    assert data_product.storage == {
+        "class": "science",
+        "retention": "7d",
+        "overflow_policy": "drop_oldest",
+    }
+    assert data_product.downlink == {"policy": "next_available_contact"}
+
+    packet = next(item for item in contract.packets if item.model_id == "hk_fast")
+    assert packet.name == "Fast Housekeeping Packet"
+    assert packet.type == "json"
+    assert packet.max_payload_bytes == 512
+    assert packet.period == "1s"
+    assert packet.telemetry == (
+        "obc.mode",
+        "eps.battery.voltage",
+        "eps.battery.current",
+    )
+
+
+def test_ground_contract_supports_explicit_generation_profile() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    contract = build_ground_contract(model, generation_profile="test-profile")
+
+    assert contract.generation_profile == "test-profile"


### PR DESCRIPTION
## Summary

Introduce the core `GroundContract` intermediate model for the `v0.8.0 — Ground Integration Artifacts` milestone.

This PR adds only the internal ground-facing contract surface and its builder.

It does not add CLI commands, generated files, JSON exports, CSV exports or Markdown exports.

## Added

- `src/orbitfabric/gen/ground/contract.py`
- `src/orbitfabric/gen/ground/builder.py`
- `src/orbitfabric/gen/ground/__init__.py`
- `tests/test_ground_contract.py`

## Architectural position

The new dependency direction is:

```text
MissionModel
        -> build_ground_contract(...)
        -> GroundContract
```

This prepares the future v0.8.0 generation chain:

```text
Mission Model
        -> validation and linting
        -> GroundContract
        -> generic ground-facing dictionaries
        -> JSON / Markdown / CSV exports
```

## GroundContract domains

The initial ground-facing contract surface includes:

- telemetry
- commands
- command arguments
- events
- faults
- data products
- packets

The builder preserves existing Mission Model semantics and keeps ordering deterministic by sorting exported domains by model ID.

## Boundary

This PR intentionally does not implement:

- `orbitfabric gen ground`
- generated ground files
- JSON dictionaries
- CSV tables
- Markdown review pages
- ground runtime behavior
- decoder generation
- command uplink behavior
- database/archive behavior
- Yamcs/OpenC3/XTCE integration
- CCSDS/PUS/CFDP behavior
- security enforcement

## Tests

Added tests cover:

- building `GroundContract` from `examples/demo-3u/mission`
- deterministic ordering
- telemetry metadata export
- command metadata export
- event metadata export
- fault metadata export
- data product metadata export
- packet membership metadata export
- explicit generation profile override

## Related issue

Part of #123.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.
