### PR TITLE
feat: add ground manifest and JSON dictionary exports

### DIFF
--- a/src/orbitfabric/gen/ground/__init__.py
+++ b/src/orbitfabric/gen/ground/__init__.py
@@ -2,8 +2,20 @@ from __future__ import annotations
 
 from orbitfabric.gen.ground.builder import build_ground_contract
 from orbitfabric.gen.ground.contract import GroundContract
+from orbitfabric.gen.ground.json_export import (
+    ground_dictionary_documents,
+    write_ground_dictionary_json_files,
+)
+from orbitfabric.gen.ground.manifest import (
+    ground_contract_manifest,
+    write_ground_contract_manifest,
+)
 
 __all__ = [
     "GroundContract",
     "build_ground_contract",
+    "ground_contract_manifest",
+    "ground_dictionary_documents",
+    "write_ground_contract_manifest",
+    "write_ground_dictionary_json_files",
 ]

--- a/src/orbitfabric/gen/ground/json_export.py
+++ b/src/orbitfabric/gen/ground/json_export.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric.gen.ground.contract import GroundContract
+from orbitfabric.gen.ground.json_safe import json_safe
 
 
 def ground_dictionary_documents(contract: GroundContract) -> dict[str, list[dict[str, Any]]]:
     """Return deterministic JSON dictionary documents from a GroundContract."""
-    return {
+    documents = {
         "telemetry_dictionary": [asdict(item) for item in contract.telemetry],
         "command_dictionary": [asdict(item) for item in contract.commands],
         "event_dictionary": [asdict(item) for item in contract.events],
@@ -18,6 +19,7 @@ def ground_dictionary_documents(contract: GroundContract) -> dict[str, list[dict
         "data_product_dictionary": [asdict(item) for item in contract.data_products],
         "packet_dictionary": [asdict(item) for item in contract.packets],
     }
+    return json_safe(documents)
 
 
 def write_ground_dictionary_json_files(

--- a/src/orbitfabric/gen/ground/json_export.py
+++ b/src/orbitfabric/gen/ground/json_export.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.gen.ground.contract import GroundContract
+
+
+def ground_dictionary_documents(contract: GroundContract) -> dict[str, list[dict[str, Any]]]:
+    """Return deterministic JSON dictionary documents from a GroundContract."""
+    return {
+        "telemetry_dictionary": [asdict(item) for item in contract.telemetry],
+        "command_dictionary": [asdict(item) for item in contract.commands],
+        "event_dictionary": [asdict(item) for item in contract.events],
+        "fault_dictionary": [asdict(item) for item in contract.faults],
+        "data_product_dictionary": [asdict(item) for item in contract.data_products],
+        "packet_dictionary": [asdict(item) for item in contract.packets],
+    }
+
+
+def write_ground_dictionary_json_files(
+    contract: GroundContract,
+    output_dir: Path,
+) -> list[Path]:
+    """Write deterministic JSON dictionary files for a GroundContract."""
+    dictionaries_dir = output_dir / "dictionaries"
+    dictionaries_dir.mkdir(parents=True, exist_ok=True)
+
+    written_files: list[Path] = []
+    for name, document in ground_dictionary_documents(contract).items():
+        output_file = dictionaries_dir / f"{name}.json"
+        output_file.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        written_files.append(output_file)
+
+    return written_files

--- a/src/orbitfabric/gen/ground/json_safe.py
+++ b/src/orbitfabric/gen/ground/json_safe.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def json_safe(value: Any) -> Any:
+    """Return a JSON-compatible representation of nested Python values."""
+    if isinstance(value, dict):
+        return {key: json_safe(item) for key, item in value.items()}
+
+    if isinstance(value, tuple | list):
+        return [json_safe(item) for item in value]
+
+    return value

--- a/src/orbitfabric/gen/ground/manifest.py
+++ b/src/orbitfabric/gen/ground/manifest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric.gen.ground.contract import GroundContract
+from orbitfabric.gen.ground.json_safe import json_safe
 
 
 def ground_contract_manifest(contract: GroundContract) -> dict[str, Any]:
@@ -37,7 +38,7 @@ def ground_contract_manifest(contract: GroundContract) -> dict[str, Any]:
             "data_products": len(contract.data_products),
             "packets": len(contract.packets),
         },
-        "contract": asdict(contract),
+        "contract": json_safe(asdict(contract)),
     }
 
 

--- a/src/orbitfabric/gen/ground/manifest.py
+++ b/src/orbitfabric/gen/ground/manifest.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.gen.ground.contract import GroundContract
+
+
+def ground_contract_manifest(contract: GroundContract) -> dict[str, Any]:
+    """Return a deterministic JSON-serializable GroundContract manifest."""
+    return {
+        "manifest_version": "0.1",
+        "kind": "orbitfabric.ground_contract_manifest",
+        "mission": {
+            "id": contract.mission_id,
+            "name": contract.mission_name,
+            "model_version": contract.model_version,
+        },
+        "generation": {
+            "profile": contract.generation_profile,
+            "generated_artifacts_are_disposable": True,
+            "contains_ground_runtime": False,
+            "contains_operator_console": False,
+            "contains_transport": False,
+            "contains_database": False,
+            "claims_yamcs_compatibility": False,
+            "claims_openc3_compatibility": False,
+            "claims_xtce_compliance": False,
+        },
+        "counts": {
+            "telemetry": len(contract.telemetry),
+            "commands": len(contract.commands),
+            "events": len(contract.events),
+            "faults": len(contract.faults),
+            "data_products": len(contract.data_products),
+            "packets": len(contract.packets),
+        },
+        "contract": asdict(contract),
+    }
+
+
+def write_ground_contract_manifest(
+    contract: GroundContract,
+    output_file: Path,
+) -> Path:
+    """Write a deterministic GroundContract manifest JSON file."""
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(ground_contract_manifest(contract), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_file

--- a/tests/test_ground_json_export.py
+++ b/tests/test_ground_json_export.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orbitfabric.gen.ground import (
+    build_ground_contract,
+    ground_dictionary_documents,
+    write_ground_dictionary_json_files,
+)
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_ground_dictionary_documents_include_expected_domains() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    documents = ground_dictionary_documents(contract)
+
+    assert set(documents) == {
+        "telemetry_dictionary",
+        "command_dictionary",
+        "event_dictionary",
+        "fault_dictionary",
+        "data_product_dictionary",
+        "packet_dictionary",
+    }
+    assert len(documents["telemetry_dictionary"]) == len(contract.telemetry)
+    assert len(documents["command_dictionary"]) == len(contract.commands)
+    assert len(documents["event_dictionary"]) == len(contract.events)
+    assert len(documents["fault_dictionary"]) == len(contract.faults)
+    assert len(documents["data_product_dictionary"]) == len(contract.data_products)
+    assert len(documents["packet_dictionary"]) == len(contract.packets)
+
+
+def test_ground_dictionary_documents_preserve_deterministic_ordering() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    documents = ground_dictionary_documents(contract)
+
+    for dictionary in documents.values():
+        model_ids = [item["model_id"] for item in dictionary]
+        assert model_ids == sorted(model_ids)
+
+
+def test_ground_dictionary_documents_export_command_and_telemetry_metadata() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    documents = ground_dictionary_documents(contract)
+
+    telemetry = next(
+        item
+        for item in documents["telemetry_dictionary"]
+        if item["model_id"] == "eps.battery.voltage"
+    )
+    assert telemetry["value_type"] == "float32"
+    assert telemetry["unit"] == "V"
+    assert telemetry["criticality"] == "high"
+    assert telemetry["limits"]["warning_low"] == 6.8
+
+    command = next(
+        item
+        for item in documents["command_dictionary"]
+        if item["model_id"] == "payload.start_acquisition"
+    )
+    assert command["target"] == "payload"
+    assert command["requires_ack"] is True
+    assert command["timeout_ms"] == 1000
+    assert command["risk"] == "medium"
+    assert command["expected_effects"]["data_products"] == [
+        "payload.radiation_histogram"
+    ]
+    assert command["arguments"][0]["name"] == "duration_s"
+    assert command["arguments"][0]["value_type"] == "uint16"
+
+
+def test_write_ground_dictionary_json_files(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    written_files = write_ground_dictionary_json_files(contract, tmp_path)
+
+    assert written_files == [
+        tmp_path / "dictionaries" / "telemetry_dictionary.json",
+        tmp_path / "dictionaries" / "command_dictionary.json",
+        tmp_path / "dictionaries" / "event_dictionary.json",
+        tmp_path / "dictionaries" / "fault_dictionary.json",
+        tmp_path / "dictionaries" / "data_product_dictionary.json",
+        tmp_path / "dictionaries" / "packet_dictionary.json",
+    ]
+
+    for output_file in written_files:
+        assert output_file.exists()
+        content = output_file.read_text(encoding="utf-8")
+        assert content.endswith("\n")
+        assert isinstance(json.loads(content), list)
+
+    telemetry_document = json.loads(
+        (tmp_path / "dictionaries" / "telemetry_dictionary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert telemetry_document == ground_dictionary_documents(contract)[
+        "telemetry_dictionary"
+    ]

--- a/tests/test_ground_manifest.py
+++ b/tests/test_ground_manifest.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orbitfabric.gen.ground import (
+    build_ground_contract,
+    ground_contract_manifest,
+    write_ground_contract_manifest,
+)
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_ground_contract_manifest_contains_boundary_flags() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    manifest = ground_contract_manifest(contract)
+
+    assert manifest["manifest_version"] == "0.1"
+    assert manifest["kind"] == "orbitfabric.ground_contract_manifest"
+    assert manifest["mission"]["id"] == "demo-3u"
+    assert manifest["mission"]["name"] == "Demo 3U Spacecraft"
+    assert manifest["mission"]["model_version"] == "0.1.0"
+    assert manifest["generation"]["profile"] == "generic"
+    assert manifest["generation"]["generated_artifacts_are_disposable"] is True
+    assert manifest["generation"]["contains_ground_runtime"] is False
+    assert manifest["generation"]["contains_operator_console"] is False
+    assert manifest["generation"]["contains_transport"] is False
+    assert manifest["generation"]["contains_database"] is False
+    assert manifest["generation"]["claims_yamcs_compatibility"] is False
+    assert manifest["generation"]["claims_openc3_compatibility"] is False
+    assert manifest["generation"]["claims_xtce_compliance"] is False
+
+
+def test_ground_contract_manifest_counts_contract_domains() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    manifest = ground_contract_manifest(contract)
+
+    assert manifest["counts"] == {
+        "telemetry": len(contract.telemetry),
+        "commands": len(contract.commands),
+        "events": len(contract.events),
+        "faults": len(contract.faults),
+        "data_products": len(contract.data_products),
+        "packets": len(contract.packets),
+    }
+
+
+def test_write_ground_contract_manifest_is_deterministic_json(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+    output_file = tmp_path / "ground_contract_manifest.json"
+
+    written_file = write_ground_contract_manifest(contract, output_file)
+
+    assert written_file == output_file
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert content.endswith("\n")
+
+    parsed = json.loads(content)
+    assert parsed == ground_contract_manifest(contract)


### PR DESCRIPTION
## Summary

Add the first machine-readable ground-facing export helpers for the `v0.8.0 — Ground Integration Artifacts` milestone.

This PR adds deterministic manifest and JSON dictionary exports from `GroundContract`.

It does not add the CLI command yet.

## Added

- `src/orbitfabric/gen/ground/manifest.py`
- `src/orbitfabric/gen/ground/json_export.py`
- public exports from `src/orbitfabric/gen/ground/__init__.py`
- `tests/test_ground_manifest.py`
- `tests/test_ground_json_export.py`

## Generated artifact shape prepared by this PR

The helpers prepare this future generated structure:

```text
generated/ground/generic/
├── ground_contract_manifest.json
└── dictionaries/
    ├── telemetry_dictionary.json
    ├── command_dictionary.json
    ├── event_dictionary.json
    ├── fault_dictionary.json
    ├── data_product_dictionary.json
    └── packet_dictionary.json
```

No generated files are committed in this PR.

## Manifest boundary

The ground manifest explicitly declares that generated ground artifacts are disposable and do not contain or claim:

- ground runtime
- operator console
- transport
- database
- Yamcs compatibility
- OpenC3 compatibility
- XTCE compliance

## JSON dictionaries

The JSON dictionary helper currently exports:

- telemetry dictionary
- command dictionary
- event dictionary
- fault dictionary
- data product dictionary
- packet dictionary

All dictionaries are derived from `GroundContract`, not directly from raw YAML.

## Boundary

This PR intentionally does not implement:

- `orbitfabric gen ground`
- CLI behavior
- CSV output
- Markdown output
- README generation
- ground runtime behavior
- decoder generation
- command uplink behavior
- database/archive behavior
- Yamcs/OpenC3/XTCE integration
- CCSDS/PUS/CFDP behavior
- security enforcement

## Tests

Added tests cover:

- manifest shape
- manifest boundary flags
- manifest counts
- deterministic manifest JSON writing
- dictionary domain coverage
- deterministic dictionary ordering
- command and telemetry metadata in JSON documents
- JSON dictionary file writing

## Related issue

Part of #123.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.
