### PR TITLE
feat: add ground generation CLI

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -8,6 +8,11 @@ import typer
 from orbitfabric import __version__
 from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
 from orbitfabric.gen.docs import generate_markdown_docs
+from orbitfabric.gen.ground import (
+    build_ground_contract,
+    write_ground_contract_manifest,
+    write_ground_dictionary_json_files,
+)
 from orbitfabric.gen.runtime import (
     build_runtime_contract,
     generate_cpp17_runtime_files,
@@ -272,6 +277,76 @@ def gen_runtime(
     typer.echo(f"  packets: {len(contract.packets)}")
     typer.echo(f"  payloads: {len(contract.payloads)}")
     typer.echo(f"  data products: {len(contract.data_products)}")
+    typer.echo("\nResult: PASSED")
+
+
+@gen_app.command("ground")
+def gen_ground(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory used to generate ground-facing artifacts.",
+        ),
+    ],
+    output_dir: Annotated[
+        Path,
+        typer.Option(
+            "--output-dir",
+            help="Directory where ground generation artifacts will be written.",
+        ),
+    ] = Path("generated/ground"),
+    profile: Annotated[
+        str,
+        typer.Option(
+            "--profile",
+            help="Ground generation profile. Currently only 'generic' is supported.",
+        ),
+    ] = "generic",
+) -> None:
+    """Generate ground-facing contract artifacts from a Mission Model."""
+    typer.echo(f"OrbitFabric Ground Generator {__version__}")
+
+    if profile != "generic":
+        typer.echo(f"\nUnsupported ground generation profile: {profile}")
+        typer.echo("Supported profiles: generic")
+        raise typer.Exit(code=1)
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    report = LintEngine().run(model)
+    if report.has_errors:
+        _print_loaded_model_summary(model)
+        _print_lint_report(report)
+        typer.echo("\nGround generation aborted because lint errors exist.")
+        raise typer.Exit(code=1)
+
+    contract = build_ground_contract(model, generation_profile=profile)
+    profile_output_dir = output_dir / profile
+    manifest_file = profile_output_dir / "ground_contract_manifest.json"
+    generated_files = [write_ground_contract_manifest(contract, manifest_file)]
+    generated_files.extend(write_ground_dictionary_json_files(contract, profile_output_dir))
+
+    typer.echo(f"\nMission: {model.spacecraft.id}")
+    typer.echo(f"Model version: {model.spacecraft.model_version}")
+    typer.echo(f"Profile: {profile}")
+    typer.echo("\nGenerated files:")
+    for path in generated_files:
+        typer.echo(f"  {path}")
+    typer.echo("\nGround contract counts:")
+    typer.echo(f"  telemetry: {len(contract.telemetry)}")
+    typer.echo(f"  commands: {len(contract.commands)}")
+    typer.echo(f"  events: {len(contract.events)}")
+    typer.echo(f"  faults: {len(contract.faults)}")
+    typer.echo(f"  data products: {len(contract.data_products)}")
+    typer.echo(f"  packets: {len(contract.packets)}")
     typer.echo("\nResult: PASSED")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,86 @@ def test_gen_runtime_rejects_unsupported_profile(tmp_path: Path) -> None:
     assert not output_dir.exists()
 
 
+def test_gen_ground_writes_manifest_and_json_dictionaries(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ground"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "ground",
+            "examples/demo-3u/mission",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    manifest_file = output_dir / "generic" / "ground_contract_manifest.json"
+    telemetry_dictionary = output_dir / "generic" / "dictionaries" / "telemetry_dictionary.json"
+    command_dictionary = output_dir / "generic" / "dictionaries" / "command_dictionary.json"
+    event_dictionary = output_dir / "generic" / "dictionaries" / "event_dictionary.json"
+    fault_dictionary = output_dir / "generic" / "dictionaries" / "fault_dictionary.json"
+    data_product_dictionary = (
+        output_dir / "generic" / "dictionaries" / "data_product_dictionary.json"
+    )
+    packet_dictionary = output_dir / "generic" / "dictionaries" / "packet_dictionary.json"
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Ground Generator {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Profile: generic" in result.output
+    assert f"  {manifest_file}" in result.output
+    assert f"  {telemetry_dictionary}" in result.output
+    assert f"  {command_dictionary}" in result.output
+    assert f"  {event_dictionary}" in result.output
+    assert f"  {fault_dictionary}" in result.output
+    assert f"  {data_product_dictionary}" in result.output
+    assert f"  {packet_dictionary}" in result.output
+    assert "Ground contract counts:" in result.output
+    assert "Result: PASSED" in result.output
+    assert manifest_file.exists()
+    assert telemetry_dictionary.exists()
+    assert command_dictionary.exists()
+    assert event_dictionary.exists()
+    assert fault_dictionary.exists()
+    assert data_product_dictionary.exists()
+    assert packet_dictionary.exists()
+
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    assert manifest["kind"] == "orbitfabric.ground_contract_manifest"
+    assert manifest["generation"]["profile"] == "generic"
+    assert manifest["generation"]["contains_ground_runtime"] is False
+    assert manifest["generation"]["claims_yamcs_compatibility"] is False
+    assert manifest["generation"]["claims_openc3_compatibility"] is False
+    assert manifest["generation"]["claims_xtce_compliance"] is False
+    assert manifest["contract"]["mission_id"] == "demo-3u"
+
+    commands = json.loads(command_dictionary.read_text(encoding="utf-8"))
+    assert any(command["model_id"] == "payload.start_acquisition" for command in commands)
+
+
+def test_gen_ground_rejects_unsupported_profile(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ground"
+
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "ground",
+            "examples/demo-3u/mission",
+            "--output-dir",
+            str(output_dir),
+            "--profile",
+            "yamcs",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Unsupported ground generation profile: yamcs" in result.output
+    assert "Supported profiles: generic" in result.output
+    assert not output_dir.exists()
+
+
 def test_inspect_mission_loads_demo_mission() -> None:
     result = runner.invoke(app, ["inspect", "mission", "examples/demo-3u/mission"])
 


### PR DESCRIPTION
## Summary

Add the first CLI entry point for the `v0.8.0 — Ground Integration Artifacts` milestone.

This PR introduces:

```bash
orbitfabric gen ground examples/demo-3u/mission/
```

The command generates the generic ground-facing manifest and JSON dictionaries from the validated Mission Model through `GroundContract`.

## Added

- `orbitfabric gen ground`
- `--profile generic`, currently the only supported profile
- `--output-dir`, defaulting to `generated/ground`
- lint gate before generation
- CLI tests for success and unsupported profile rejection

## Generated output

Default command:

```bash
orbitfabric gen ground examples/demo-3u/mission/
```

Default output shape:

```text
generated/ground/generic/
├── ground_contract_manifest.json
└── dictionaries/
    ├── telemetry_dictionary.json
    ├── command_dictionary.json
    ├── event_dictionary.json
    ├── fault_dictionary.json
    ├── data_product_dictionary.json
    └── packet_dictionary.json
```

## Boundary

This PR intentionally does not add:

- CSV output
- Markdown output
- generated README
- ground runtime behavior
- decoder generation
- command uplink behavior
- database/archive behavior
- Yamcs/OpenC3/XTCE integration
- CCSDS/PUS/CFDP behavior
- security enforcement

## Tests

Added CLI coverage for:

- successful ground generation
- manifest file generation
- all six JSON dictionary files
- manifest boundary flags
- unsupported ground profile rejection

## Related issue

Part of #123.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.
