### PR TITLE
feat: add ground CSV dictionary exports

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -11,6 +11,7 @@ from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.gen.ground import (
     build_ground_contract,
     write_ground_contract_manifest,
+    write_ground_dictionary_csv_files,
     write_ground_dictionary_json_files,
 )
 from orbitfabric.gen.runtime import (
@@ -333,6 +334,7 @@ def gen_ground(
     manifest_file = profile_output_dir / "ground_contract_manifest.json"
     generated_files = [write_ground_contract_manifest(contract, manifest_file)]
     generated_files.extend(write_ground_dictionary_json_files(contract, profile_output_dir))
+    generated_files.extend(write_ground_dictionary_csv_files(contract, profile_output_dir))
 
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")

--- a/src/orbitfabric/gen/ground/__init__.py
+++ b/src/orbitfabric/gen/ground/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from orbitfabric.gen.ground.builder import build_ground_contract
 from orbitfabric.gen.ground.contract import GroundContract
+from orbitfabric.gen.ground.csv_export import write_ground_dictionary_csv_files
 from orbitfabric.gen.ground.json_export import (
     ground_dictionary_documents,
     write_ground_dictionary_json_files,
@@ -17,5 +18,6 @@ __all__ = [
     "ground_contract_manifest",
     "ground_dictionary_documents",
     "write_ground_contract_manifest",
+    "write_ground_dictionary_csv_files",
     "write_ground_dictionary_json_files",
 ]

--- a/src/orbitfabric/gen/ground/csv_export.py
+++ b/src/orbitfabric/gen/ground/csv_export.py
@@ -5,8 +5,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from orbitfabric.gen.ground import ground_dictionary_documents
 from orbitfabric.gen.ground.contract import GroundContract
+from orbitfabric.gen.ground.json_export import ground_dictionary_documents
 
 CSV_DICTIONARY_HEADERS: dict[str, tuple[str, ...]] = {
     "telemetry_dictionary": (

--- a/src/orbitfabric/gen/ground/csv_export.py
+++ b/src/orbitfabric/gen/ground/csv_export.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.gen.ground import ground_dictionary_documents
+from orbitfabric.gen.ground.contract import GroundContract
+
+CSV_DICTIONARY_HEADERS: dict[str, tuple[str, ...]] = {
+    "telemetry_dictionary": (
+        "model_id",
+        "name",
+        "value_type",
+        "unit",
+        "source",
+        "sampling",
+        "criticality",
+        "persistence",
+        "downlink_priority",
+        "limits",
+        "enum_values",
+        "quality",
+        "description",
+    ),
+    "command_dictionary": (
+        "model_id",
+        "target",
+        "description",
+        "arguments",
+        "allowed_modes",
+        "preconditions",
+        "requires_ack",
+        "timeout_ms",
+        "risk",
+        "emits",
+        "expected_effects",
+    ),
+    "event_dictionary": (
+        "model_id",
+        "source",
+        "severity",
+        "description",
+        "downlink_priority",
+        "persistence",
+    ),
+    "fault_dictionary": (
+        "model_id",
+        "source",
+        "severity",
+        "description",
+        "condition",
+        "emits",
+        "recovery",
+    ),
+    "data_product_dictionary": (
+        "model_id",
+        "producer",
+        "producer_type",
+        "type",
+        "estimated_size_bytes",
+        "priority",
+        "payload",
+        "storage",
+        "downlink",
+        "description",
+    ),
+    "packet_dictionary": (
+        "model_id",
+        "name",
+        "type",
+        "max_payload_bytes",
+        "period",
+        "telemetry",
+        "description",
+    ),
+}
+
+
+def write_ground_dictionary_csv_files(
+    contract: GroundContract,
+    output_dir: Path,
+) -> list[Path]:
+    """Write deterministic CSV dictionary files for a GroundContract."""
+    csv_dir = output_dir / "csv"
+    csv_dir.mkdir(parents=True, exist_ok=True)
+
+    written_files: list[Path] = []
+    documents = ground_dictionary_documents(contract)
+    for name, rows in documents.items():
+        output_file = csv_dir / f"{name}.csv"
+        _write_dictionary_csv(output_file, CSV_DICTIONARY_HEADERS[name], rows)
+        written_files.append(output_file)
+
+    return written_files
+
+
+def _write_dictionary_csv(
+    output_file: Path,
+    headers: tuple[str, ...],
+    rows: list[dict[str, Any]],
+) -> None:
+    with output_file.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=headers, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({header: _csv_cell(row.get(header)) for header in headers})
+
+
+def _csv_cell(value: Any) -> str | int | float | bool | None:
+    if isinstance(value, dict | list):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+    return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,12 @@ def test_gen_ground_writes_manifest_and_json_dictionaries(tmp_path: Path) -> Non
         output_dir / "generic" / "dictionaries" / "data_product_dictionary.json"
     )
     packet_dictionary = output_dir / "generic" / "dictionaries" / "packet_dictionary.json"
+    telemetry_csv = output_dir / "generic" / "csv" / "telemetry_dictionary.csv"
+    command_csv = output_dir / "generic" / "csv" / "command_dictionary.csv"
+    event_csv = output_dir / "generic" / "csv" / "event_dictionary.csv"
+    fault_csv = output_dir / "generic" / "csv" / "fault_dictionary.csv"
+    data_product_csv = output_dir / "generic" / "csv" / "data_product_dictionary.csv"
+    packet_csv = output_dir / "generic" / "csv" / "packet_dictionary.csv"
 
     assert result.exit_code == 0
     assert f"OrbitFabric Ground Generator {__version__}" in result.output
@@ -230,6 +236,12 @@ def test_gen_ground_writes_manifest_and_json_dictionaries(tmp_path: Path) -> Non
     assert f"  {fault_dictionary}" in result.output
     assert f"  {data_product_dictionary}" in result.output
     assert f"  {packet_dictionary}" in result.output
+    assert f"  {telemetry_csv}" in result.output
+    assert f"  {command_csv}" in result.output
+    assert f"  {event_csv}" in result.output
+    assert f"  {fault_csv}" in result.output
+    assert f"  {data_product_csv}" in result.output
+    assert f"  {packet_csv}" in result.output
     assert "Ground contract counts:" in result.output
     assert "Result: PASSED" in result.output
     assert manifest_file.exists()
@@ -239,6 +251,12 @@ def test_gen_ground_writes_manifest_and_json_dictionaries(tmp_path: Path) -> Non
     assert fault_dictionary.exists()
     assert data_product_dictionary.exists()
     assert packet_dictionary.exists()
+    assert telemetry_csv.exists()
+    assert command_csv.exists()
+    assert event_csv.exists()
+    assert fault_csv.exists()
+    assert data_product_csv.exists()
+    assert packet_csv.exists()
 
     manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
     assert manifest["kind"] == "orbitfabric.ground_contract_manifest"

--- a/tests/test_ground_csv_export.py
+++ b/tests/test_ground_csv_export.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from orbitfabric.gen.ground import build_ground_contract, write_ground_dictionary_csv_files
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_write_ground_dictionary_csv_files(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    written_files = write_ground_dictionary_csv_files(contract, tmp_path)
+
+    assert written_files == [
+        tmp_path / "csv" / "telemetry_dictionary.csv",
+        tmp_path / "csv" / "command_dictionary.csv",
+        tmp_path / "csv" / "event_dictionary.csv",
+        tmp_path / "csv" / "fault_dictionary.csv",
+        tmp_path / "csv" / "data_product_dictionary.csv",
+        tmp_path / "csv" / "packet_dictionary.csv",
+    ]
+
+    for output_file in written_files:
+        assert output_file.exists()
+        assert output_file.read_text(encoding="utf-8")
+
+
+def test_ground_csv_telemetry_headers_and_rows(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    write_ground_dictionary_csv_files(contract, tmp_path)
+
+    telemetry_file = tmp_path / "csv" / "telemetry_dictionary.csv"
+    with telemetry_file.open(encoding="utf-8", newline="") as stream:
+        rows = list(csv.DictReader(stream))
+
+    assert rows
+    assert rows[0].keys() == {
+        "model_id",
+        "name",
+        "value_type",
+        "unit",
+        "source",
+        "sampling",
+        "criticality",
+        "persistence",
+        "downlink_priority",
+        "limits",
+        "enum_values",
+        "quality",
+        "description",
+    }
+    assert [row["model_id"] for row in rows] == sorted(row["model_id"] for row in rows)
+
+    battery_voltage = next(
+        row for row in rows if row["model_id"] == "eps.battery.voltage"
+    )
+    assert battery_voltage["name"] == "Battery Voltage"
+    assert battery_voltage["value_type"] == "float32"
+    assert battery_voltage["unit"] == "V"
+    assert json.loads(battery_voltage["limits"])["warning_low"] == 6.8
+    assert json.loads(battery_voltage["quality"]) == {
+        "default": "good",
+        "required": True,
+    }
+
+
+def test_ground_csv_command_nested_fields_are_json_cells(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    write_ground_dictionary_csv_files(contract, tmp_path)
+
+    command_file = tmp_path / "csv" / "command_dictionary.csv"
+    with command_file.open(encoding="utf-8", newline="") as stream:
+        rows = list(csv.DictReader(stream))
+
+    command = next(row for row in rows if row["model_id"] == "payload.start_acquisition")
+
+    assert command["target"] == "payload"
+    assert command["risk"] == "medium"
+    assert json.loads(command["allowed_modes"]) == ["NOMINAL"]
+    assert json.loads(command["emits"]) == ["payload.acquisition_started"]
+    assert json.loads(command["arguments"])[0]["name"] == "duration_s"
+    assert json.loads(command["expected_effects"])["data_products"] == [
+        "payload.radiation_histogram"
+    ]


### PR DESCRIPTION
## Summary

Add CSV dictionary exports for the `v0.8.0 - Ground Integration Artifacts` milestone.

This PR extends the existing generic ground generation path with review-friendly CSV files, while keeping JSON as the machine-readable artifact format.

## Added

- `src/orbitfabric/gen/ground/csv_export.py`
- public `write_ground_dictionary_csv_files(...)` export
- CSV generation integrated into `orbitfabric gen ground`
- `tests/test_ground_csv_export.py`
- CLI assertions for generated CSV files

## Generated output added by this PR

The command:

```bash
orbitfabric gen ground examples/demo-3u/mission/
```

now also writes:

```text
generated/ground/generic/csv/
├── telemetry_dictionary.csv
├── command_dictionary.csv
├── event_dictionary.csv
├── fault_dictionary.csv
├── data_product_dictionary.csv
└── packet_dictionary.csv
```

## CSV strategy

CSV files are intended as review artifacts.

Simple scalar fields are written directly as columns.

Nested values such as limits, quality, command arguments, expected effects, packet telemetry membership and recovery metadata are serialized into stable compact JSON cells.

## Boundary

This PR intentionally does not add:

- Markdown output
- generated README
- ground runtime behavior
- decoder generation
- command uplink behavior
- database/archive behavior
- Yamcs/OpenC3/XTCE integration
- CCSDS/PUS/CFDP behavior
- security enforcement

## Tests

Added tests cover:

- all six CSV files are written
- stable CSV header fields
- deterministic row ordering
- telemetry scalar fields
- telemetry nested JSON cells
- command nested JSON cells
- CLI output includes generated CSV files

## Related issue

Part of #123.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.
