### PR TITLE
feat: add ground Markdown review artifacts

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -13,6 +13,7 @@ from orbitfabric.gen.ground import (
     write_ground_contract_manifest,
     write_ground_dictionary_csv_files,
     write_ground_dictionary_json_files,
+    write_ground_markdown_review_artifacts,
 )
 from orbitfabric.gen.runtime import (
     build_runtime_contract,
@@ -335,6 +336,7 @@ def gen_ground(
     generated_files = [write_ground_contract_manifest(contract, manifest_file)]
     generated_files.extend(write_ground_dictionary_json_files(contract, profile_output_dir))
     generated_files.extend(write_ground_dictionary_csv_files(contract, profile_output_dir))
+    generated_files.extend(write_ground_markdown_review_artifacts(contract, profile_output_dir))
 
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")

--- a/src/orbitfabric/gen/ground/__init__.py
+++ b/src/orbitfabric/gen/ground/__init__.py
@@ -11,6 +11,9 @@ from orbitfabric.gen.ground.manifest import (
     ground_contract_manifest,
     write_ground_contract_manifest,
 )
+from orbitfabric.gen.ground.markdown_export import (
+    write_ground_markdown_review_artifacts,
+)
 
 __all__ = [
     "GroundContract",
@@ -20,4 +23,5 @@ __all__ = [
     "write_ground_contract_manifest",
     "write_ground_dictionary_csv_files",
     "write_ground_dictionary_json_files",
+    "write_ground_markdown_review_artifacts",
 ]

--- a/src/orbitfabric/gen/ground/markdown_export.py
+++ b/src/orbitfabric/gen/ground/markdown_export.py
@@ -394,7 +394,7 @@ def _arguments(arguments: tuple[Any, ...]) -> str:
             rendered.append(f"`{argument.name}` ({argument.value_type}, {metadata})")
         else:
             rendered.append(f"`{argument.name}` ({argument.value_type})")
-    return "<br>".join(rendered)
+    return "; ".join(rendered)
 
 
 def _argument_metadata(argument: Any) -> str:
@@ -417,7 +417,7 @@ def _argument_metadata(argument: Any) -> str:
 def _list(values: tuple[str, ...] | list[str] | None) -> str:
     if not values:
         return ""
-    return "<br>".join(_code(value) for value in values)
+    return ", ".join(_code(value) for value in values)
 
 
 def _compact(value: Any) -> str:
@@ -425,12 +425,12 @@ def _compact(value: Any) -> str:
         return ""
 
     if isinstance(value, dict):
-        return "<br>".join(
+        return "; ".join(
             _compact_key_value(key, item) for key, item in value.items()
         )
 
     if isinstance(value, list | tuple):
-        return "<br>".join(_compact(item) for item in value)
+        return ", ".join(_compact(item) for item in value)
 
     return _text(value)
 

--- a/src/orbitfabric/gen/ground/markdown_export.py
+++ b/src/orbitfabric/gen/ground/markdown_export.py
@@ -26,11 +26,21 @@ def _render_readme(contract: GroundContract) -> str:
     lines = [
         "# OrbitFabric Ground Integration Artifacts",
         "",
-        "This directory contains generated ground-facing artifacts derived from the OrbitFabric Mission Model.",
+        (
+            "This directory contains generated ground-facing artifacts derived from "
+            "the OrbitFabric Mission Model."
+        ),
         "",
-        "These files are intended to help ground software engineers, mission operators and integration teams review what the spacecraft contract exposes to the ground side.",
+        (
+            "These files are intended to help ground software engineers, mission "
+            "operators and integration teams review what the spacecraft contract "
+            "exposes to the ground side."
+        ),
         "",
-        "The Mission Model remains the source of truth. These artifacts are generated outputs and can be deleted and regenerated at any time.",
+        (
+            "The Mission Model remains the source of truth. These artifacts are "
+            "generated outputs and can be deleted and regenerated at any time."
+        ),
         "",
         "## Mission",
         "",
@@ -43,11 +53,26 @@ def _render_readme(contract: GroundContract) -> str:
         "",
         "| Path | Purpose | Primary audience |",
         "| --- | --- | --- |",
-        "| `ground_contract_manifest.json` | Machine-readable manifest and boundary declaration. | Tooling and integration checks |",
-        "| `dictionaries/*.json` | Machine-readable ground dictionaries. | Ground tooling, scripts and automated checks |",
-        "| `csv/*.csv` | Review-friendly tabular dictionaries. | Engineers and reviewers |",
-        "| `ground_dictionaries.md` | Human-readable review document. | Engineers, operators and reviewers |",
-        "| `README.md` | This generated orientation file. | Everyone opening the artifact directory |",
+        (
+            "| `ground_contract_manifest.json` | Machine-readable manifest and "
+            "boundary declaration. | Tooling and integration checks |"
+        ),
+        (
+            "| `dictionaries/*.json` | Machine-readable ground dictionaries. | "
+            "Ground tooling, scripts and automated checks |"
+        ),
+        (
+            "| `csv/*.csv` | Review-friendly tabular dictionaries. | "
+            "Engineers and reviewers |"
+        ),
+        (
+            "| `ground_dictionaries.md` | Human-readable review document. | "
+            "Engineers, operators and reviewers |"
+        ),
+        (
+            "| `README.md` | This generated orientation file. | Everyone "
+            "opening the artifact directory |"
+        ),
         "",
         "## Contract coverage",
         "",
@@ -62,16 +87,33 @@ def _render_readme(contract: GroundContract) -> str:
         "",
         "## Boundary",
         "",
-        "These artifacts do not implement a ground system. They do not contain runtime behavior, transport behavior, database behavior, decoder logic or command uplink logic.",
+        (
+            "These artifacts do not implement a ground system. They do not contain "
+            "runtime behavior, transport behavior, database behavior, decoder logic "
+            "or command uplink logic."
+        ),
         "",
-        "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, PUS or CFDP. They provide generic, tool-neutral mission contract evidence that other tools can consume or map later.",
+        (
+            "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, "
+            "PUS or CFDP. They provide generic, tool-neutral mission contract "
+            "evidence that other tools can consume or map later."
+        ),
         "",
         "## Recommended review flow",
         "",
-        "1. Start from `ground_contract_manifest.json` to verify the mission identity, generation profile and declared boundary.",
-        "2. Read `ground_dictionaries.md` to review the contract as a coherent engineering document.",
+        (
+            "1. Start from `ground_contract_manifest.json` to verify the mission "
+            "identity, generation profile and declared boundary."
+        ),
+        (
+            "2. Read `ground_dictionaries.md` to review the contract as a coherent "
+            "engineering document."
+        ),
         "3. Use `csv/*.csv` for spreadsheet-style inspection and review comments.",
-        "4. Use `dictionaries/*.json` for scripts, tooling and deterministic integration checks.",
+        (
+            "4. Use `dictionaries/*.json` for scripts, tooling and deterministic "
+            "integration checks."
+        ),
         "",
     ]
     return "\n".join(lines)
@@ -87,13 +129,23 @@ def _render_ground_dictionaries(contract: GroundContract) -> str:
         "",
         f"Ground generation profile: `{contract.generation_profile}`",
         "",
-        "This document is generated from the OrbitFabric `GroundContract` and is intended for human review.",
+        (
+            "This document is generated from the OrbitFabric `GroundContract` and "
+            "is intended for human review."
+        ),
         "",
-        "It summarizes the ground-facing telemetry, commands, events, faults, data products and packets exposed by the Mission Model.",
+        (
+            "It summarizes the ground-facing telemetry, commands, events, faults, "
+            "data products and packets exposed by the Mission Model."
+        ),
         "",
         "## Review boundary",
         "",
-        "This document is not a ground runtime specification. It does not define binary packet decoding, transport protocols, database schemas, command uplink execution or operator console behavior.",
+        (
+            "This document is not a ground runtime specification. It does not "
+            "define binary packet decoding, transport protocols, database schemas, "
+            "command uplink execution or operator console behavior."
+        ),
         "",
         "It is a tool-neutral review layer over the mission data contract.",
         "",
@@ -105,7 +157,10 @@ def _render_ground_dictionaries(contract: GroundContract) -> str:
         f"| Commands | {len(contract.commands)} | Ground-callable command contract |",
         f"| Events | {len(contract.events)} | Operational event vocabulary |",
         f"| Faults | {len(contract.faults)} | Fault vocabulary and recovery hints |",
-        f"| Data products | {len(contract.data_products)} | Products to store, downlink or process |",
+        (
+            f"| Data products | {len(contract.data_products)} | Products to store, "
+            "downlink or process |"
+        ),
         f"| Packets | {len(contract.packets)} | Logical packet membership |",
         "",
     ]
@@ -124,9 +179,15 @@ def _render_telemetry(contract: GroundContract) -> list[str]:
     lines = [
         "## Telemetry dictionary",
         "",
-        "Telemetry entries describe values expected by the ground side. Limits and quality metadata are shown where available.",
+        (
+            "Telemetry entries describe values expected by the ground side. Limits "
+            "and quality metadata are shown where available."
+        ),
         "",
-        "| Model ID | Name | Type | Unit | Source | Sampling | Criticality | Persistence | Downlink | Limits | Quality |",
+        (
+            "| Model ID | Name | Type | Unit | Source | Sampling | Criticality | "
+            "Persistence | Downlink | Limits | Quality |"
+        ),
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for item in contract.telemetry:
@@ -157,9 +218,15 @@ def _render_commands(contract: GroundContract) -> list[str]:
     lines = [
         "## Command dictionary",
         "",
-        "Command entries describe the callable contract visible to the ground side. This is not a command encoder or uplink implementation.",
+        (
+            "Command entries describe the callable contract visible to the ground "
+            "side. This is not a command encoder or uplink implementation."
+        ),
         "",
-        "| Model ID | Target | Modes | Ack | Timeout ms | Risk | Arguments | Emits | Expected effects | Preconditions |",
+        (
+            "| Model ID | Target | Modes | Ack | Timeout ms | Risk | Arguments | "
+            "Emits | Expected effects | Preconditions |"
+        ),
         "| --- | --- | --- | --- | ---: | --- | --- | --- | --- | --- |",
     ]
     for item in contract.commands:
@@ -217,7 +284,10 @@ def _render_faults(contract: GroundContract) -> list[str]:
     lines = [
         "## Fault dictionary",
         "",
-        "Fault entries summarize fault identifiers, severity and recovery hints. They do not implement onboard or ground fault handling.",
+        (
+            "Fault entries summarize fault identifiers, severity and recovery "
+            "hints. They do not implement onboard or ground fault handling."
+        ),
         "",
         "| Model ID | Source | Severity | Condition | Emits | Recovery | Description |",
         "| --- | --- | --- | --- | --- | --- | --- |",
@@ -246,9 +316,15 @@ def _render_data_products(contract: GroundContract) -> list[str]:
     lines = [
         "## Data product dictionary",
         "",
-        "Data products describe files or logical products expected to be stored, downlinked or processed by the ground side.",
+        (
+            "Data products describe files or logical products expected to be "
+            "stored, downlinked or processed by the ground side."
+        ),
         "",
-        "| Model ID | Producer | Type | Size bytes | Priority | Storage | Downlink | Description |",
+        (
+            "| Model ID | Producer | Type | Size bytes | Priority | Storage | "
+            "Downlink | Description |"
+        ),
         "| --- | --- | --- | ---: | --- | --- | --- | --- |",
     ]
     for item in contract.data_products:
@@ -276,9 +352,15 @@ def _render_packets(contract: GroundContract) -> list[str]:
     lines = [
         "## Packet dictionary",
         "",
-        "Packets describe logical membership of model fields. They do not define binary layout, offsets, framing or transport.",
+        (
+            "Packets describe logical membership of model fields. They do not "
+            "define binary layout, offsets, framing or transport."
+        ),
         "",
-        "| Model ID | Name | Type | Max payload bytes | Period | Telemetry membership | Description |",
+        (
+            "| Model ID | Name | Type | Max payload bytes | Period | Telemetry "
+            "membership | Description |"
+        ),
         "| --- | --- | --- | ---: | --- | --- | --- |",
     ]
     for item in contract.packets:
@@ -329,14 +411,22 @@ def _compact(value: Any) -> str:
 
     if isinstance(value, dict):
         return "<br>".join(
-            f"{_text(key)}: {_compact(item) if isinstance(item, dict | list | tuple) else _text(item)}"
-            for key, item in value.items()
+            _compact_key_value(key, item) for key, item in value.items()
         )
 
     if isinstance(value, list | tuple):
         return "<br>".join(_compact(item) for item in value)
 
     return _text(value)
+
+
+def _compact_key_value(key: Any, value: Any) -> str:
+    if isinstance(value, dict | list | tuple):
+        rendered_value = _compact(value)
+    else:
+        rendered_value = _text(value)
+
+    return f"{_text(key)}: {rendered_value}"
 
 
 def _bool(value: bool) -> str:

--- a/src/orbitfabric/gen/ground/markdown_export.py
+++ b/src/orbitfabric/gen/ground/markdown_export.py
@@ -389,14 +389,29 @@ def _arguments(arguments: tuple[Any, ...]) -> str:
 
     rendered = []
     for argument in arguments:
-        constraints = _compact(argument.constraints)
-        if constraints:
-            rendered.append(
-                f"`{argument.name}` ({argument.value_type}, {constraints})"
-            )
+        metadata = _argument_metadata(argument)
+        if metadata:
+            rendered.append(f"`{argument.name}` ({argument.value_type}, {metadata})")
         else:
             rendered.append(f"`{argument.name}` ({argument.value_type})")
     return "<br>".join(rendered)
+
+
+def _argument_metadata(argument: Any) -> str:
+    metadata: list[str] = []
+
+    if argument.minimum is not None:
+        metadata.append(f"min: {_text(argument.minimum)}")
+    if argument.maximum is not None:
+        metadata.append(f"max: {_text(argument.maximum)}")
+    if argument.enum_values:
+        metadata.append(f"enum: {_list(argument.enum_values)}")
+    if argument.default is not None:
+        metadata.append(f"default: {_text(argument.default)}")
+    if argument.description:
+        metadata.append(f"description: {_text(argument.description)}")
+
+    return "; ".join(metadata)
 
 
 def _list(values: tuple[str, ...] | list[str] | None) -> str:

--- a/src/orbitfabric/gen/ground/markdown_export.py
+++ b/src/orbitfabric/gen/ground/markdown_export.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.gen.ground.contract import GroundContract
+
+
+def write_ground_markdown_review_artifacts(
+    contract: GroundContract,
+    output_dir: Path,
+) -> list[Path]:
+    """Write human-reviewable Markdown artifacts for a GroundContract."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    readme_file = output_dir / "README.md"
+    dictionaries_file = output_dir / "ground_dictionaries.md"
+
+    readme_file.write_text(_render_readme(contract), encoding="utf-8")
+    dictionaries_file.write_text(_render_ground_dictionaries(contract), encoding="utf-8")
+
+    return [readme_file, dictionaries_file]
+
+
+def _render_readme(contract: GroundContract) -> str:
+    lines = [
+        "# OrbitFabric Ground Integration Artifacts",
+        "",
+        "This directory contains generated ground-facing artifacts derived from the OrbitFabric Mission Model.",
+        "",
+        "These files are intended to help ground software engineers, mission operators and integration teams review what the spacecraft contract exposes to the ground side.",
+        "",
+        "The Mission Model remains the source of truth. These artifacts are generated outputs and can be deleted and regenerated at any time.",
+        "",
+        "## Mission",
+        "",
+        f"- Mission ID: `{contract.mission_id}`",
+        f"- Mission name: {contract.mission_name}",
+        f"- Model version: `{contract.model_version}`",
+        f"- Ground profile: `{contract.generation_profile}`",
+        "",
+        "## Generated files",
+        "",
+        "| Path | Purpose | Primary audience |",
+        "| --- | --- | --- |",
+        "| `ground_contract_manifest.json` | Machine-readable manifest and boundary declaration. | Tooling and integration checks |",
+        "| `dictionaries/*.json` | Machine-readable ground dictionaries. | Ground tooling, scripts and automated checks |",
+        "| `csv/*.csv` | Review-friendly tabular dictionaries. | Engineers and reviewers |",
+        "| `ground_dictionaries.md` | Human-readable review document. | Engineers, operators and reviewers |",
+        "| `README.md` | This generated orientation file. | Everyone opening the artifact directory |",
+        "",
+        "## Contract coverage",
+        "",
+        "| Domain | Count |",
+        "| --- | ---: |",
+        f"| Telemetry | {len(contract.telemetry)} |",
+        f"| Commands | {len(contract.commands)} |",
+        f"| Events | {len(contract.events)} |",
+        f"| Faults | {len(contract.faults)} |",
+        f"| Data products | {len(contract.data_products)} |",
+        f"| Packets | {len(contract.packets)} |",
+        "",
+        "## Boundary",
+        "",
+        "These artifacts do not implement a ground system. They do not contain runtime behavior, transport behavior, database behavior, decoder logic or command uplink logic.",
+        "",
+        "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, PUS or CFDP. They provide generic, tool-neutral mission contract evidence that other tools can consume or map later.",
+        "",
+        "## Recommended review flow",
+        "",
+        "1. Start from `ground_contract_manifest.json` to verify the mission identity, generation profile and declared boundary.",
+        "2. Read `ground_dictionaries.md` to review the contract as a coherent engineering document.",
+        "3. Use `csv/*.csv` for spreadsheet-style inspection and review comments.",
+        "4. Use `dictionaries/*.json` for scripts, tooling and deterministic integration checks.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _render_ground_dictionaries(contract: GroundContract) -> str:
+    lines = [
+        "# Ground Dictionaries Review",
+        "",
+        f"Mission: `{contract.mission_id}`",
+        "",
+        f"Model version: `{contract.model_version}`",
+        "",
+        f"Ground generation profile: `{contract.generation_profile}`",
+        "",
+        "This document is generated from the OrbitFabric `GroundContract` and is intended for human review.",
+        "",
+        "It summarizes the ground-facing telemetry, commands, events, faults, data products and packets exposed by the Mission Model.",
+        "",
+        "## Review boundary",
+        "",
+        "This document is not a ground runtime specification. It does not define binary packet decoding, transport protocols, database schemas, command uplink execution or operator console behavior.",
+        "",
+        "It is a tool-neutral review layer over the mission data contract.",
+        "",
+        "## Summary",
+        "",
+        "| Domain | Count | Review focus |",
+        "| --- | ---: | --- |",
+        f"| Telemetry | {len(contract.telemetry)} | Values expected from the spacecraft |",
+        f"| Commands | {len(contract.commands)} | Ground-callable command contract |",
+        f"| Events | {len(contract.events)} | Operational event vocabulary |",
+        f"| Faults | {len(contract.faults)} | Fault vocabulary and recovery hints |",
+        f"| Data products | {len(contract.data_products)} | Products to store, downlink or process |",
+        f"| Packets | {len(contract.packets)} | Logical packet membership |",
+        "",
+    ]
+
+    lines.extend(_render_telemetry(contract))
+    lines.extend(_render_commands(contract))
+    lines.extend(_render_events(contract))
+    lines.extend(_render_faults(contract))
+    lines.extend(_render_data_products(contract))
+    lines.extend(_render_packets(contract))
+
+    return "\n".join(lines)
+
+
+def _render_telemetry(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Telemetry dictionary",
+        "",
+        "Telemetry entries describe values expected by the ground side. Limits and quality metadata are shown where available.",
+        "",
+        "| Model ID | Name | Type | Unit | Source | Sampling | Criticality | Persistence | Downlink | Limits | Quality |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for item in contract.telemetry:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _text(item.name),
+                    _code(item.value_type),
+                    _text(item.unit),
+                    _code(item.source),
+                    _text(item.sampling),
+                    _text(item.criticality),
+                    _text(item.persistence),
+                    _text(item.downlink_priority),
+                    _compact(item.limits),
+                    _compact(item.quality),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_commands(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Command dictionary",
+        "",
+        "Command entries describe the callable contract visible to the ground side. This is not a command encoder or uplink implementation.",
+        "",
+        "| Model ID | Target | Modes | Ack | Timeout ms | Risk | Arguments | Emits | Expected effects | Preconditions |",
+        "| --- | --- | --- | --- | ---: | --- | --- | --- | --- | --- |",
+    ]
+    for item in contract.commands:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _code(item.target),
+                    _list(item.allowed_modes),
+                    _bool(item.requires_ack),
+                    _text(item.timeout_ms),
+                    _text(item.risk),
+                    _arguments(item.arguments),
+                    _list(item.emits),
+                    _compact(item.expected_effects),
+                    _compact(item.preconditions),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_events(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Event dictionary",
+        "",
+        "Events define the operational vocabulary emitted by the spacecraft contract.",
+        "",
+        "| Model ID | Source | Severity | Downlink | Persistence | Description |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for item in contract.events:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _code(item.source),
+                    _text(item.severity),
+                    _text(item.downlink_priority),
+                    _text(item.persistence),
+                    _text(item.description),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_faults(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Fault dictionary",
+        "",
+        "Fault entries summarize fault identifiers, severity and recovery hints. They do not implement onboard or ground fault handling.",
+        "",
+        "| Model ID | Source | Severity | Condition | Emits | Recovery | Description |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for item in contract.faults:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _code(item.source),
+                    _text(item.severity),
+                    _compact(item.condition),
+                    _list(item.emits),
+                    _compact(item.recovery),
+                    _text(item.description),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_data_products(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Data product dictionary",
+        "",
+        "Data products describe files or logical products expected to be stored, downlinked or processed by the ground side.",
+        "",
+        "| Model ID | Producer | Type | Size bytes | Priority | Storage | Downlink | Description |",
+        "| --- | --- | --- | ---: | --- | --- | --- | --- |",
+    ]
+    for item in contract.data_products:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _code(item.producer),
+                    _text(item.type),
+                    _text(item.estimated_size_bytes),
+                    _text(item.priority),
+                    _compact(item.storage),
+                    _compact(item.downlink),
+                    _text(item.description),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_packets(contract: GroundContract) -> list[str]:
+    lines = [
+        "## Packet dictionary",
+        "",
+        "Packets describe logical membership of model fields. They do not define binary layout, offsets, framing or transport.",
+        "",
+        "| Model ID | Name | Type | Max payload bytes | Period | Telemetry membership | Description |",
+        "| --- | --- | --- | ---: | --- | --- | --- |",
+    ]
+    for item in contract.packets:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _code(item.model_id),
+                    _text(item.name),
+                    _text(item.type),
+                    _text(item.max_payload_bytes),
+                    _text(item.period),
+                    _list(item.telemetry),
+                    _text(item.description),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def _arguments(arguments: tuple[Any, ...]) -> str:
+    if not arguments:
+        return ""
+
+    rendered = []
+    for argument in arguments:
+        constraints = _compact(argument.constraints)
+        if constraints:
+            rendered.append(
+                f"`{argument.name}` ({argument.value_type}, {constraints})"
+            )
+        else:
+            rendered.append(f"`{argument.name}` ({argument.value_type})")
+    return "<br>".join(rendered)
+
+
+def _list(values: tuple[str, ...] | list[str] | None) -> str:
+    if not values:
+        return ""
+    return "<br>".join(_code(value) for value in values)
+
+
+def _compact(value: Any) -> str:
+    if value in (None, {}, [], ()):
+        return ""
+
+    if isinstance(value, dict):
+        return "<br>".join(
+            f"{_text(key)}: {_compact(item) if isinstance(item, dict | list | tuple) else _text(item)}"
+            for key, item in value.items()
+        )
+
+    if isinstance(value, list | tuple):
+        return "<br>".join(_compact(item) for item in value)
+
+    return _text(value)
+
+
+def _bool(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _code(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    return f"`{_escape_markdown(str(value))}`"
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return _escape_markdown(str(value))
+
+
+def _escape_markdown(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")

--- a/tests/test_ground_markdown_export.py
+++ b/tests/test_ground_markdown_export.py
@@ -44,7 +44,10 @@ def test_ground_readme_is_human_reviewable(tmp_path: Path) -> None:
     assert "`ground_contract_manifest.json`" in content
     assert "`ground_dictionaries.md`" in content
     assert "The Mission Model remains the source of truth." in content
-    assert "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, PUS or CFDP." in content
+    assert (
+        "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, "
+        "PUS or CFDP."
+    ) in content
 
 
 def test_ground_dictionaries_markdown_contains_review_sections(tmp_path: Path) -> None:

--- a/tests/test_ground_markdown_export.py
+++ b/tests/test_ground_markdown_export.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from orbitfabric.gen.ground import (
+    build_ground_contract,
+    write_ground_markdown_review_artifacts,
+)
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_write_ground_markdown_review_artifacts(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    written_files = write_ground_markdown_review_artifacts(contract, tmp_path)
+
+    assert written_files == [
+        tmp_path / "README.md",
+        tmp_path / "ground_dictionaries.md",
+    ]
+    assert (tmp_path / "README.md").exists()
+    assert (tmp_path / "ground_dictionaries.md").exists()
+
+
+def test_ground_readme_is_human_reviewable(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    write_ground_markdown_review_artifacts(contract, tmp_path)
+
+    content = (tmp_path / "README.md").read_text(encoding="utf-8")
+
+    assert content.startswith("# OrbitFabric Ground Integration Artifacts")
+    assert "## Mission" in content
+    assert "## Generated files" in content
+    assert "## Contract coverage" in content
+    assert "## Boundary" in content
+    assert "## Recommended review flow" in content
+    assert "Mission ID: `demo-3u`" in content
+    assert "Ground profile: `generic`" in content
+    assert "`ground_contract_manifest.json`" in content
+    assert "`ground_dictionaries.md`" in content
+    assert "The Mission Model remains the source of truth." in content
+    assert "They also do not claim compatibility with Yamcs, OpenC3, XTCE, CCSDS, PUS or CFDP." in content
+
+
+def test_ground_dictionaries_markdown_contains_review_sections(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    write_ground_markdown_review_artifacts(contract, tmp_path)
+
+    content = (tmp_path / "ground_dictionaries.md").read_text(encoding="utf-8")
+
+    assert content.startswith("# Ground Dictionaries Review")
+    assert "## Review boundary" in content
+    assert "## Summary" in content
+    assert "## Telemetry dictionary" in content
+    assert "## Command dictionary" in content
+    assert "## Event dictionary" in content
+    assert "## Fault dictionary" in content
+    assert "## Data product dictionary" in content
+    assert "## Packet dictionary" in content
+    assert "This document is generated from the OrbitFabric `GroundContract`" in content
+    assert "This document is not a ground runtime specification." in content
+
+
+def test_ground_dictionaries_markdown_contains_domain_content(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    contract = build_ground_contract(model)
+
+    write_ground_markdown_review_artifacts(contract, tmp_path)
+
+    content = (tmp_path / "ground_dictionaries.md").read_text(encoding="utf-8")
+
+    assert "`eps.battery.voltage`" in content
+    assert "Battery Voltage" in content
+    assert "warning_low: 6.8" in content
+    assert "`payload.start_acquisition`" in content
+    assert "`duration_s` (uint16" in content
+    assert "`payload.acquisition_started`" in content
+    assert "`eps.battery_low`" in content
+    assert "`eps.battery_low_fault`" in content
+    assert "`payload.radiation_histogram`" in content
+    assert "`hk_fast`" in content


### PR DESCRIPTION
## Summary

Add human-reviewable Markdown artifacts for the `v0.8.0 - Ground Integration Artifacts` milestone.

This PR completes the generic ground artifact set with readable review documents generated from `GroundContract`.

## Added

- `src/orbitfabric/gen/ground/markdown_export.py`
- public `write_ground_markdown_review_artifacts(...)` export
- Markdown review artifacts integrated into `orbitfabric gen ground`
- `tests/test_ground_markdown_export.py`

## Generated output added by this PR

The command:

```bash
orbitfabric gen ground examples/demo-3u/mission/
```

now also writes:

```text
generated/ground/generic/
├── README.md
└── ground_dictionaries.md
```

## Human-reviewable strategy

`README.md` is an orientation document for the generated artifact directory. It explains mission identity, generated file purpose, contract coverage, boundary and recommended review flow.

`ground_dictionaries.md` is a structured engineering review document. It includes readable sections for:

- telemetry
- commands
- events
- faults
- data products
- packets

The Markdown renderer avoids being a raw JSON dump. Scalar fields are shown directly, list values are split with line breaks, command arguments are summarized in readable form and nested metadata is compacted into review-friendly key/value text.

## Boundary

This PR intentionally does not add:

- ground runtime behavior
- decoder generation
- command uplink behavior
- database/archive behavior
- Yamcs/OpenC3/XTCE integration
- CCSDS/PUS/CFDP behavior
- security enforcement

## Tests

Added tests cover:

- README generation
- ground dictionary Markdown generation
- required review sections
- mission identity and profile visibility
- boundary wording
- domain-specific content visibility
- readable telemetry, command, event, fault, data product and packet references

## Related issue

Part of #128.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.
