### PR TITLE
docs: align v0.8.0 ground integration release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,63 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ---
 
-## [v0.7.0] — Generated Runtime Skeletons
+## [v0.8.0] - Ground Integration Artifacts
+
+### Added
+
+- Added the `GroundContract` intermediate model for ground-facing generation.
+- Added the `orbitfabric gen ground` command.
+- Added the initial `generic` ground generation profile.
+- Added `ground_contract_manifest.json` generation.
+- Added JSON ground dictionaries for telemetry, commands, events, faults, data products and packets.
+- Added CSV ground dictionaries for review workflows.
+- Added generated `README.md` for the ground artifact directory.
+- Added generated `ground_dictionaries.md` for human engineering review.
+- Added manifest boundary flags for ground runtime, operator console, transport, database, Yamcs, OpenC3 and XTCE claims.
+- Added Ground Integration Artifacts reference documentation.
+- Added ADR-0012 for the Ground Integration Artifacts boundary.
+- Added v0.8.0 release notes.
+
+### Changed
+
+- Extended the public documentation baseline from v0.7.0 to v0.8.0.
+- Extended the Mission Data Chain from runtime-facing contract bindings to ground-facing contract exports.
+- Updated README, architecture, roadmap, quickstart, development guide, contributing guide, versioning documentation and demo walkthrough for v0.8.0.
+- Updated the package and CLI version to `0.8.0`.
+- Marked `v0.9 - Plugin and Extensibility Layer` as the next roadmap milestone.
+
+### Boundaries
+
+The Ground Integration Artifacts slice intentionally does not introduce:
+
+- live ground segment;
+- mission control system;
+- operator console;
+- telemetry archive;
+- telemetry database;
+- command uplink service;
+- telecommand transport;
+- telemetry downlink runtime;
+- network/session/routing behavior;
+- command authentication or authorization;
+- security enforcement;
+- Yamcs integration;
+- OpenC3 integration;
+- XTCE compliance;
+- CCSDS/PUS/CFDP implementation;
+- binary packet decoder;
+- binary telecommand encoder;
+- offset/bitfield layout model;
+- calibration model;
+- RF/link-budget behavior;
+- pass scheduling;
+- station automation.
+
+Ground Integration Artifacts in v0.8.0 are ground-facing contract exports only.
+
+---
+
+## [v0.7.0] - Generated Runtime Skeletons
 
 ### Added
 
@@ -36,7 +92,7 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 - Extended the Mission Data Chain from data-flow evidence to runtime-facing contract bindings.
 - Updated README, architecture, roadmap, quickstart, development guide, contributing guide and versioning documentation for v0.7.0.
 - Updated the package and CLI version to `0.7.0`.
-- Marked `v0.8 — Ground Integration Artifacts` as the next roadmap milestone.
+- Marked `v0.8 - Ground Integration Artifacts` as the next roadmap milestone.
 
 ### Boundaries
 
@@ -65,7 +121,7 @@ Generated Runtime Skeletons in v0.7.0 are runtime-facing contract bindings only.
 
 ---
 
-## [v0.6.0] — End-to-End Mission Data Flow Evidence
+## [v0.6.0] - End-to-End Mission Data Flow Evidence
 
 ### Added
 
@@ -107,7 +163,7 @@ The End-to-End Mission Data Flow Evidence slice intentionally does not introduce
 
 ---
 
-## [v0.5.0] — Commandability and Autonomy Contracts
+## [v0.5.0] - Commandability and Autonomy Contracts
 
 ### Added
 
@@ -146,7 +202,7 @@ The Commandability and Autonomy Contract slice intentionally does not introduce:
 
 ---
 
-## [v0.4.0] — Contact Windows and Downlink Flow Contracts
+## [v0.4.0] - Contact Windows and Downlink Flow Contracts
 
 ### Added
 
@@ -196,7 +252,7 @@ The Contact Windows and Downlink Flow Contract slice intentionally does not intr
 
 ---
 
-## [v0.3.0] — Data Product and Storage Contracts
+## [v0.3.0] - Data Product and Storage Contracts
 
 ### Added
 
@@ -248,7 +304,7 @@ The Data Product and Storage Contract slice intentionally does not introduce:
 
 ---
 
-## [v0.2.2] — Payload Contract Release Alignment
+## [v0.2.2] - Payload Contract Release Alignment
 
 ### Changed
 
@@ -259,7 +315,7 @@ The Data Product and Storage Contract slice intentionally does not introduce:
 
 ---
 
-## [v0.2.1] — Payload Contract Model
+## [v0.2.1] - Payload Contract Model
 
 ### Added
 
@@ -274,7 +330,7 @@ The Data Product and Storage Contract slice intentionally does not introduce:
 - Added generated payload contract documentation.
 - Added generated `payloads.md` documentation output.
 - Added minimal payload-aware scenario behavior.
-- Added nominal payload lifecycle simulation for `READY → ACQUIRING → READY`.
+- Added nominal payload lifecycle simulation for `READY -> ACQUIRING -> READY`.
 - Added invalid payload contract fixtures.
 - Added negative tests for mutated payload contract fixtures.
 - Added ADR-0006 for the Payload Contract Model.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.7.0 — Generated Runtime Skeletons`.
+The current public baseline is `v0.8.0 - Ground Integration Artifacts`.
 
-In v0.7.0, Generated Runtime Skeletons means runtime-facing contract bindings.
+In v0.8.0, Ground Integration Artifacts means ground-facing Mission Data Contract exports.
 
-The next development focus is `v0.8 — Ground Integration Artifacts`.
+The next development focus is `v0.9 - Plugin and Extensibility Layer`.
 
 The current baseline proves this Mission Data Chain:
 
@@ -28,6 +28,7 @@ Payload Contract
   -> Commandability and Autonomy Contract
   -> End-to-End Mission Data Flow Evidence
   -> Runtime-Facing Contract Bindings
+  -> Ground-Facing Integration Artifacts
 ```
 
 Do not add large integrations before the contract model is coherent.
@@ -49,17 +50,22 @@ Out of scope for the current preview:
 - HAL;
 - CCSDS/PUS/CFDP implementation;
 - Yamcs/OpenC3 full integration;
+- XTCE compliance;
+- binary packet decoders;
+- telemetry archive runtime;
+- ground database implementation;
 - Basilisk integration;
 - cFS/F Prime bridge;
 - web UI;
-- database-backed telemetry archive;
 - real spacecraft data.
 
 Runtime-facing contract bindings must remain generated, deterministic and disposable.
 
-User implementation code must live outside `generated/`.
+Ground-facing integration artifacts must remain generated, deterministic, tool-neutral and disposable.
 
-The next milestone may generate ground integration artifacts, but those artifacts must remain exports or dictionaries derived from the Mission Data Contract. They must not be presented as a live ground segment, operator console, command uplink service or telemetry archive.
+User implementation code and downstream integration code must live outside `generated/`.
+
+Future plugin and extensibility work must not allow plugins to silently redefine core Mission Data Contract semantics or bypass validation.
 
 ---
 
@@ -115,7 +121,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.7.0
+orbitfabric 0.8.0
 ```
 
 ---
@@ -146,6 +152,8 @@ orbitfabric gen runtime examples/demo-3u/mission/
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
 
+orbitfabric gen ground examples/demo-3u/mission/
+
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
   --json generated/reports/battery_low_during_payload_report.json \
   --log generated/logs/battery_low_during_payload.log
@@ -166,6 +174,7 @@ gen docs      -> Result: PASSED
 gen data-flow -> Result: PASSED
 gen runtime   -> Result: PASSED
 cmake build   -> passing
+gen ground    -> Result: PASSED
 sim           -> Result: PASSED
 ```
 
@@ -209,7 +218,9 @@ cli -> sim
 lint -> model
 gen -> model
 gen -> RuntimeContract builder
+gen -> GroundContract builder
 RuntimeContract builder -> model
+GroundContract builder -> model
 sim -> model
 ```
 
@@ -223,6 +234,7 @@ lint -> sim
 gen -> sim
 sim -> gen
 RuntimeContract builder -> raw YAML files
+GroundContract builder -> raw YAML files
 profile-specific generator -> raw YAML files
 ```
 
@@ -238,8 +250,8 @@ Good examples:
 
 ```text
 Add contact downlink consistency rules
-Generate contact downlink documentation
-Align public documentation with v0.7
+Generate ground dictionaries
+Align public documentation with v0.8
 Fix scenario command validation
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios and runtime-facing contract bindings once.
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings and ground-facing integration artifacts once.
 Validate them, document them, simulate them and generate deterministic integration artifacts from the same source of truth.
 
 </div>
@@ -19,9 +19,9 @@ Validate them, document them, simulate them and generate deterministic integrati
 
 OrbitFabric is a **model-first Mission Data Fabric** for small spacecraft.
 
-It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation and generated integration artifacts.
+It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation, runtime-facing bindings and ground-facing integration artifacts.
 
-OrbitFabric is not a flight software framework, not a ground segment, and not a spacecraft dynamics simulator.
+OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
 
 It is the contract layer between:
 
@@ -31,6 +31,7 @@ onboard software
 simulation
 testing
 documentation
+runtime-facing integration
 ground integration
 ```
 
@@ -40,71 +41,53 @@ ground integration
 
 ## Current Status
 
-OrbitFabric is currently at `v0.7.0 — Generated Runtime Skeletons`.
+OrbitFabric is currently at `v0.8.0 - Ground Integration Artifacts`.
 
-In v0.7.0, **Generated Runtime Skeletons** means runtime-facing contract bindings.
+In v0.8.0, **Ground Integration Artifacts** means ground-facing Mission Data Contract exports.
 
-OrbitFabric does not generate onboard behavior or flight software.
+OrbitFabric does not generate a ground segment, mission control system, telemetry archive, command uplink service, operator console, decoder runtime, database, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
 
-It generates a deterministic, host-buildable software boundary derived from the validated Mission Model.
+It generates deterministic, inspectable, tool-neutral ground-facing artifacts derived from the validated Mission Model.
 
 The current repository includes:
 
-- the `v0.2.1 — Payload Contract Model` vertical slice;
-- the `v0.2.3 — Mission Data Chain Roadmap Alignment` direction;
-- the `v0.3.0 — Data Product and Storage Contracts` vertical slice;
-- the `v0.4.0 — Contact Windows and Downlink Flow Contracts` vertical slice;
-- the `v0.5.0 — Commandability and Autonomy Contracts` vertical slice;
-- the `v0.6.0 — End-to-End Mission Data Flow Evidence` vertical slice;
-- the `v0.7.0 — Generated Runtime Skeletons` vertical slice.
+- the `v0.2.1 - Payload Contract Model` vertical slice;
+- the `v0.2.3 - Mission Data Chain Roadmap Alignment` direction;
+- the `v0.3.0 - Data Product and Storage Contracts` vertical slice;
+- the `v0.4.0 - Contact Windows and Downlink Flow Contracts` vertical slice;
+- the `v0.5.0 - Commandability and Autonomy Contracts` vertical slice;
+- the `v0.6.0 - End-to-End Mission Data Flow Evidence` vertical slice;
+- the `v0.7.0 - Generated Runtime Skeletons` vertical slice;
+- the `v0.8.0 - Ground Integration Artifacts` vertical slice.
 
 The current vertical slice is functional:
 
 - Mission Model YAML loading;
-- optional `payloads.yaml` loading;
-- optional `data_products.yaml` loading;
-- optional `contacts.yaml` loading;
-- optional `commandability.yaml` loading;
 - structural validation;
 - semantic linting;
-- engineering lint rules;
-- payload contract lint rules;
-- data product contract lint rules;
-- contact/downlink contract lint rules;
-- commandability/autonomy contract lint rules;
-- command-declared data product effect linting;
-- scenario data-flow expectation reference validation;
-- JSON lint report generation;
 - generated Markdown documentation;
-- generated payload contract documentation;
-- generated data product contract documentation;
-- generated contact/downlink contract documentation;
-- generated commandability/autonomy contract documentation;
-- generated data-flow evidence documentation;
-- scenario YAML loading;
-- scenario reference validation;
+- scenario YAML loading and validation;
 - deterministic scenario execution;
-- minimal payload lifecycle simulation;
-- contract-level data-flow evidence recording;
-- simulation JSON report generation with `data_flow_evidence`;
-- simulation plain-text log generation;
+- JSON lint and simulation reports;
 - RuntimeContract construction;
 - `orbitfabric gen runtime` generation;
-- C++17 runtime-facing identifier headers;
-- C++17 runtime value enums;
-- C++17 static metadata registries;
-- C++17 command argument structs;
-- C++17 abstract adapter interfaces;
-- C++17 host-build smoke files;
+- C++17 runtime-facing contract bindings;
+- host-build smoke validation for generated C++17 bindings;
+- GroundContract construction;
+- `orbitfabric gen ground` generation;
+- generic ground contract manifest;
+- JSON ground dictionaries;
+- CSV ground dictionaries;
+- human-reviewable ground Markdown artifacts;
 - synthetic demo mission: `demo-3u`.
 
 The repository also includes a growing set of example mission slices:
 
-- `examples/demo-3u/` — synthetic clean-room demo mission;
-- `examples/university-cubesat-minislice/` — generic university CubeSat minislice;
-- `examples/oresat-inspired-minislice/` — public-material-derived low-power / beacon / constrained-downlink minislice;
-- `examples/finch-inspired-minislice/` — public-material-derived imaging acquisition / ADCS readiness / compression / constrained-downlink minislice;
-- `examples/spacelab-inspired-communications-minislice/` — public-material-derived TT&C / OBDH / beacon / telecommanded data-request / decoder-evidence minislice.
+- `examples/demo-3u/` - synthetic clean-room demo mission;
+- `examples/university-cubesat-minislice/` - generic university CubeSat minislice;
+- `examples/oresat-inspired-minislice/` - public-material-derived low-power / beacon / constrained-downlink minislice;
+- `examples/finch-inspired-minislice/` - public-material-derived imaging acquisition / ADCS readiness / compression / constrained-downlink minislice;
+- `examples/spacelab-inspired-communications-minislice/` - public-material-derived TT&C / OBDH / beacon / telecommanded data-request / decoder-evidence minislice.
 
 The `*-inspired-*` examples are conceptual public demos. They are not official models, not endorsed by the original project teams, and do not imply adoption of OrbitFabric by those teams.
 
@@ -123,6 +106,9 @@ mkdocs build --strict
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
 -> passing after orbitfabric gen runtime
+
+orbitfabric gen ground examples/demo-3u/mission/
+-> passing
 ```
 
 ---
@@ -146,7 +132,8 @@ It models:
 - optional Contact Windows and Downlink Flow Contracts;
 - optional Commandability and Autonomy Contracts;
 - contract-level Mission Data Flow Evidence;
-- generated runtime-facing contract bindings.
+- generated runtime-facing contract bindings;
+- generated ground-facing integration artifacts.
 
 The data-flow evidence chain connects:
 
@@ -160,20 +147,22 @@ command expected effect
         -> scenario evidence
         -> generated documentation
         -> JSON report evidence
+        -> runtime-facing bindings
+        -> ground-facing artifacts
 ```
 
-The v0.7 runtime-facing binding chain is:
+The v0.8 ground-facing generation chain is:
 
 ```text
 Mission Model
         -> validation and linting
-        -> RuntimeContract
-        -> generated C++17 contract bindings
-        -> host-build smoke validation
-        -> user implementation outside generated/
+        -> GroundContract
+        -> generic ground-facing dictionaries
+        -> JSON / CSV / Markdown artifacts
+        -> downstream ground-system integration outside OrbitFabric
 ```
 
-Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence and Runtime Contract Binding artifacts are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime or real FDIR behavior.
+Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding and Ground Integration artifacts are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
 
 ---
 
@@ -190,6 +179,10 @@ OrbitFabric is not:
 - a hardware abstraction layer;
 - a CubeSat tutorial;
 - a ground segment;
+- a mission control system;
+- an operator console;
+- a telemetry archive;
+- a command uplink service;
 - a payload firmware framework;
 - a payload driver framework;
 - a payload physical simulator;
@@ -205,7 +198,9 @@ OrbitFabric is not:
 
 Generated Runtime Skeletons in v0.7.0 are runtime-facing contract bindings.
 
-They are not flight software.
+Ground Integration Artifacts in v0.8.0 are ground-facing contract exports.
+
+Neither is flight software or ground software.
 
 ---
 
@@ -247,22 +242,7 @@ Payload Contract
         -> Commandability and Autonomy Contract
         -> End-to-End Mission Data Flow Evidence
         -> Runtime-Facing Contract Bindings
-```
-
-The data-flow scenario demonstrates:
-
-```text
-payload.start_acquisition
-        -> payload.acquisition_started
-        -> payload lifecycle ACQUIRING
-        -> payload.acquisition.active = true
-        -> payload.radiation_histogram evidence recorded
-        -> storage intent declared
-        -> downlink intent declared
-        -> science_next_available_contact eligible
-        -> demo_contact_001 matched
-        -> DATA_FLOW expectation met
-        -> SCENARIO PASSED
+        -> Ground-Facing Integration Artifacts
 ```
 
 ---
@@ -288,7 +268,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.7.0
+orbitfabric 0.8.0
 ```
 
 ---
@@ -333,15 +313,6 @@ generated/docs/
 └── data_flow.md
 ```
 
-A dedicated data-flow generator is also available:
-
-```bash
-orbitfabric gen data-flow examples/demo-3u/mission/ \
-  --output-file generated/docs/data_flow.md
-```
-
-Generated files are derived from the validated Mission Model. Do not edit them manually.
-
 ---
 
 ## Generate Runtime Contract Bindings
@@ -378,6 +349,43 @@ cmake --build generated/runtime/cpp17/build
 This is host-build smoke validation only.
 
 It does not produce flight software.
+
+---
+
+## Generate Ground Integration Artifacts
+
+Generate the generic ground-facing mission data package:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+Generated files:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+These files are ground-facing contract exports.
+
+They are not a ground runtime, decoder, telemetry archive, database, operator console, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
 
 ---
 
@@ -432,30 +440,12 @@ The current vertical slice can produce:
 ```text
 generated/
 ├── docs/
-│   ├── telemetry.md
-│   ├── commands.md
-│   ├── events.md
-│   ├── faults.md
-│   ├── modes.md
-│   ├── packets.md
-│   ├── payloads.md
-│   ├── data_products.md
-│   ├── contacts.md
-│   ├── commandability.md
-│   └── data_flow.md
 ├── reports/
-│   ├── lint_report.json
-│   ├── battery_low_during_payload_report.json
-│   └── payload_data_flow_evidence_report.json
 ├── logs/
-│   ├── battery_low_during_payload.log
-│   └── payload_data_flow_evidence.log
-└── runtime/
-    └── cpp17/
-        ├── runtime_contract_manifest.json
-        ├── CMakeLists.txt
-        ├── include/orbitfabric/generated/*.hpp
-        └── src/orbitfabric_runtime_contract_smoke.cpp
+├── runtime/
+│   └── cpp17/
+└── ground/
+    └── generic/
 ```
 
 Generated artifacts are reproducible outputs. They are not the source of truth.
@@ -486,12 +476,9 @@ Useful entry points:
 - `docs/DEVELOPMENT.md`
 - `docs/QUICKSTART.md`
 - `docs/DEMO_WALKTHROUGH.md`
-- `docs/reference/mission-model-v0.1.md`
-- `docs/reference/data-flow-evidence.md`
 - `docs/reference/runtime-contract-bindings.md`
-- `docs/reference/json-reports-v0.1.md`
-- `docs/reference/lint-rules-v0.1.md`
-- `docs/releases/v0.7.0.md`
+- `docs/reference/ground-integration-artifacts.md`
+- `docs/releases/v0.8.0.md`
 - `docs/adr/`
 
 Build the documentation site locally:
@@ -550,10 +537,15 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 orbitfabric gen docs examples/demo-3u/mission/
 
+orbitfabric gen data-flow examples/demo-3u/mission/ \
+  --output-file generated/docs/data_flow.md
+
 orbitfabric gen runtime examples/demo-3u/mission/
 
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
+
+orbitfabric gen ground examples/demo-3u/mission/
 
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
   --json generated/reports/payload_data_flow_evidence_report.json \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# OrbitFabric — Architecture
+# OrbitFabric - Architecture
 
-Version: 0.7.0  
+Version: 0.8.0  
 Status: Development preview  
-Scope: Mission Data Contract architecture through Generated Runtime Skeletons
+Scope: Mission Data Contract architecture through Ground Integration Artifacts
 
 ---
 
@@ -16,13 +16,16 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, documentation and scenario evidence from one source of truth.
+It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, documentation and scenario evidence from one source of truth.
 
 OrbitFabric is not designed as:
 
 ```text
 flight software framework
 ground segment
+mission control system
+operator console
+telemetry archive
 spacecraft dynamics simulator
 payload runtime framework
 CCSDS/PUS/CFDP implementation
@@ -31,13 +34,13 @@ hardware abstraction layer
 
 Its architectural role is:
 
-> define, validate, simulate, document and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation and future ground integration artifacts.
+> define, validate, simulate, document and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings and ground-facing integration.
 
-The current architectural baseline is `v0.7.0 — Generated Runtime Skeletons`.
+The current architectural baseline is `v0.8.0 - Ground Integration Artifacts`.
 
-In v0.7.0, Generated Runtime Skeletons means runtime-facing contract bindings.
+In v0.8.0, Ground Integration Artifacts means ground-facing Mission Data Contract exports.
 
-The next architectural step is `v0.8 — Ground Integration Artifacts`.
+The next architectural step is `v0.9 - Plugin and Extensibility Layer`.
 
 ---
 
@@ -47,21 +50,23 @@ The next architectural step is `v0.8 — Ground Integration Artifacts`.
 
 The Mission Model is the source of truth.
 
-Runtime-facing bindings, simulation behavior, generated documentation and future integration artifacts must derive from the model.
+Runtime-facing bindings, ground-facing artifacts, simulation behavior and generated documentation must derive from the model.
 
 No important mission behavior should live only in Python code, documentation, generated files or simulator internals.
 
 ### 2.2 Contract Before Runtime
 
-OrbitFabric does not implement a flight runtime.
+OrbitFabric does not implement a flight runtime or a ground runtime.
 
 It implements a host-side toolchain that proves and hardens the Mission Data Contract.
 
-v0.7.0 introduces generated runtime-facing contract bindings, not onboard behavior.
+v0.7.0 introduced generated runtime-facing contract bindings, not onboard behavior.
 
-### 2.3 Chain Before Runtime Bindings
+v0.8.0 introduced generated ground-facing contract exports, not ground behavior.
 
-OrbitFabric models the Mission Data Chain before generating software-facing artifacts.
+### 2.3 Chain Before Generated Artifacts
+
+OrbitFabric models the Mission Data Chain before generating downstream artifacts.
 
 The current chain is:
 
@@ -74,16 +79,18 @@ Payload behavior
         -> Commandability and Autonomy Contracts
         -> End-to-End Mission Data Flow Evidence
         -> Runtime-Facing Contract Bindings
-        -> future Ground Integration Artifacts
+        -> Ground-Facing Integration Artifacts
 ```
 
-### 2.4 Runtime Bindings Are Not Runtime Behavior
+### 2.4 Generated Bindings and Exports Are Not Behavior
 
 Generated Runtime Skeletons are contract bindings.
 
-They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces and host-build smoke validation.
+Generated Ground Integration Artifacts are contract exports.
 
-They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime or flight-ready behavior.
+They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries and review documents.
+
+They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows or live ground operations.
 
 ### 2.5 Lint as Engineering Judgment
 
@@ -115,7 +122,7 @@ It is not a real-time onboard runtime.
 
 ### 2.8 Ground by Construction
 
-OrbitFabric should eventually produce artifacts useful for ground integration.
+OrbitFabric produces artifacts useful for ground integration.
 
 It must not become a ground segment.
 
@@ -145,6 +152,7 @@ OrbitFabric
 │   ├── commandability/autonomy contracts
 │   ├── data-flow evidence contracts
 │   ├── runtime-facing contract binding inputs
+│   ├── ground-facing contract export inputs
 │   └── scenarios
 │
 ├── Toolchain
@@ -154,21 +162,23 @@ OrbitFabric
 │   ├── orbitfabric gen docs
 │   ├── orbitfabric gen data-flow
 │   ├── orbitfabric gen runtime
+│   ├── orbitfabric gen ground
 │   └── orbitfabric sim
 │
 ├── Model Layer
 ├── Lint Layer
 ├── Simulation Layer
 ├── RuntimeContract Layer
+├── GroundContract Layer
 ├── Generation Layer
 └── Future Extension Layer
 ```
 
 ---
 
-## 4. Current Capability Boundary — v0.7.0
+## 4. Current Capability Boundary - v0.8.0
 
-OrbitFabric v0.7.0 includes:
+OrbitFabric v0.8.0 includes:
 
 ```text
 Mission Model YAML
@@ -180,39 +190,27 @@ optional commandability.yaml domain
 Pydantic typed validation
 structural validation
 semantic lint
-payload contract lint rules
-data product contract lint rules
-contact/downlink contract lint rules
-commandability/autonomy contract lint rules
-command-declared data product effect lint rules
-scenario data-flow expectation reference checks
-scenario loading
-scenario reference validation
+scenario loading and reference validation
 host-side deterministic scenario execution
-payload lifecycle scenario behavior
 contract-level data-flow evidence recording
 generated Markdown docs
-generated payload documentation
-generated data product documentation
-generated contact/downlink documentation
-generated commandability/autonomy documentation
-generated data-flow evidence documentation
 JSON lint reports
 JSON scenario reports with data_flow_evidence
 plain-text scenario logs
 RuntimeContract intermediate model
 orbitfabric gen runtime command
-runtime_contract_manifest.json
-C++17 mission identifier headers
-C++17 runtime value enums
-C++17 static metadata registries
-C++17 command argument structs
-C++17 abstract adapter interfaces
+C++17 runtime-facing contract bindings
 C++17 host-build smoke CMake target
+GroundContract intermediate model
+orbitfabric gen ground command
+generic ground contract manifest
+JSON ground dictionaries
+CSV ground dictionaries
+human-reviewable ground Markdown artifacts
 synthetic demo mission
 ```
 
-OrbitFabric v0.7.0 excludes:
+OrbitFabric v0.8.0 excludes:
 
 ```text
 flight runtime
@@ -221,32 +219,26 @@ RTOS integration
 Linux onboard service
 hardware drivers
 real onboard storage runtime
-file-system abstraction
-compression engine
-payload data processing pipeline
-orbit propagation
-TLE parsing
-ground track computation
-antenna pointing
-RF link budget simulation
-real contact scheduling
 real downlink execution
-onboard downlink queues
-live ground links
 downlink runtime
 ground segment
+mission control system
+operator console
+telemetry archive
+telemetry database
+command uplink service
+telecommand transport
+network/session/routing behavior
+binary packet decoder
+binary telecommand encoder
+Yamcs integration
+OpenC3 integration
+XTCE compliance
 CCSDS/PUS/CFDP implementation
-Yamcs/OpenC3 integration
-Basilisk bridge
-cFS/F Prime bridge
-formal verification
-security model
+security enforcement
 real command authentication
 real command authorization
 live uplink services
-operator consoles
-command queues
-onboard schedulers
 flight autonomy runtime
 real FDIR or safing logic
 ```
@@ -274,7 +266,9 @@ Typed Mission Model
       │
       ├──────────────► Scenario Runner ─────────► Simulation Log + Scenario Report
       │
-      └──────────────► RuntimeContract Builder ─► Runtime-Facing Contract Bindings
+      ├──────────────► RuntimeContract Builder ─► Runtime-Facing Contract Bindings
+      │
+      └──────────────► GroundContract Builder ──► Ground-Facing Integration Artifacts
 ```
 
 The model is loaded once and consumed by multiple downstream layers.
@@ -313,11 +307,14 @@ End-to-End Mission Data Flow Evidence
       │
       ▼
 Runtime-Facing Contract Bindings
+      │
+      ▼
+Ground-Facing Integration Artifacts
 ```
 
-This is the architectural reason OrbitFabric did not jump directly from payload contracts to runtime generation.
+This is the architectural reason OrbitFabric did not jump directly from payload contracts to ground exports.
 
-Runtime-facing contract bindings are useful only after the mission data chain is explicit enough to generate meaningful integration artifacts.
+Ground-facing artifacts are useful only after the mission data chain and runtime-facing contract surface are explicit enough to generate meaningful integration evidence.
 
 ---
 
@@ -331,6 +328,7 @@ orbitfabric lint examples/demo-3u/mission/
 orbitfabric gen docs examples/demo-3u/mission/
 orbitfabric gen data-flow examples/demo-3u/mission/
 orbitfabric gen runtime examples/demo-3u/mission/
+orbitfabric gen ground examples/demo-3u/mission/
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 orbitfabric inspect mission examples/demo-3u/mission/
@@ -345,7 +343,8 @@ orbitfabric
 ├── gen
 │   ├── docs <mission-dir>
 │   ├── data-flow <mission-dir>
-│   └── runtime <mission-dir>
+│   ├── runtime <mission-dir>
+│   └── ground <mission-dir>
 ├── sim <scenario-file>
 ├── inspect
 │   └── mission <mission-dir>
@@ -353,173 +352,13 @@ orbitfabric
     └── scenario <scenario-file>
 ```
 
-Future commands may include:
-
-```text
-orbitfabric init
-orbitfabric gen yamcs
-orbitfabric gen openc3
-orbitfabric gen xtce
-orbitfabric export ground
-orbitfabric validate mission
-```
-
-These are not current requirements.
+Future commands may include tool-specific exporters only after their semantics are implemented and tested explicitly.
 
 ---
 
-## 8. Model Layer
+## 8. RuntimeContract Architecture
 
-The Model Layer loads and represents the Mission Model.
-
-It is responsible for reading YAML files, validating top-level domain keys, building typed model objects, detecting duplicate IDs and exposing validated model objects to lint, simulation and generation layers.
-
-Current required files:
-
-```text
-spacecraft.yaml
-subsystems.yaml
-modes.yaml
-telemetry.yaml
-commands.yaml
-events.yaml
-faults.yaml
-packets.yaml
-policies.yaml
-```
-
-Current optional files:
-
-```text
-payloads.yaml
-data_products.yaml
-contacts.yaml
-commandability.yaml
-```
-
----
-
-## 9. Lint Layer
-
-The Lint Layer performs mission consistency analysis.
-
-Current rule families:
-
-```text
-OF-SYN-*   syntax and file parsing
-OF-STR-*   structural validation
-OF-ID-*    identifier and uniqueness rules
-OF-REF-*   cross-reference rules
-OF-TLM-*   telemetry rules
-OF-CMD-*   command rules, including data product expected effects
-OF-EVT-*   event rules
-OF-FLT-*   fault rules
-OF-MODE-*  mode and transition rules
-OF-PKT-*   packet rules
-OF-PAY-*   payload contract rules
-OF-DP-*    data product contract rules
-OF-CON-*   contact assumption rules
-OF-DL-*    downlink flow assumption rules
-OF-CAB-*   commandability rule diagnostics
-OF-AUT-*   autonomous action diagnostics
-OF-REC-*   recovery intent diagnostics
-OF-SCN-*   scenario rules, including data-flow expectation references
-```
-
-v0.7.0 does not change Mission Data Contract lint semantics.
-
-It consumes the validated contract for runtime-facing generation.
-
----
-
-## 10. Simulation Layer
-
-The Simulation Layer executes operational scenarios against a validated Mission Model.
-
-It is responsible for:
-
-- loading scenario YAML;
-- validating scenario references;
-- initializing simulation state;
-- executing timeline steps;
-- dispatching commands in the host-side simulator;
-- applying command expected effects;
-- tracking payload lifecycle state;
-- injecting telemetry;
-- evaluating faults;
-- emitting events;
-- applying simple recovery actions;
-- recording contract-level data-flow evidence;
-- checking data-flow expectations;
-- producing logs;
-- producing scenario reports.
-
-The Simulation Layer does not model:
-
-```text
-orbital dynamics
-attitude dynamics
-power system physics
-thermal behavior
-RF link budget
-contact visibility
-real-time scheduling
-hardware communication
-embedded resource constraints
-storage runtime behavior
-downlink runtime behavior
-contact visibility behavior
-flight qualification semantics
-```
-
-It is an operational consistency simulator, not a spacecraft physics simulator.
-
----
-
-## 11. Data Flow Evidence Architecture
-
-Data Flow Evidence is produced when an accepted command declares data products in `expected_effects.data_products`.
-
-The recorded evidence connects:
-
-```text
-command id
-data product id
-producer
-producer type
-storage intent
-downlink intent
-eligible downlink flows
-matching contact windows
-```
-
-Scenario assertions may check:
-
-```text
-data_product
-triggered_by_command
-storage_intent_declared
-downlink_intent_declared
-eligible_downlink_flow
-contact_window
-```
-
-This evidence is exported in simulation JSON reports under:
-
-```text
-summary.data_flow_evidence
-data_flow_evidence[]
-```
-
-This is contract-level evidence only.
-
-It does not create payload files, write onboard storage, execute downlink queues or schedule contacts.
-
----
-
-## 12. RuntimeContract Architecture
-
-v0.7.0 introduces RuntimeContract as the mandatory intermediate model for runtime-facing generation.
+RuntimeContract is the intermediate model for runtime-facing generation.
 
 The required dependency direction is:
 
@@ -531,38 +370,109 @@ Mission Model
         -> generated runtime-facing files
 ```
 
-The disallowed direction is:
+RuntimeContract contains the software-facing subset of the Mission Data Contract.
 
-```text
-profile-specific generator
-        -> raw YAML files
-        -> simulator internals
-        -> documentation generator internals
-```
-
-RuntimeContract contains the software-facing subset of the Mission Data Contract:
-
-```text
-mission identity
-modes
-telemetry
-commands
-command arguments
-events
-faults
-packets
-payloads
-data products
-storage policy identifiers
-downlink policy identifiers
-generation metadata
-```
-
-It is smaller than the full Mission Model by design.
+It is not flight software and it is not the source of truth.
 
 ---
 
-## 13. Runtime-Facing Generation Layer
+## 9. GroundContract Architecture
+
+v0.8.0 introduces GroundContract as the intermediate model for ground-facing generation.
+
+The required dependency direction is:
+
+```text
+Mission Model
+        -> validation and linting
+        -> GroundContract builder
+        -> generic ground exporter
+        -> generated ground-facing package
+```
+
+The disallowed direction is:
+
+```text
+ground exporter
+        -> raw YAML files
+        -> simulator internals
+        -> runtime generator internals
+        -> generated runtime files
+```
+
+GroundContract contains the ground-facing subset of the Mission Data Contract:
+
+```text
+mission identity
+telemetry dictionaries
+command dictionaries
+event dictionaries
+fault dictionaries
+data product dictionaries
+packet dictionaries
+generation metadata
+boundary flags
+```
+
+It is not a mission database runtime.
+
+It is not a ground segment configuration format.
+
+It is not the source of truth.
+
+---
+
+## 10. Ground-Facing Generation Layer
+
+The generic ground profile generates:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/*.json
+├── csv/*.csv
+└── ground_dictionaries.md
+```
+
+These artifacts expose:
+
+```text
+telemetry contract metadata
+command contract metadata
+event contract metadata
+fault contract metadata
+data product contract metadata
+packet membership metadata
+review-oriented documentation
+machine-readable dictionaries
+spreadsheet-friendly dictionaries
+manifest boundary flags
+```
+
+They do not expose:
+
+```text
+binary packet decoder
+ground runtime
+telemetry archive
+database implementation
+operator console
+command uplink service
+Yamcs compatibility
+OpenC3 compatibility
+XTCE compliance
+CCSDS/PUS/CFDP behavior
+security enforcement
+```
+
+Generated ground artifacts are disposable.
+
+Downstream ground integration code must live outside generated OrbitFabric output unless explicitly generated by a future tool-specific profile.
+
+---
+
+## 11. Runtime-Facing Generation Layer
 
 The C++17 runtime profile generates:
 
@@ -577,29 +487,9 @@ generated/runtime/cpp17/CMakeLists.txt
 generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
 ```
 
-These artifacts expose:
+These artifacts expose stable generated identifiers, typed command argument structs, static metadata registries, abstract adapter interfaces and host-build smoke validation.
 
-```text
-stable generated identifiers
-typed command argument structs
-static metadata registries
-abstract adapter interfaces
-host-build smoke validation
-```
-
-They do not expose:
-
-```text
-runtime loops
-command queues
-command dispatch implementation
-scheduler behavior
-HAL or driver abstractions
-RTOS integration
-binary serialization
-CCSDS/PUS/CFDP behavior
-flight software behavior
-```
+They do not implement flight behavior.
 
 Generated runtime-facing artifacts are disposable.
 
@@ -607,9 +497,9 @@ User implementation code must live outside `generated/`.
 
 ---
 
-## 14. Host-Build Smoke Validation
+## 12. Host-Build and Ground Export Validation
 
-v0.7.0 generated C++17 bindings can be validated with:
+Runtime-facing bindings can be validated with:
 
 ```bash
 orbitfabric gen runtime examples/demo-3u/mission/
@@ -617,13 +507,19 @@ cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
 ```
 
-This confirms that generated headers and smoke source are syntactically valid and buildable as C++17 on the host.
+Ground-facing artifacts can be validated with:
 
-It does not validate flight behavior.
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+This confirms that the generated contract surfaces are syntactically valid and reproducible on the host.
+
+It does not validate flight behavior or live ground behavior.
 
 ---
 
-## 15. Documentation Generation Layer
+## 13. Documentation Generation Layer
 
 The Generation Layer derives human-readable and machine-readable artifacts from the Mission Model.
 
@@ -643,22 +539,17 @@ generated/docs/commandability.md
 generated/docs/data_flow.md
 ```
 
-The standard docs command generates all of these when the relevant contract domains are present:
+Ground-facing review artifacts are generated under:
 
-```bash
-orbitfabric gen docs examples/demo-3u/mission/
+```text
+generated/ground/generic/
 ```
 
-The data-flow page can also be generated directly:
-
-```bash
-orbitfabric gen data-flow examples/demo-3u/mission/ \
-  --output-file generated/docs/data_flow.md
-```
+Generated documentation is not the source of truth.
 
 ---
 
-## 16. Demo Mission Architecture
+## 14. Demo Mission Architecture
 
 The canonical demo is `demo-3u`.
 
@@ -686,72 +577,31 @@ examples/demo-3u/
     └── payload_data_flow_evidence.yaml
 ```
 
-The data-flow scenario demonstrates:
-
-```text
-payload.start_acquisition
-        -> payload.radiation_histogram
-        -> storage intent declared
-        -> downlink intent declared
-        -> science_next_available_contact
-        -> demo_contact_001
-```
-
 The demo must stay synthetic and clean-room.
 
 ---
 
-## 17. Reports Architecture
+## 15. Reports and Generated Artifact Architecture
 
 Reports are JSON where machine-readable output is required.
 
-### 17.1 Lint Report
+Generated artifact manifests are also JSON where deterministic downstream inspection is required.
 
-Conceptual shape:
+Current generated JSON families include:
 
-```json
-{
-  "tool": "orbitfabric-lint",
-  "version": "0.7.0",
-  "mission": "demo-3u",
-  "model_version": "0.1.0",
-  "result": "passed",
-  "summary": {
-    "errors": 0,
-    "warnings": 0,
-    "info": 0
-  },
-  "findings": []
-}
+```text
+lint reports
+simulation reports
+runtime contract manifest
+ground contract manifest
+ground dictionaries
 ```
 
-### 17.2 Scenario Report
-
-Conceptual shape:
-
-```json
-{
-  "tool": "orbitfabric-sim",
-  "version": "0.7.0",
-  "scenario": "payload_data_flow_evidence",
-  "mission": "demo-3u",
-  "result": "passed",
-  "summary": {
-    "events": 2,
-    "commands": 2,
-    "mode_transitions": 1,
-    "data_flow_evidence": 1,
-    "failed_expectations": 0
-  },
-  "data_flow_evidence": []
-}
-```
-
-Reports must be stable enough for tests and CI.
+Reports and manifests must remain stable enough for tests and CI, but they are still development-preview artifacts before v1.0.
 
 ---
 
-## 18. Layer Dependency Rules
+## 16. Layer Dependency Rules
 
 Allowed dependencies:
 
@@ -767,7 +617,9 @@ sim -> model
 sim -> reports
 gen -> model
 gen -> RuntimeContract builder
+gen -> GroundContract builder
 RuntimeContract builder -> model
+GroundContract builder -> model
 reports -> lint report data
 reports -> simulation report data
 ```
@@ -783,6 +635,7 @@ lint -> sim
 sim -> gen
 gen -> sim
 RuntimeContract builder -> raw YAML files
+GroundContract builder -> raw YAML files
 profile-specific generator -> raw YAML files
 ```
 
@@ -790,7 +643,7 @@ The Model Layer must remain the lowest stable layer.
 
 ---
 
-## 19. Testing Architecture
+## 17. Testing Architecture
 
 Current test strategy covers:
 
@@ -812,6 +665,11 @@ data-flow evidence JSON report tests
 documentation generator tests
 RuntimeContract builder tests
 C++17 runtime generator tests
+GroundContract builder tests
+ground manifest tests
+ground JSON export tests
+ground CSV export tests
+ground Markdown export tests
 CLI smoke tests
 ```
 
@@ -834,24 +692,25 @@ Release validation additionally includes:
 orbitfabric gen runtime examples/demo-3u/mission/
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
+orbitfabric gen ground examples/demo-3u/mission/
 ```
 
 ---
 
-## 20. Future Extension Architecture
+## 18. Future Extension Architecture
 
 Future extensions should be added as generators, plugins or adapters.
 
 Possible future layers:
 
 ```text
-Ground Integration Artifact Generators
-Yamcs Export Generator
-OpenC3 Export Generator
-XTCE Export Generator
+Custom Ground Exporters
 Custom Lint Rule Plugins
 Custom Mission Model Extensions
 Runtime Adapter SDK
+Yamcs Export Generator
+OpenC3 Export Generator
+XTCE Export Generator
 Basilisk Bridge
 cFS/F Prime Integration Bridges
 ```
@@ -862,12 +721,13 @@ They must not redefine the mission contract.
 
 ---
 
-## 21. Anti-Patterns
+## 19. Anti-Patterns
 
 The following patterns are architecturally wrong:
 
 ```text
 runtime-first drift
+ground-first drift
 demo-driven special cases
 hidden mission logic
 premature standard compliance
@@ -881,9 +741,9 @@ proprietary example contamination
 
 ---
 
-## 22. v0.7.0 Acceptance Architecture
+## 20. v0.8.0 Acceptance Architecture
 
-OrbitFabric v0.7.0 is architecturally acceptable when this flow works end-to-end:
+OrbitFabric v0.8.0 is architecturally acceptable when this flow works end-to-end:
 
 ```bash
 ruff check .
@@ -910,6 +770,8 @@ orbitfabric gen runtime examples/demo-3u/mission/
 
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
+
+orbitfabric gen ground examples/demo-3u/mission/
 ```
 
 And produces:
@@ -917,38 +779,35 @@ And produces:
 ```text
 valid lint output
 Markdown mission documentation
-payload contract documentation
-data product contract documentation
-contact/downlink contract documentation
-commandability/autonomy contract documentation
-data-flow evidence documentation
 scenario execution logs
 scenario JSON reports
 data_flow_evidence JSON records
 RuntimeContract manifest
 C++17 runtime-facing contract headers
 host-build smoke validation
+GroundContract manifest
+JSON ground dictionaries
+CSV ground dictionaries
+human-reviewable ground Markdown artifacts
 ```
 
-No flight runtime, ground export, orbital propagation, RF simulation, storage/downlink runtime, live uplink or autonomy runtime is required for v0.7.0.
+No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console or autonomy runtime is required for v0.8.0.
 
 ---
 
-## 23. Next Architectural Step — v0.8
+## 21. Next Architectural Step - v0.9
 
 The next architectural step is:
 
 ```text
-v0.8 — Ground Integration Artifacts
+v0.9 - Plugin and Extensibility Layer
 ```
 
-The purpose is to start deriving ground-facing artifacts from the Mission Data Contract without becoming a ground segment.
-
-v0.8 must not claim Yamcs/OpenC3/XTCE compatibility unless specific exported artifacts are implemented and tested.
+The purpose is to introduce controlled extension points without letting plugins redefine core OrbitFabric semantics or bypass Mission Model validation.
 
 ---
 
-## 24. Final Architectural Statement
+## 22. Final Architectural Statement
 
 OrbitFabric is architecturally centered on the Mission Data Contract.
 
@@ -964,7 +823,9 @@ The v0.6 data-flow evidence layer proves the first end-to-end Mission Data Chain
 
 The v0.7 runtime-facing binding layer exposes that contract to implementation code without generating flight behavior.
 
-Future ground integrations consume the contract.
+The v0.8 ground-facing artifact layer exposes that contract to ground integration work without generating ground behavior.
+
+Future plugins must consume the contract.
 
 Nothing should bypass the contract.
 

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -20,7 +20,7 @@ Define once. Validate. Simulate. Test. Document. Integrate.
 
 The goal is not to model a real CubeSat.
 
-The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution and generated runtime-facing contract bindings.
+The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution, runtime-facing contract bindings and ground-facing integration artifacts.
 
 ---
 
@@ -122,7 +122,7 @@ examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 
 `nominal_payload_acquisition.yaml` demonstrates a nominal payload lifecycle path.
 
-`payload_data_flow_evidence.yaml` demonstrates the contract-level data-flow evidence path introduced in v0.6 and retained in the v0.7 baseline.
+`payload_data_flow_evidence.yaml` demonstrates the contract-level data-flow evidence path introduced in v0.6 and retained in the v0.8 baseline.
 
 ---
 
@@ -132,15 +132,15 @@ The battery-low scenario demonstrates this operational sequence:
 
 ```text
 payload.start_acquisition
-→ payload.acquisition_started
-→ NOMINAL -> PAYLOAD_ACTIVE
-→ battery voltage degradation
-→ eps.battery_low
-→ PAYLOAD_ACTIVE -> DEGRADED
-→ payload.stop_acquisition AUTO_DISPATCHED
-→ payload.acquisition_stopped
-→ payload.acquisition.active = false
-→ SCENARIO PASSED
+-> payload.acquisition_started
+-> NOMINAL -> PAYLOAD_ACTIVE
+-> battery voltage degradation
+-> eps.battery_low
+-> PAYLOAD_ACTIVE -> DEGRADED
+-> payload.stop_acquisition AUTO_DISPATCHED
+-> payload.acquisition_stopped
+-> payload.acquisition.active = false
+-> SCENARIO PASSED
 ```
 
 This remains a deterministic host-side operational scenario.
@@ -155,16 +155,16 @@ The data-flow evidence scenario demonstrates the contract chain:
 
 ```text
 payload.start_acquisition
-→ payload.acquisition_started
-→ payload lifecycle ACQUIRING
-→ payload.acquisition.active = true
-→ DATA_PRODUCT payload.radiation_histogram CONTRACT_EVIDENCE_RECORDED
-→ DATA_FLOW payload.radiation_histogram EXPECTATION_MET
-→ payload.stop_acquisition
-→ payload.acquisition_stopped
-→ payload lifecycle READY
-→ payload.acquisition.active = false
-→ SCENARIO PASSED
+-> payload.acquisition_started
+-> payload lifecycle ACQUIRING
+-> payload.acquisition.active = true
+-> DATA_PRODUCT payload.radiation_histogram CONTRACT_EVIDENCE_RECORDED
+-> DATA_FLOW payload.radiation_histogram EXPECTATION_MET
+-> payload.stop_acquisition
+-> payload.acquisition_stopped
+-> payload lifecycle READY
+-> payload.acquisition.active = false
+-> SCENARIO PASSED
 ```
 
 The scenario checks that the command-declared data product effect is traceable to:
@@ -178,21 +178,15 @@ payload.start_acquisition
         -> demo_contact_001
 ```
 
-This is not real payload file generation.
+This is deterministic contract-level evidence generated from the Mission Model and scenario expectations.
 
-It is not real onboard storage.
-
-It is not downlink queue execution.
-
-It is not contact scheduling.
-
-It is deterministic contract-level evidence generated from the Mission Model and scenario expectations.
+It is not real payload file generation, onboard storage, downlink queue execution or contact scheduling.
 
 ---
 
 ## 7. Generate runtime-facing contract bindings
 
-v0.7.0 adds generated runtime-facing contract bindings for the same `demo-3u` Mission Model.
+v0.7.0 added generated runtime-facing contract bindings for the same `demo-3u` Mission Model.
 
 Run:
 
@@ -237,7 +231,46 @@ It does not validate flight behavior.
 
 ---
 
-## 9. Run the scenarios
+## 9. Generate ground-facing integration artifacts
+
+v0.8.0 adds generated ground-facing integration artifacts for the same `demo-3u` Mission Model.
+
+Run:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+Generated files:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+These artifacts expose the mission data contract to ground-side review and downstream integration workflows.
+
+They do not implement a ground segment, decoder, telemetry archive, database, operator console, command uplink service, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
+
+---
+
+## 10. Run the scenarios
 
 Battery-low recovery:
 
@@ -259,7 +292,7 @@ Result: PASSED
 
 ---
 
-## 10. Generate scenario outputs
+## 11. Generate scenario outputs
 
 Battery-low recovery outputs:
 
@@ -288,7 +321,7 @@ generated/logs/payload_data_flow_evidence.log
 
 ---
 
-## 11. Generate mission documentation
+## 12. Generate mission documentation
 
 ```bash
 orbitfabric gen docs examples/demo-3u/mission/
@@ -311,8 +344,6 @@ generated/docs/
 └── data_flow.md
 ```
 
-The generated data-flow documentation exposes declared command-to-data-product paths and traces storage intent, downlink intent, eligible downlink flows and matching contact windows as contract data.
-
 A dedicated generator is also available:
 
 ```bash
@@ -324,7 +355,7 @@ None of these pages describes runtime behavior.
 
 ---
 
-## 12. What the simulator checks
+## 13. What the simulator checks
 
 During execution, OrbitFabric checks that:
 
@@ -332,7 +363,6 @@ During execution, OrbitFabric checks that:
 - commands are allowed in the current mode;
 - expected command effects are applied;
 - payload lifecycle preconditions are respected;
-- payload lifecycle expected effects are applied;
 - events are emitted;
 - telemetry injections update simulation state;
 - fault conditions are evaluated;
@@ -350,7 +380,7 @@ The simulator does not execute real storage, real downlink, live uplink, contact
 
 ---
 
-## 13. Expected final state
+## 14. Expected final state
 
 At the end of the battery-low scenario:
 
@@ -380,11 +410,12 @@ command accepted
   -> storage/downlink/contact intent checked
   -> scenario evidence produced
   -> runtime-facing bindings generated from the same model
+  -> ground-facing artifacts generated from the same model
 ```
 
 ---
 
-## 14. Clean-room boundary
+## 15. Clean-room boundary
 
 This demo is deliberately synthetic.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -50,7 +50,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.7.0
+orbitfabric 0.8.0
 ```
 
 ---
@@ -75,7 +75,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.7 Vertical Slice
+## Verify the Current v0.8 Vertical Slice
 
 Run mission lint:
 
@@ -110,6 +110,12 @@ cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
 ```
 
+Generate ground-facing integration artifacts:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
 Run the battery-low recovery scenario:
 
 ```bash
@@ -134,6 +140,7 @@ gen docs      -> Result: PASSED
 gen data-flow -> Result: PASSED
 gen runtime   -> Result: PASSED
 cmake build   -> passing
+gen ground    -> Result: PASSED
 sim           -> Result: PASSED
 ```
 
@@ -166,6 +173,26 @@ generated/runtime/cpp17/CMakeLists.txt
 generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
 ```
 
+The generated ground-facing integration artifacts should include:
+
+```text
+generated/ground/generic/ground_contract_manifest.json
+generated/ground/generic/README.md
+generated/ground/generic/dictionaries/telemetry_dictionary.json
+generated/ground/generic/dictionaries/command_dictionary.json
+generated/ground/generic/dictionaries/event_dictionary.json
+generated/ground/generic/dictionaries/fault_dictionary.json
+generated/ground/generic/dictionaries/data_product_dictionary.json
+generated/ground/generic/dictionaries/packet_dictionary.json
+generated/ground/generic/csv/telemetry_dictionary.csv
+generated/ground/generic/csv/command_dictionary.csv
+generated/ground/generic/csv/event_dictionary.csv
+generated/ground/generic/csv/fault_dictionary.csv
+generated/ground/generic/csv/data_product_dictionary.csv
+generated/ground/generic/csv/packet_dictionary.csv
+generated/ground/generic/ground_dictionaries.md
+```
+
 ---
 
 ## Generated Outputs
@@ -177,7 +204,8 @@ generated/
 ├── docs/
 ├── reports/
 ├── logs/
-└── runtime/
+├── runtime/
+└── ground/
 ```
 
 These files are reproducible outputs.
@@ -197,7 +225,9 @@ examples/demo-3u/scenarios/*.yaml
 
 Generated runtime-facing contract bindings are disposable.
 
-User implementation code must live outside `generated/`.
+Generated ground-facing integration artifacts are disposable.
+
+User implementation code and downstream integration code must live outside `generated/`.
 
 ---
 
@@ -239,6 +269,8 @@ Do not add generated artifacts that bypass validation.
 Do not add runtime or ground integration artifacts before the relevant contract layer exists.
 
 Do not put user code inside generated runtime bindings.
+
+Do not present generated ground artifacts as live ground behavior.
 
 ---
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,6 +1,6 @@
-# OrbitFabric — Project Charter
+# OrbitFabric - Project Charter
 
-Version: 0.7
+Version: 0.8
 Status: Draft
 Scope: Mission Data Contract foundation, Mission Data Chain and generated contract-facing artifacts
 
@@ -10,11 +10,11 @@ Scope: Mission Data Contract foundation, Mission Data Chain and generated contra
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios and runtime-facing contract bindings once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings and ground-facing integration artifacts once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration artifacts for onboard and ground systems.
 
 OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool or a payload runtime framework.
 
-It is the contract layer between mission design, onboard software, simulation, testing, documentation and ground integration.
+It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing integration and ground integration.
 
 The guiding principle is:
 
@@ -45,7 +45,8 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - autonomy and recovery expectations;
 - operational scenarios;
 - validation and linting rules;
-- runtime-facing generated contract bindings.
+- runtime-facing generated contract bindings;
+- ground-facing generated integration artifacts.
 
 The Mission Data Contract is the single source of truth for all derived artifacts.
 
@@ -88,7 +89,8 @@ The initial target users are:
 - embedded engineers entering the small spacecraft domain;
 - small space startups and technical teams needing disciplined mission-data organization;
 - research labs needing repeatable mission simulations and test scenarios;
-- space software architects who need a coherent contract between payload behavior, onboard data handling and ground-facing artifacts.
+- space software architects who need a coherent contract between payload behavior, onboard data handling and ground-facing artifacts;
+- ground software engineers who need reviewable mission data dictionaries before integration starts.
 
 The target is not purely educational.
 
@@ -122,19 +124,19 @@ The correct long-term role is:
 
 ### 6.1 Mission Model First
 
-OrbitFabric starts from the Mission Model, not from the onboard runtime.
+OrbitFabric starts from the Mission Model, not from the onboard runtime or the ground system.
 
-The runtime-facing bindings, simulator, documentation and ground artifacts must be derived from the model, not the other way around.
+The runtime-facing bindings, ground-facing artifacts, simulator and documentation must be derived from the model, not the other way around.
 
 ### 6.2 Contract Before Code
 
 The first valuable artifact is the contract.
 
-Code generation, runtime execution and integration bridges are secondary and must not be designed before the model has sufficient clarity.
+Code generation, runtime execution, ground integration and integration bridges are secondary and must not redefine the model.
 
-### 6.3 Mission Data Chain Before Runtime-Facing Bindings
+### 6.3 Mission Data Chain Before Generated Artifacts
 
-OrbitFabric must make the mission data chain explicit before generating software-facing artifacts.
+OrbitFabric must make the mission data chain explicit before generating software-facing or ground-facing artifacts.
 
 The current chain is:
 
@@ -148,37 +150,26 @@ payload behavior
         -> autonomy and recovery expectations
         -> end-to-end scenario evidence
         -> runtime-facing contract bindings
+        -> ground-facing integration artifacts
 ```
 
-Only after these concepts are sufficiently clear should OrbitFabric derive ground integration artifacts from them.
+Only after these concepts are sufficiently clear should OrbitFabric derive plugin, tool-specific or external integration layers from them.
 
-### 6.4 Generated Code Is Disposable
+### 6.4 Generated Artifacts Are Disposable
 
-Generated runtime-facing contract bindings are reproducible outputs.
+Generated runtime-facing contract bindings and ground-facing integration artifacts are reproducible outputs.
 
 They are not the source of truth.
 
 Users must not place handwritten implementation code inside generated files.
 
-User implementation code must live outside `generated/` and integrate through generated identifiers, descriptors, typed structures and abstract interfaces.
+User implementation code and downstream integration code must live outside `generated/` and integrate through generated identifiers, descriptors, typed structures, abstract interfaces, manifests or dictionaries.
 
 ### 6.5 Linting as Engineering Judgment
 
 OrbitFabric linting must not be limited to YAML syntax validation.
 
 It must perform mission consistency analysis.
-
-Examples:
-
-- high-criticality telemetry without limits is an error;
-- a command allowed in SAFE mode despite operational risk is an error;
-- a fault emitting an unknown event is an error;
-- a packet referencing unknown telemetry is an error;
-- a command without timeout is at least a warning;
-- an event without downlink priority is at least a warning;
-- an incomplete data product storage intent is at least a warning;
-- a high-priority data product without downlink intent is at least a warning;
-- a contact profile referenced by downlink policy but missing from the model is an error.
 
 The lint system is a core feature, not a utility.
 
@@ -200,13 +191,13 @@ OrbitFabric must not become a full ground segment.
 
 However, it must generate artifacts useful for ground integration:
 
-- Markdown or HTML documentation;
-- JSON mission database exports;
-- packet descriptions;
-- decoder skeletons;
+- generated review documentation;
+- JSON ground dictionaries;
+- CSV review dictionaries;
+- packet membership dictionaries;
 - data product dictionaries;
 - downlink policy descriptions;
-- future Yamcs/OpenC3/XTCE exports.
+- future Yamcs/OpenC3/XTCE exports when explicitly implemented and tested.
 
 ### 6.8 Clean-Room Development
 
@@ -230,14 +221,14 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 ## 7. Completed Early Scope
 
-The current v0.7.0 baseline includes:
+The current v0.8.0 baseline includes:
 
 - Mission Model YAML files;
 - model loading;
 - structural validation;
 - semantic linting;
 - generated Markdown documentation;
-- simple deterministic host-side scenario simulation;
+- deterministic host-side scenario simulation;
 - scenario runner;
 - payload contract model;
 - data product contract model;
@@ -247,11 +238,11 @@ The current v0.7.0 baseline includes:
 - RuntimeContract intermediate model;
 - generated C++17 runtime-facing contract bindings;
 - C++17 host-build smoke validation;
-- generated payload documentation;
-- generated data product documentation;
-- generated contact/downlink documentation;
-- generated commandability/autonomy documentation;
-- generated data-flow documentation;
+- GroundContract intermediate model;
+- generated generic ground-facing dictionaries;
+- generated JSON ground dictionaries;
+- generated CSV ground dictionaries;
+- generated ground Markdown review artifacts;
 - readable logs;
 - JSON reports;
 - one complete demo mission named `demo-3u`.
@@ -263,43 +254,42 @@ orbitfabric lint examples/demo-3u/mission/
 orbitfabric gen docs examples/demo-3u/mission/
 orbitfabric gen data-flow examples/demo-3u/mission/
 orbitfabric gen runtime examples/demo-3u/mission/
+orbitfabric gen ground examples/demo-3u/mission/
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 ```
 
 ---
 
-## 8. Payload Contract Direction
+## 8. Ground Integration Artifact Direction
 
-The Payload / IOD Payload Contract Model makes mission-specific payload behavior explicit without turning OrbitFabric into a payload runtime framework.
+The Ground Integration Artifacts slice makes mission data visible to ground-side engineering workflows without turning OrbitFabric into ground software.
 
-A payload contract may describe:
+A ground artifact may describe:
 
-- payload identity;
-- payload profile;
-- linked subsystem;
-- lifecycle states;
-- telemetry references;
-- command references;
-- event references;
-- fault references;
-- command preconditions;
-- expected effects;
-- scenario-level behavior;
-- generated documentation.
+- telemetry identity and metadata;
+- command identity, arguments and allowed modes;
+- event identity and severity;
+- fault identity and recovery intent metadata;
+- data product identity, storage intent and downlink intent;
+- packet membership;
+- manifest boundary flags;
+- human-reviewable dictionary documentation.
 
-A payload contract must not describe:
+A ground artifact must not describe or implement:
 
-- payload firmware;
-- payload drivers;
-- hardware buses;
-- physical payload simulation;
-- scientific data processing pipelines;
-- real payload acquisition implementation.
+- live telemetry transport;
+- binary packet decoding;
+- command uplink;
+- authentication or authorization;
+- telemetry archive storage;
+- operator displays;
+- ground station scheduling;
+- Yamcs/OpenC3/XTCE compatibility unless explicitly implemented and tested.
 
-Payload contracts are part of the Mission Data Contract.
+Ground artifacts are part of the Mission Data Contract output chain.
 
-They are the foundation for later data product, storage and downlink modeling.
+They are the foundation for later tool-specific exporters and plugin extensibility.
 
 ---
 
@@ -318,7 +308,8 @@ Payload or subsystem activity
         -> commandability and autonomy constraints
         -> end-to-end scenario evidence
         -> runtime-facing contract bindings
-        -> future ground artifacts
+        -> ground-facing integration artifacts
+        -> future plugins and tool-specific exporters
 ```
 
 This direction is essential for small spacecraft and CubeSat missions because the value of mission data depends on the full path from onboard generation to ground consumption.
@@ -349,6 +340,10 @@ Early OrbitFabric versions must not include:
 - F Prime integration;
 - Yamcs integration as a live service;
 - OpenC3 integration as a live service;
+- XTCE compliance;
+- telemetry archive implementation;
+- operator console implementation;
+- command uplink implementation;
 - Basilisk integration as a dynamics simulator;
 - formal verification;
 - advanced security;
@@ -369,57 +364,9 @@ The initial demo mission is `demo-3u`.
 
 It is a synthetic 3U CubeSat-like mission used only to demonstrate OrbitFabric concepts.
 
-It contains:
+It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings and ground-facing integration artifacts.
 
-- OBC;
-- EPS mock;
-- Payload mock;
-- Radio mock;
-- operational modes:
-  - BOOT;
-  - NOMINAL;
-  - PAYLOAD_ACTIVE;
-  - DEGRADED;
-  - SAFE;
-  - MAINTENANCE;
-- battery-voltage telemetry;
-- payload acquisition state telemetry;
-- payload start/stop commands;
-- EPS status command;
-- battery warning fault;
-- battery critical fault;
-- payload contract `demo_iod_payload`;
-- data product contract `payload.radiation_histogram`;
-- contact profile `primary_ground_contact`;
-- link profile `uhf_downlink_nominal`;
-- contact window `demo_contact_001`;
-- downlink flow `science_next_available_contact`;
-- command sources `ground_operator` and `onboard_autonomy`;
-- commandability rule `payload_start_ground_rule`;
-- autonomous actions for low/critical battery recovery assumptions;
-- recovery intents toward DEGRADED and SAFE;
-- one nominal payload acquisition scenario;
-- one scenario where the payload is active, battery voltage degrades, a warning event is emitted, the spacecraft transitions to DEGRADED and the payload is automatically stopped;
-- one scenario demonstrating contract-level data-flow evidence;
-- generated runtime-facing contract bindings derived from the same model.
-
-The expected battery-low scenario narrative is:
-
-```text
-[00:00] MODE=NOMINAL
-[00:05] COMMAND payload.start_acquisition -> ACCEPTED
-[00:05] EVENT payload.acquisition_started
-[00:05] PAYLOAD demo_iod_payload LIFECYCLE=ACQUIRING
-[00:32] EVENT eps.battery_low severity=WARNING
-[00:32] MODE TRANSITION PAYLOAD_ACTIVE -> DEGRADED
-[00:32] COMMAND payload.stop_acquisition -> AUTO_DISPATCHED
-[00:32] PAYLOAD demo_iod_payload LIFECYCLE=READY
-[00:40] SCENARIO PASSED
-```
-
-The demo also includes synthetic contact/downlink, commandability/autonomy, data-flow and runtime-binding slices.
-
-Those assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
+The demo assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
 
 ---
 
@@ -437,12 +384,17 @@ The recommended technical baseline is:
 - MkDocs Material for documentation;
 - C++17 for the first generated runtime-facing binding profile;
 - CMake for host-build smoke validation;
+- JSON, CSV and Markdown for the first generated ground-facing artifact package;
 - GitHub Actions for CI;
 - Apache-2.0 license.
 
 The generated C++17 surface is intentionally contract-facing and host-buildable.
 
 It is not a flight runtime.
+
+The generated ground-facing package is intentionally tool-neutral and reviewable.
+
+It is not a ground runtime.
 
 ---
 
@@ -456,7 +408,7 @@ The repository should contain:
 - documentation;
 - examples;
 - tests;
-- generated artifacts examples;
+- generated artifact examples only when explicitly required;
 - architectural decision records.
 
 Initial repository structure:
@@ -490,10 +442,11 @@ OrbitFabric is successful in the early public preview if a user can:
 6. generate Markdown documentation from the same Mission Model;
 7. generate runtime-facing C++17 contract bindings from the same Mission Model;
 8. validate those generated bindings through a host-side C++17 smoke build;
-9. understand the project positioning from the README in less than one minute;
-10. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
-11. understand how payload contracts fit into the Mission Data Contract;
-12. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations and runtime-facing bindings fit into the roadmap before ground artifacts.
+9. generate ground-facing JSON, CSV and Markdown artifacts from the same Mission Model;
+10. understand the project positioning from the README in less than one minute;
+11. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
+12. understand how payload contracts fit into the Mission Data Contract;
+13. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings and ground-facing artifacts fit into the roadmap before plugin extensibility.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 
@@ -549,7 +502,7 @@ The project should prefer:
 - generated documentation over manually duplicated references;
 - generated contract-facing artifacts over hidden implementation assumptions;
 - clean interfaces over premature integrations;
-- mission data chain modeling before runtime-facing and ground-facing generation.
+- mission data chain modeling before runtime-facing, ground-facing and plugin generation.
 
 The project should reject:
 
@@ -560,7 +513,8 @@ The project should reject:
 - undocumented assumptions;
 - private mission-derived examples;
 - flight runtime generation from an immature model;
-- ground integration exports before the contract they export is clear.
+- ground integration exports that imply unimplemented ground behavior;
+- plugins that bypass or redefine the Mission Data Contract.
 
 ---
 
@@ -574,7 +528,7 @@ The first versions must prove one thing convincingly:
 
 > A small spacecraft mission can be described once, validated semantically, simulated operationally, tested through scenarios, documented automatically and exposed through generated contract-facing artifacts from a single source of truth.
 
-The next versions must extend that proof to the ground-facing side:
+The current version extends that proof to the ground-facing side:
 
 > Payload behavior, data products, onboard storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations and runtime-facing contract bindings can feed ground integration artifacts without duplicating or redefining the mission contract.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,6 @@ Mission Model YAML
   -> generated Markdown docs
   -> mission inspection
   -> scenario validation
-  -> scenario loading
   -> deterministic scenario execution
   -> Payload Contract documentation
   -> Data Product Contract documentation
@@ -23,6 +22,10 @@ Mission Model YAML
   -> RuntimeContract generation
   -> C++17 runtime-facing contract bindings
   -> C++17 host-build smoke validation
+  -> GroundContract generation
+  -> ground-facing JSON dictionaries
+  -> ground-facing CSV dictionaries
+  -> human-reviewable ground Markdown artifacts
   -> JSON lint reports
   -> JSON simulation reports with data-flow evidence
   -> simulation logs
@@ -31,6 +34,8 @@ Mission Model YAML
 OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
 
 Generated runtime-facing contract bindings are not flight software.
+
+Generated ground integration artifacts are not ground software.
 
 ---
 
@@ -98,7 +103,7 @@ orbitfabric --help
 Expected version for the current development preview:
 
 ```text
-orbitfabric 0.7.0
+orbitfabric 0.8.0
 ```
 
 ---
@@ -161,12 +166,6 @@ Generate a JSON lint report:
 ```bash
 orbitfabric lint examples/demo-3u/mission/ \
   --json generated/reports/lint_report.json
-```
-
-Generated output:
-
-```text
-generated/reports/lint_report.json
 ```
 
 ---
@@ -258,7 +257,44 @@ It does not validate flight behavior.
 
 ---
 
-## 13. Run the battery-low demo scenario
+## 13. Generate ground integration artifacts
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+Generated output:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+The generated ground files are ground-facing contract exports.
+
+They are intended for engineering review, scripts and downstream integration work.
+
+They do not implement a live ground segment, decoder, telemetry archive, database, operator console or command uplink service.
+
+---
+
+## 14. Run the battery-low demo scenario
 
 ```bash
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
@@ -278,16 +314,9 @@ orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
   --log generated/logs/battery_low_during_payload.log
 ```
 
-Generated outputs:
-
-```text
-generated/reports/battery_low_during_payload_report.json
-generated/logs/battery_low_during_payload.log
-```
-
 ---
 
-## 14. Run the data-flow evidence scenario
+## 15. Run the data-flow evidence scenario
 
 ```bash
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
@@ -315,7 +344,7 @@ command -> data product -> storage intent -> downlink intent -> downlink flow ->
 
 ---
 
-## 15. What this proves
+## 16. What this proves
 
 The current demo proves that OrbitFabric can:
 
@@ -323,28 +352,22 @@ The current demo proves that OrbitFabric can:
 - load optional `payloads.yaml`, `data_products.yaml`, `contacts.yaml` and `commandability.yaml` domains;
 - validate Mission Model structure;
 - run semantic lint rules;
-- validate payload, data product, contact/downlink and commandability/autonomy references;
-- validate command-declared data product effects;
-- validate scenario data-flow expectation references;
 - generate Markdown documentation;
-- generate payload, data product, contact/downlink, commandability/autonomy and data-flow documentation;
 - inspect a Mission Model summary;
 - validate scenarios without executing them;
-- load scenarios;
 - execute deterministic operational sequences;
-- emit events;
-- apply a fault-triggered mode transition;
-- auto-dispatch a recovery command in the host-side scenario simulator;
 - record contract-level data-flow evidence;
 - assert command-to-data-product-to-contact evidence in a scenario;
 - produce JSON reports and logs;
 - build a RuntimeContract from the validated Mission Model;
 - generate deterministic C++17 runtime-facing contract bindings;
-- validate generated C++17 contract bindings with a host-build smoke target.
+- validate generated C++17 contract bindings with a host-build smoke target;
+- build a GroundContract from the validated Mission Model;
+- generate deterministic JSON, CSV and Markdown ground-facing contract artifacts.
 
 ---
 
-## 16. What this does not prove
+## 17. What this does not prove
 
 The current demo does not prove:
 
@@ -358,6 +381,12 @@ The current demo does not prove:
 - RF link budget simulation;
 - CCSDS, PUS or CFDP compliance;
 - compatibility with cFS, F Prime, Yamcs or OpenC3;
+- XTCE compliance;
+- binary decoder behavior;
+- command uplink behavior;
+- telemetry archive behavior;
+- database behavior;
+- operator console behavior;
 - orbital, attitude, power or thermal dynamics;
 - command dispatch runtime behavior;
 - telemetry polling runtime behavior;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
-# OrbitFabric — Roadmap
+# OrbitFabric - Roadmap
 
-Version: v0.7.0  
+Version: v0.8.0  
 Status: Development preview  
 Scope: v0.3 to v1.0 planning
 
@@ -59,18 +59,18 @@ v0.4.0  Contact Windows and Downlink Flow Contracts           completed
 v0.5.0  Commandability and Autonomy Contracts                 completed
 v0.6.0  End-to-End Mission Data Flow Evidence                 completed
 v0.7.0  Generated Runtime Skeletons                           completed
-v0.8    Ground Integration Artifacts                          next
-v0.9    Plugin and Extensibility Layer                        future
+v0.8.0  Ground Integration Artifacts                          completed
+v0.9    Plugin and Extensibility Layer                        next
 v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target after v0.7.0 is now `v0.8 — Ground Integration Artifacts`.
+The immediate target after v0.8.0 is now `v0.9 - Plugin and Extensibility Layer`.
 
-Ground integration artifacts remain downstream of the Mission Data Contract. v0.7 completed the first runtime-facing contract binding layer required before ground-facing exports are useful.
+Ground integration artifacts remain downstream of the Mission Data Contract. v0.8 completed the first ground-facing contract export layer required before tool-specific integrations or extension points are useful.
 
 ---
 
-## 3. Completed Baseline — v0.1 Mission Contract MVP
+## 3. Completed Baseline - v0.1 Mission Contract MVP
 
 v0.1 proved that a user can:
 
@@ -82,7 +82,7 @@ v0.1 proved that a user can:
 
 ---
 
-## 4. Completed Slice — v0.2.1 Payload Contract Model
+## 4. Completed Slice - v0.2.1 Payload Contract Model
 
 v0.2.1 introduced the first narrow vertical slice for Payload / IOD Payload Contracts.
 
@@ -103,7 +103,7 @@ They must not describe payload firmware, payload drivers, hardware buses, onboar
 
 ---
 
-## 5. Completed Alignment — v0.2.2 Payload Contract Release Alignment
+## 5. Completed Alignment - v0.2.2 Payload Contract Release Alignment
 
 v0.2.2 aligned README, public documentation, roadmap, changelog, release notes and public communication with the Payload Contract Model.
 
@@ -111,7 +111,7 @@ It did not introduce new model semantics.
 
 ---
 
-## 6. Completed Alignment — v0.2.3 Mission Data Chain Roadmap Alignment
+## 6. Completed Alignment - v0.2.3 Mission Data Chain Roadmap Alignment
 
 v0.2.3 formalized the post-payload direction:
 
@@ -131,7 +131,7 @@ It remained architecture-first and documentation-first.
 
 ---
 
-## 7. Completed Slice — v0.3.0 Data Product and Storage Contracts
+## 7. Completed Slice - v0.3.0 Data Product and Storage Contracts
 
 v0.3.0 introduced data products as first-class mission data artifacts.
 
@@ -157,7 +157,7 @@ v0.3.0 did not implement real storage, file systems, compression, payload proces
 
 ---
 
-## 8. Completed Slice — v0.4.0 Contact Windows and Downlink Flow Contracts
+## 8. Completed Slice - v0.4.0 Contact Windows and Downlink Flow Contracts
 
 v0.4.0 modeled contact windows and downlink flow assumptions without becoming a ground segment, an orbital dynamics simulator, an RF simulator or a downlink runtime.
 
@@ -181,7 +181,7 @@ It did not implement real contact scheduling, real downlink execution, RF behavi
 
 ---
 
-## 9. Completed Slice — v0.5.0 Commandability and Autonomy Contracts
+## 9. Completed Slice - v0.5.0 Commandability and Autonomy Contracts
 
 v0.5.0 made command use and autonomous behavior explicit in the Mission Data Contract.
 
@@ -206,7 +206,7 @@ v0.5.0 did not implement real command authentication, authorization, encryption,
 
 ---
 
-## 10. Completed Slice — v0.6.0 End-to-End Mission Data Flow Evidence
+## 10. Completed Slice - v0.6.0 End-to-End Mission Data Flow Evidence
 
 v0.6.0 combined payload contracts, data products, storage intent, downlink assumptions, contact windows and command effects into deterministic scenario evidence.
 
@@ -243,13 +243,11 @@ v0.6.0 did not implement real payload file generation, onboard storage runtime, 
 
 ---
 
-## 11. Completed Slice — v0.7.0 Generated Runtime Skeletons
-
-### 11.1 Objective
+## 11. Completed Slice - v0.7.0 Generated Runtime Skeletons
 
 v0.7.0 introduced the first generated runtime-facing contract binding layer derived from the Mission Data Contract.
 
-The public milestone name is:
+The public milestone name was:
 
 ```text
 Generated Runtime Skeletons
@@ -264,8 +262,6 @@ runtime-facing contract bindings
 This is not flight software.
 
 It is a generated software boundary that implementation code can include, compile and implement against outside `generated/`.
-
-### 11.2 Completed Capabilities
 
 v0.7.0 introduced:
 
@@ -286,105 +282,119 @@ Runtime Contract Bindings reference documentation
 v0.7.0 release notes
 ```
 
-Generated output:
-
-```text
-generated/runtime/cpp17/runtime_contract_manifest.json
-generated/runtime/cpp17/include/orbitfabric/generated/mission_ids.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_enums.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_registries.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/command_args.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/adapter_interfaces.hpp
-generated/runtime/cpp17/CMakeLists.txt
-generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
-```
-
-### 11.3 Boundary
-
-v0.7.0 intentionally does not implement:
-
-```text
-flight-ready runtime
-complete OBC framework
-command dispatch runtime
-command queues
-telemetry polling runtime
-event routing runtime
-fault manager runtime
-scheduler
-HAL
-drivers
-RTOS abstraction
-binary serialization
-CCSDS/PUS/CFDP behavior
-storage runtime
-downlink runtime
-user-code merge
-protected regions
-```
-
-The milestone proves that the Mission Data Contract can generate deterministic, host-buildable, software-facing contract artifacts.
-
-It does not prove flight readiness.
+v0.7.0 intentionally did not implement flight-ready runtime, command dispatch runtime, command queues, telemetry polling runtime, event routing runtime, fault manager runtime, scheduler, HAL, drivers, RTOS abstraction, binary serialization, CCSDS/PUS/CFDP behavior, storage runtime, downlink runtime, user-code merge or protected regions.
 
 ---
 
-## 12. Next Milestone — v0.8 Ground Integration Artifacts
+## 12. Completed Slice - v0.8.0 Ground Integration Artifacts
 
 ### 12.1 Objective
 
-Generate useful artifacts for ground integration without becoming a ground segment.
+v0.8.0 introduced the first generated ground-facing artifact package derived from the Mission Data Contract.
 
-v0.8 should consume the same Mission Data Contract and the same contract discipline introduced through v0.1 through v0.7.
-
-The goal is not to implement Yamcs, OpenC3, XTCE tooling or a ground database.
-
-The goal is to produce clean, inspectable exports that ground-side tools could consume or adapt.
-
-### 12.2 Candidate Features
+The public milestone name is:
 
 ```text
-JSON mission database export
-telemetry dictionary export
-command dictionary export
-event dictionary export
-fault dictionary export
-data product dictionary export
-packet dictionary export
-runtime contract manifest reuse for ground exports
-simple decoder skeletons
-Yamcs-like export prototype
-OpenC3-like export prototype
-XTCE exploration/prototype
-ground-facing documentation page
+Ground Integration Artifacts
 ```
 
-### 12.3 Required Boundary
-
-v0.8 generated artifacts must be described as:
+The precise architectural meaning is:
 
 ```text
-ground-facing contract exports
-integration artifacts
-development-preview dictionaries
+ground-facing Mission Data Contract exports
 ```
 
-They must not be described as:
+This is not a ground segment.
+
+It is a deterministic, inspectable, tool-neutral artifact package that ground software teams can review, adapt or consume downstream.
+
+### 12.2 Completed Capabilities
+
+v0.8.0 introduced:
+
+```text
+GroundContract intermediate model
+orbitfabric gen ground command
+generic generation profile
+ground_contract_manifest.json
+JSON telemetry dictionary
+JSON command dictionary
+JSON event dictionary
+JSON fault dictionary
+JSON data product dictionary
+JSON packet dictionary
+CSV telemetry dictionary
+CSV command dictionary
+CSV event dictionary
+CSV fault dictionary
+CSV data product dictionary
+CSV packet dictionary
+generated ground artifact README.md
+generated ground_dictionaries.md review document
+Ground Integration Artifacts reference documentation
+ADR-0012 Ground Integration Artifacts Boundary
+v0.8.0 release notes
+```
+
+Generated output:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+### 12.3 Boundary
+
+v0.8.0 intentionally does not implement:
 
 ```text
 live ground segment
 mission control system
 operator console
 telemetry archive
+telemetry database
 command uplink service
-Yamcs compatibility unless tested
-OpenC3 compatibility unless tested
-XTCE compliance unless verified
+telecommand transport
+telemetry downlink runtime
+network/session/routing behavior
+command authentication or authorization
+security enforcement
+Yamcs integration
+OpenC3 integration
+XTCE compliance
+CCSDS/PUS/CFDP implementation
+binary packet decoder
+binary telecommand encoder
+offset/bitfield layout model
+calibration model
+RF/link-budget behavior
+pass scheduling
+station automation
 ```
+
+The milestone proves that the Mission Data Contract can generate deterministic, reviewable and machine-readable ground-facing artifacts.
+
+It does not prove live ground-system readiness.
 
 ---
 
-## 13. Future Milestone — v0.9 Plugin and Extensibility Layer
+## 13. Next Milestone - v0.9 Plugin and Extensibility Layer
 
 v0.9 should introduce controlled extension points after the core mission data chain and first generated artifact layers have matured.
 
@@ -410,7 +420,7 @@ Plugins must extend OrbitFabric without silently redefining core semantics.
 
 ---
 
-## 14. Future Milestone — v1.0 Stable Mission Data Contract
+## 14. Future Milestone - v1.0 Stable Mission Data Contract
 
 v1.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
 
@@ -424,7 +434,9 @@ stable Contact/Downlink Contract schema
 stable Commandability Contract schema
 stable data-flow evidence semantics
 stable RuntimeContract semantics
+stable GroundContract semantics
 stable runtime-facing contract binding surface
+stable ground-facing artifact package
 stable CLI commands
 stable lint rule code policy
 stable generated documentation format
@@ -498,6 +510,7 @@ When deciding what to implement next, use these rules.
 10. Ground Assumptions Are Contracts.
 11. Generated Code Is Disposable.
 12. User Code Lives Outside `generated/`.
+13. Tool-specific Claims Require Tests.
 
 ---
 
@@ -506,23 +519,23 @@ When deciding what to implement next, use these rules.
 The immediate work package is:
 
 ```text
-v0.8 — Ground Integration Artifacts
+v0.9 - Plugin and Extensibility Layer
 ```
 
 Required sequence:
 
 ```text
-1. define the minimal ground export scope
-2. keep ground artifacts downstream of the Mission Model
-3. reuse RuntimeContract or a similarly explicit intermediate export model where useful
-4. generate dictionaries before tool-specific integrations
-5. avoid claiming Yamcs/OpenC3/XTCE compatibility before it is implemented and tested
+1. define extension boundaries before adding plugin execution behavior
+2. keep plugins downstream of the Mission Model
+3. define explicit plugin metadata
+4. avoid plugins silently redefining core semantics
+5. provide one minimal example plugin only after the extension contract is clear
 6. preserve the Mission Data Contract as source of truth
 ```
 
-Do not add live ground services before ground export boundaries are clear.
+Do not add broad plugin machinery before the extension boundary is clear.
 
-Do not turn OrbitFabric into a ground segment.
+Do not let plugins bypass validation or generated artifact contracts.
 
 ---
 
@@ -536,7 +549,9 @@ The v0.6 roadmap step completed the first end-to-end contract-level Mission Data
 
 The v0.7 roadmap step completed the first runtime-facing contract binding slice.
 
-Only after the mission data chain, commandability, autonomy, end-to-end evidence and runtime-facing binding layers are clear should OrbitFabric grow into ground integration artifacts and plugin extensibility.
+The v0.8 roadmap step completed the first ground-facing contract export slice.
+
+Only after the mission data chain, commandability, autonomy, end-to-end evidence, runtime-facing binding layer and ground-facing artifact layer are clear should OrbitFabric grow into plugin extensibility.
 
 The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,19 +2,19 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios and runtime-facing contract bindings in a single Mission Data Contract.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings and ground-facing integration artifacts in a single Mission Data Contract.
 
-From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic host-buildable software-facing artifacts.
+From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic integration artifacts.
 
 ## Current development preview
 
 OrbitFabric is currently at:
 
 ```text
-v0.7.0 — Generated Runtime Skeletons
+v0.8.0 - Ground Integration Artifacts
 ```
 
-In v0.7.0, Generated Runtime Skeletons means **runtime-facing contract bindings**.
+In v0.8.0, Ground Integration Artifacts means **ground-facing Mission Data Contract exports**.
 
 The current public preview includes:
 
@@ -37,10 +37,13 @@ The current public preview includes:
 - JSON simulation reports with contract-level data-flow evidence;
 - data-flow scenario assertions;
 - RuntimeContract generation;
-- generated C++17 identifiers, enums and registries;
-- generated C++17 command argument structs;
-- generated C++17 abstract adapter interfaces;
+- generated C++17 runtime-facing contract bindings;
 - generated C++17 host-build smoke files;
+- GroundContract generation;
+- generated ground contract manifest;
+- generated JSON ground dictionaries;
+- generated CSV ground dictionaries;
+- generated human-reviewable ground Markdown artifacts;
 - a clean-room synthetic `demo-3u` mission.
 
 ## Core Idea
@@ -57,11 +60,14 @@ Mission Model
   -> end-to-end mission data flow evidence
   -> RuntimeContract
   -> generated runtime-facing contract bindings
-  -> future ground integration artifacts
+  -> GroundContract
+  -> generated ground-facing integration artifacts
 ```
 
 OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
 
-It is the contract layer between mission design, onboard software, simulation, testing, documentation and future ground integration artifacts.
+It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing bindings and ground-facing integration artifacts.
 
 Generated runtime-facing contract bindings are not flight software.
+
+Generated ground integration artifacts are not ground software.

--- a/docs/reference/data-flow-evidence.md
+++ b/docs/reference/data-flow-evidence.md
@@ -1,7 +1,7 @@
 # Data Flow Evidence
 
 Status: Development preview  
-Scope: Introduced in OrbitFabric v0.6.0 and retained in the v0.7.0 baseline
+Scope: Introduced in OrbitFabric v0.6.0 and retained in the v0.8.0 baseline
 
 ---
 
@@ -48,7 +48,7 @@ scenarios/*.yaml
         expect.data_flow assertions
 ```
 
-Generated documentation and JSON reports are derived artifacts.
+Generated documentation, JSON reports, runtime-facing bindings and ground-facing artifacts are derived outputs.
 
 They are not the source of truth.
 
@@ -202,7 +202,17 @@ Matching Contact Windows
 
 ---
 
-## 8. Demo scenario
+## 8. Relationship with runtime and ground artifacts
+
+v0.7 builds on Data Flow Evidence by deriving runtime-facing contract bindings from the same validated Mission Model.
+
+v0.8 builds on the same chain by deriving ground-facing contract exports from the same validated Mission Model.
+
+Data Flow Evidence remains a contract-level precondition for meaningful runtime-facing and ground-facing generated artifacts.
+
+---
+
+## 9. Demo scenario
 
 The canonical data-flow evidence demo scenario is:
 
@@ -231,7 +241,7 @@ orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
 
 ---
 
-## 9. Boundary
+## 10. Boundary
 
 Data Flow Evidence does not implement:
 
@@ -247,6 +257,7 @@ RF behavior
 ground station operations
 CCSDS/PUS/CFDP behavior
 runtime behavior
+ground runtime behavior
 ```
 
 It is deterministic contract-level evidence.
@@ -257,7 +268,7 @@ It does not prove that real flight or ground software exists.
 
 ---
 
-## 10. Architectural meaning
+## 11. Architectural meaning
 
 v0.6 completed the first end-to-end Mission Data Chain evidence slice:
 
@@ -272,6 +283,8 @@ Payload Contract
         -> End-to-End Mission Data Flow Evidence
 ```
 
-v0.7 builds on this by deriving runtime-facing contract bindings from the same validated Mission Model.
+v0.7 exposed that chain through runtime-facing contract bindings.
 
-Data Flow Evidence remains a contract-level precondition for meaningful runtime-facing and ground-facing generated artifacts.
+v0.8 exposed that chain through ground-facing contract artifacts.
+
+Both remain downstream of the Mission Model.

--- a/docs/reference/ground-integration-artifacts.md
+++ b/docs/reference/ground-integration-artifacts.md
@@ -1,6 +1,6 @@
 # Ground Integration Artifacts
 
-Status: Planned for v0.8.0  
+Status: Introduced in v0.8.0  
 Scope: Ground-facing Mission Data Contract exports
 
 ---
@@ -25,9 +25,9 @@ They are not a Yamcs, OpenC3 or XTCE integration.
 
 ---
 
-## Intended Flow
+## Implemented Flow
 
-The intended v0.8.0 flow is:
+The v0.8.0 flow is:
 
 ```text
 Mission Model
@@ -67,7 +67,7 @@ Which assumptions remain external implementation concerns?
 
 ## Generated Package
 
-The planned generic output package is:
+The generic output package is:
 
 ```text
 generated/ground/generic/
@@ -96,9 +96,31 @@ It is not intended to be executed.
 
 ---
 
+## Command
+
+Ground artifacts are generated with:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+Default output:
+
+```text
+generated/ground/generic/
+```
+
+The currently supported generation profile is:
+
+```text
+generic
+```
+
+---
+
 ## GroundContract
 
-GroundContract is the planned v0.8.0 intermediate model for ground-facing generation.
+GroundContract is the v0.8.0 intermediate model for ground-facing generation.
 
 It is derived from the validated Mission Model.
 
@@ -137,12 +159,12 @@ Future tool-specific profiles may be considered only when their outputs are impl
 
 ## Telemetry Dictionary
 
-The telemetry dictionary may expose:
+The telemetry dictionary exposes:
 
 ```text
-id
+model_id
 name
-type
+value_type
 unit
 source
 sampling
@@ -150,7 +172,7 @@ criticality
 persistence
 downlink_priority
 limits
-enum
+enum_values
 quality
 description
 ```
@@ -161,10 +183,10 @@ It does not implement telemetry decoding, telemetry polling, alarm runtime, arch
 
 ## Command Dictionary
 
-The command dictionary may expose:
+The command dictionary exposes:
 
 ```text
-id
+model_id
 target
 description
 arguments
@@ -179,7 +201,7 @@ expected_effects
 
 It does not implement command encoding, command uplink, authentication, authorization, queuing, routing, retry logic or runtime ACK handling.
 
-The existing command `risk` metadata may be exported because it is already part of the Mission Model.
+The existing command `risk` metadata is exported because it is already part of the Mission Model.
 
 This does not create a security model.
 
@@ -187,10 +209,10 @@ This does not create a security model.
 
 ## Event Dictionary
 
-The event dictionary may expose:
+The event dictionary exposes:
 
 ```text
-id
+model_id
 source
 severity
 description
@@ -204,10 +226,10 @@ It does not implement event routing, event storage, alerting or operator notific
 
 ## Fault Dictionary
 
-The fault dictionary may expose:
+The fault dictionary exposes:
 
 ```text
-id
+model_id
 source
 severity
 description
@@ -222,10 +244,10 @@ It does not implement fault detection, FDIR, safing behavior, command dispatch o
 
 ## Data Product Dictionary
 
-The data product dictionary may expose:
+The data product dictionary exposes:
 
 ```text
-id
+model_id
 producer
 producer_type
 type
@@ -243,10 +265,10 @@ It does not implement payload processing, file creation, compression, storage, r
 
 ## Packet Dictionary
 
-The packet dictionary may expose:
+The packet dictionary exposes:
 
 ```text
-id
+model_id
 name
 type
 max_payload_bytes
@@ -261,15 +283,15 @@ It is not a binary decoder specification.
 
 The current Mission Model does not define byte offsets, bit offsets, endianness, scaling rules, calibration curves, APID, VCID, CCSDS headers, PUS service/subservice fields, framing or transport.
 
-Therefore v0.8.0 must not claim decoder generation, CCSDS compliance, PUS compliance or CFDP behavior.
+Therefore v0.8.0 does not claim decoder generation, CCSDS compliance, PUS compliance or CFDP behavior.
 
 ---
 
 ## Manifest
 
-The generated manifest should explicitly describe the generated package and its boundary.
+The generated manifest explicitly describes the generated package and its boundary.
 
-Expected boundary flags include:
+Boundary flags include:
 
 ```json
 {
@@ -295,21 +317,17 @@ They prevent generated dictionaries from being mistaken for live ground software
 
 ---
 
-## CLI
+## JSON, CSV and Markdown Outputs
 
-The planned CLI command is:
-
-```bash
-orbitfabric gen ground examples/demo-3u/mission/
-```
-
-Default output:
+The generic profile writes three review layers:
 
 ```text
-generated/ground/generic/
+JSON dictionaries  -> machine-readable contract artifacts
+CSV dictionaries   -> spreadsheet-style review artifacts
+Markdown documents -> human-reviewable engineering artifacts
 ```
 
-Only the `generic` profile is planned for v0.8.0.
+The generated Markdown avoids HTML table line-break tags so that it remains readable in common Markdown editors.
 
 ---
 
@@ -367,9 +385,9 @@ Neither should bypass Mission Model validation.
 
 ## Relationship with Security Assumptions
 
-v0.8.0 may export existing command `risk` metadata.
+v0.8.0 exports existing command `risk` metadata.
 
-It must not introduce security assumptions, command authorization, authentication, audit runtime, cryptography, key management or enforcement behavior.
+It does not introduce security assumptions, command authorization, authentication, audit runtime, cryptography, key management or enforcement behavior.
 
 Security assumptions are a separate future contract-model topic.
 

--- a/docs/reference/json-reports-v0.1.md
+++ b/docs/reference/json-reports-v0.1.md
@@ -5,7 +5,7 @@ This page documents the JSON reports currently produced by OrbitFabric.
 Current documented baseline:
 
 ```text
-v0.7.0 — Generated Runtime Skeletons
+v0.8.0 - Ground Integration Artifacts
 ```
 
 OrbitFabric JSON reports are generated artifacts intended for:
@@ -25,7 +25,7 @@ The source of truth remains the Mission Model YAML and scenario YAML.
 
 The JSON report structures documented here are development-preview contracts.
 
-They are stable enough for current v0.7 workflows, but they are not a v1.0 compatibility promise.
+They are stable enough for current v0.8 workflows, but they are not a v1.0 compatibility promise.
 
 Future versions may introduce:
 
@@ -46,7 +46,7 @@ Current example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.7.0"
+  "version": "0.8.0"
 }
 ```
 
@@ -225,6 +225,30 @@ It does not imply real payload file generation, onboard storage writes, downlink
 
 ---
 
+## Ground artifacts and JSON dictionaries
+
+v0.8.0 also generates JSON ground dictionaries through:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+The JSON ground dictionaries are generated under:
+
+```text
+generated/ground/generic/dictionaries/
+```
+
+They are ground-facing generated artifacts, not JSON reports.
+
+They are documented separately in:
+
+```text
+Reference -> Ground Integration Artifacts
+```
+
+---
+
 ## Simulation report example
 
 Compact example:
@@ -232,7 +256,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-sim",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "mission": "demo-3u",
   "scenario": "payload_data_flow_evidence",
   "result": "passed",

--- a/docs/reference/lint-rules-v0.1.md
+++ b/docs/reference/lint-rules-v0.1.md
@@ -5,7 +5,7 @@ This page documents the diagnostics and lint rules currently implemented by Orbi
 Current documented baseline:
 
 ```text
-v0.7.0 — Generated Runtime Skeletons
+v0.8.0 - Ground Integration Artifacts
 ```
 
 OrbitFabric diagnostics are intentionally actionable. A diagnostic should tell the user:
@@ -93,17 +93,7 @@ OrbitFabric diagnostics expose a common diagnostic shape across Mission Model lo
 
 ---
 
-## `OF-SYN-*` — Syntax and file loading diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-SYN-001` | `ERROR` | mission path | Mission path does not exist or is not a directory. | Pass an existing Mission Model directory. |
-| `OF-SYN-002` | `ERROR` | mission file | A required Mission Model file is missing. | Add the required YAML file. |
-| `OF-SYN-003` | `ERROR` | YAML | A YAML file is syntactically invalid. | Fix YAML syntax. |
-| `OF-SYN-004` | `ERROR` | YAML | A YAML file is empty. | Add the required top-level content. |
-| `OF-SYN-005` | `ERROR` | YAML | A YAML file does not contain a top-level mapping. | Use a YAML mapping at the top level. |
-
-Current required Mission Model files:
+## Current required Mission Model files
 
 ```text
 spacecraft.yaml
@@ -128,272 +118,6 @@ commandability.yaml
 
 ---
 
-## `OF-STR-*` — Structural diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-STR-001` | `ERROR` | top-level key | A required top-level key is missing from a Mission Model YAML file. | Add the expected top-level key. |
-| `OF-STR-002` | `ERROR` | top-level key | An unexpected top-level key was found in a Mission Model YAML file. | Remove or rename the unexpected key. |
-| `OF-STR-003` | `ERROR` | typed model validation | Pydantic model validation failed. | Fix the field type, required field or invalid value. |
-
----
-
-## `OF-ID-*` — Identifier diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-ID-001` | `ERROR` | model domain | Duplicate IDs are not allowed within the same domain. | Rename or remove the duplicate object. |
-
-Domains currently checked for duplicate IDs:
-
-```text
-subsystems
-modes
-telemetry
-commands
-events
-faults
-packets
-payloads
-data_products
-contact_profiles
-link_profiles
-contact_windows
-downlink_flows
-command_sources
-commandability_rules
-autonomous_actions
-recovery_intents
-```
-
----
-
-## `OF-REF-*` — Cross-reference diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-REF-001` | `ERROR` | telemetry | Telemetry source does not reference an existing subsystem. | Add the subsystem or fix telemetry `source`. |
-| `OF-REF-002` | `ERROR` | commands | Command target does not reference an existing subsystem. | Add the subsystem or fix command `target`. |
-| `OF-REF-003` | `ERROR` | events | Event source does not reference an existing subsystem. | Add the subsystem or fix event `source`. |
-| `OF-REF-004` | `ERROR` | faults | Fault source does not reference an existing subsystem. | Add the subsystem or fix fault `source`. |
-| `OF-REF-005` | `ERROR` | faults | Fault condition references unknown telemetry. | Add the telemetry item or fix the fault condition. |
-| `OF-REF-006` | `ERROR` | commands | Command emits an unknown event. | Add the event or fix command `emits`. |
-| `OF-REF-007` | `ERROR` | faults | Fault emits an unknown event. | Add the event or fix fault `emits`. |
-| `OF-REF-008` | `ERROR` | commands | Command allowed mode does not reference an existing mode. | Add the mode or fix `allowed_modes`. |
-| `OF-REF-009` | `ERROR` | faults | Fault recovery references an unknown target mode. | Add the mode or fix `recovery.mode_transition`. |
-| `OF-REF-010` | `ERROR` | packets | Packet references unknown telemetry. | Add the telemetry item or fix packet `telemetry`. |
-
----
-
-## `OF-TLM-*` — Telemetry rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-TLM-001` | `ERROR` | telemetry | High or critical numeric telemetry must define operational limits. | Add warning or critical limits. |
-| `OF-TLM-006` | `ERROR` | telemetry | Enum telemetry must define enum values. | Add a non-empty `enum` list. |
-| `OF-TLM-007` | `WARNING` | telemetry | Telemetry quality policy should be defined. | Add a `quality` policy with required/default fields. |
-
----
-
-## `OF-CMD-*` — Command rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-CMD-005` | `WARNING` | commands | Command should define `timeout_ms`. | Add `timeout_ms` to make command behavior testable. |
-| `OF-CMD-006` | `WARNING` | commands | Command should define expected effects. | Add `expected_effects` or explicitly justify no expected effects. |
-| `OF-CMD-007` | `ERROR` | commands | A medium, high or critical-risk command is allowed in `SAFE` mode. | Remove `SAFE` from `allowed_modes` or lower the command risk. |
-| `OF-CMD-008` | `ERROR` | commands | `expected_effects.data_products` is not a list or contains a non-string entry. | Set `expected_effects.data_products` to a list of data product IDs declared in `data_products.yaml`. |
-| `OF-CMD-009` | `ERROR` | commands | Command expected effects reference an unknown data product. | Add the data product to `data_products.yaml` or fix `expected_effects.data_products`. |
-
-The data-flow evidence path starts from command expected effects such as:
-
-```yaml
-expected_effects:
-  data_products:
-    - payload.radiation_histogram
-```
-
-These rules ensure that the command-to-data-product link is explicit and valid before scenario evidence, generated data-flow documentation or runtime-facing contract bindings depend on it.
-
----
-
-## `OF-EVT-*` — Event rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-EVT-002` | `WARNING` | events | Event should define downlink priority. | Add `downlink_priority`. |
-| `OF-EVT-003` | `WARNING` | events | Event should define persistence policy. | Add `persistence`. |
-
----
-
-## `OF-FLT-*` — Fault rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-FLT-003` | `ERROR` | faults | Fault must emit at least one event. | Add at least one event ID to the fault `emits` list. |
-| `OF-FLT-005` | `ERROR` | faults | Fault recovery references an unknown command. | Add the command or fix `recovery.auto_commands`. |
-
----
-
-## `OF-MODE-*` — Mode rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-MODE-001` | `ERROR` | modes | Exactly one initial mode must be defined. | Set `initial: true` on exactly one mode. |
-| `OF-MODE-003` | `ERROR` | mode transitions | Mode transition source or target is not a known mode. | Add the referenced mode or fix the transition. |
-
----
-
-## `OF-PKT-*` — Packet rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-PKT-002` | `ERROR` | packets | Packet must not be empty. | Add at least one telemetry item to the packet. |
-| `OF-PKT-003` | `ERROR` | packets | Packet `max_payload_bytes` must be positive. | Set `max_payload_bytes` to a positive integer. |
-
----
-
-## `OF-PAY-*` — Payload Contract rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-PAY-001` | `ERROR` | payloads | Payload subsystem reference must exist. | Add the subsystem or fix `payload.subsystem`. |
-| `OF-PAY-002` | `ERROR` | payloads | Payload subsystem must have type `payload`. | Link the payload contract to a payload subsystem. |
-| `OF-PAY-003` | `ERROR` | payloads | Payload lifecycle must define an initial state. | Add `lifecycle.initial_state`. |
-| `OF-PAY-004` | `ERROR` | payloads | Payload lifecycle initial state must exist in lifecycle states. | Add the state or fix `initial_state`. |
-| `OF-PAY-005` | `ERROR` | payloads | Payload telemetry reference must exist. | Add the telemetry or fix the reference. |
-| `OF-PAY-006` | `ERROR` | payloads | Payload command reference must exist. | Add the command or fix the reference. |
-| `OF-PAY-007` | `ERROR` | payloads | Payload event reference must exist. | Add the event or fix the reference. |
-| `OF-PAY-008` | `ERROR` | payloads | Payload fault reference must exist. | Add the fault or fix the reference. |
-| `OF-PAY-009` | `ERROR` | commands | Command payload lifecycle precondition references an unknown payload or state. | Fix the payload lifecycle precondition. |
-| `OF-PAY-010` | `ERROR` | commands | Command expected payload lifecycle effect references an unknown payload or state. | Fix the expected payload lifecycle effect. |
-
-Payload rules are contract-level rules. They do not validate payload firmware, drivers, buses or physical payload behavior.
-
----
-
-## `OF-DP-*` — Data Product Contract rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-DP-002` | `ERROR` | data_products | Data product producer reference must exist. | Add the producer payload/subsystem or fix `producer`. |
-| `OF-DP-003` | `ERROR` | data_products | Optional data product payload reference must exist. | Add the payload contract or fix `payload`. |
-| `OF-DP-006` | `WARNING` | data_products | Data product storage intent should define retention. | Set `storage.retention` or remove storage intent if not retained. |
-| `OF-DP-007` | `WARNING` | data_products | Data product storage intent should define overflow policy. | Set `storage.overflow_policy` for retained data products. |
-| `OF-DP-008` | `WARNING` | data_products | High or critical priority data product should define downlink intent. | Set `downlink.policy`. |
-
-Structural validation covers additional data product constraints such as duplicate IDs, positive estimated size and known literal values for product type, storage class, overflow policy and downlink policy.
-
-Data Product rules are contract-level rules. They do not validate real storage, compression, contact scheduling or downlink runtime behavior.
-
----
-
-## `OF-CON-*` — Contact assumption rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-CON-001` | `ERROR` | contact_windows | Contact window references an unknown contact profile. | Add the contact profile or fix `contact_window.contact_profile`. |
-| `OF-CON-002` | `ERROR` | contact_windows | Contact window references an unknown link profile. | Add the link profile or fix `contact_window.link_profile`. |
-
----
-
-## `OF-DL-*` — Downlink flow assumption rules
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-DL-001` | `ERROR` | downlink_flows | Downlink flow references an unknown contact profile. | Add the contact profile or fix `downlink_flow.contact_profile`. |
-| `OF-DL-002` | `ERROR` | downlink_flows | Downlink flow references an unknown link profile. | Add the link profile or fix `downlink_flow.link_profile`. |
-| `OF-DL-003` | `ERROR` | downlink_flows | Downlink flow references an unknown eligible data product. | Add the data product or fix `downlink_flow.eligible_data_products`. |
-| `OF-DL-004` | `WARNING` | data_products | High-priority data product has downlink intent but is not eligible in any downlink flow. | Add the data product to a downlink flow or revise its downlink intent. |
-| `OF-DL-005` | `WARNING` | downlink_flows | Estimated eligible data product volume may exceed declared contact capacity. | Increase capacity, reduce eligible volume or split the flow. |
-
----
-
-## `OF-CAB-*` — Commandability rule diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-CAB-001` | `ERROR` | commandability_rules | Commandability rule references an unknown command. | Add the command to `commands.yaml` or fix `rule.command`. |
-| `OF-CAB-002` | `ERROR` | commandability_rules | Commandability rule references an unknown mode. | Add the mode to `modes.yaml` or fix `rule.allowed_modes`. |
-| `OF-CAB-003` | `ERROR` | commandability_rules | Commandability rule references an unknown source. | Add the source to `commandability.sources` or fix `rule.sources`. |
-| `OF-CAB-004` | `WARNING` | command_sources | Ground command source requires contact but has no contact profile. | Set `contact_profile` or set `requires_contact` to false. |
-| `OF-CAB-005` | `ERROR` | command_sources | Command source references an unknown contact profile. | Add the contact profile to `contacts.yaml` or fix `source.contact_profile`. |
-| `OF-CAB-006` | `ERROR` | commandability_rules | Commandability rule references an unknown expected event. | Add the event to `events.yaml` or fix `rule.expected_events`. |
-| `OF-CAB-007` | `WARNING` | commandability_rules | Risky command lacks explicit required confirmation intent. | Add a commandability rule with `confirmation: required`, or lower the command risk if appropriate. |
-
----
-
-## `OF-AUT-*` — Autonomous action diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-AUT-001` | `ERROR` | autonomous_actions | Autonomous action dispatches an unknown command. | Add the command to `commands.yaml` or fix `dispatches.command`. |
-| `OF-AUT-002` | `ERROR` | autonomous_actions | Autonomous action references an unknown source. | Add the source to `commandability.sources` or fix `dispatches.source`. |
-| `OF-AUT-003` | `ERROR` | autonomous_actions | Autonomous action trigger references an unknown event, fault, telemetry item or mode. | Add the referenced object to the Mission Model or fix `action.trigger`. |
-| `OF-AUT-004` | `ERROR` | autonomous_actions | Autonomous action references an unknown expected event. | Add the event to `events.yaml` or fix `expected_events`. |
-| `OF-AUT-005` | `WARNING` | autonomous_actions | Autonomous action lacks expected events or effects. | Add `expected_events` or `expected_effects` to make the assumption testable. |
-
----
-
-## `OF-REC-*` — Recovery intent diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-REC-001` | `ERROR` | recovery_intents | Recovery intent references an unknown command. | Add the command to `commands.yaml` or fix `recovery_intent.commands`. |
-| `OF-REC-002` | `ERROR` | recovery_intents | Recovery intent references an unknown fault, event or mode. | Add the referenced object to the Mission Model or fix `recovery_intent`. |
-| `OF-REC-003` | `ERROR` | recovery_intents | Recovery intent references an unknown expected event. | Add the event to `events.yaml` or fix `recovery_intent.expected_events`. |
-
----
-
-## `OF-SCN-*` — Scenario diagnostics
-
-| Rule | Severity | Domain | Description | Suggested fix |
-|---|---|---|---|---|
-| `OF-SCN-000` | `ERROR` | scenario path | Scenario path does not exist or is not a file. | Pass an existing scenario YAML file. |
-| `OF-SCN-001` | `ERROR` | scenario | Scenario command or expected command references an unknown command. | Use a command defined in `commands.yaml`. |
-| `OF-SCN-002` | `ERROR` | scenario | Scenario event expectation references an unknown event. | Use an event defined in `events.yaml`. |
-| `OF-SCN-003` | `ERROR` | scenario | Scenario mode expectation references an unknown mode. | Use a mode defined in `modes.yaml`. |
-| `OF-SCN-004` | `ERROR` | scenario | Scenario telemetry injection or expectation references unknown telemetry. | Use telemetry defined in `telemetry.yaml`. |
-| `OF-SCN-005` | `ERROR` | scenario | Scenario timeline must be monotonic. | Sort scenario steps by non-decreasing time. |
-| `OF-SCN-006` | `ERROR` | scenario | Scenario initial mode references unknown mode. | Use a mode defined in `modes.yaml`. |
-| `OF-SCN-007` | `ERROR` | scenario | Scenario initial telemetry references unknown telemetry. | Use telemetry defined in `telemetry.yaml`. |
-| `OF-SCN-008` | `ERROR` | scenario YAML | Scenario YAML is syntactically invalid. | Fix YAML syntax. |
-| `OF-SCN-009` | `ERROR` | scenario YAML | Scenario YAML file is empty. | Add scenario content. |
-| `OF-SCN-010` | `ERROR` | scenario YAML | Scenario YAML does not contain a top-level mapping. | Use a YAML mapping at the top level. |
-| `OF-SCN-011` | `ERROR` | scenario | A required scenario top-level key is missing. | Add the required key. |
-| `OF-SCN-012` | `ERROR` | scenario | An unexpected scenario top-level key was found. | Remove or rename the unexpected key. |
-| `OF-SCN-013` | `ERROR` | scenario model validation | Scenario typed model validation failed. | Fix the invalid field, missing field or invalid value. |
-| `OF-SCN-014` | `ERROR` | scenario | Scenario data-flow expectation references an unknown data product. | Use a data product defined in `data_products.yaml`. |
-| `OF-SCN-015` | `ERROR` | scenario | Scenario data-flow expectation references an unknown command. | Use a command defined in `commands.yaml`. |
-| `OF-SCN-016` | `ERROR` | scenario | Scenario data-flow expectation references an unknown downlink flow. | Use a downlink flow defined in `contacts.yaml`. |
-| `OF-SCN-017` | `ERROR` | scenario | Scenario data-flow expectation references an unknown contact window. | Use a contact window defined in `contacts.yaml`. |
-
-Required scenario top-level keys:
-
-```text
-scenario
-mission
-initial_state
-steps
-```
-
-Data-flow expectations use this shape:
-
-```yaml
-expect:
-  data_flow:
-    data_product: payload.radiation_histogram
-    triggered_by_command: payload.start_acquisition
-    storage_intent_declared: true
-    downlink_intent_declared: true
-    eligible_downlink_flow: science_next_available_contact
-    contact_window: demo_contact_001
-```
-
-These expectations validate contract-level evidence only. They do not execute real storage, downlink, contact scheduling or ground integration behavior.
-
----
-
 ## Current command coverage
 
 Current behavior:
@@ -404,7 +128,20 @@ Current behavior:
 | `orbitfabric gen docs <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric gen data-flow <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric gen runtime <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
+| `orbitfabric gen ground <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric sim <scenario-file>` | Scenario loading diagnostics, Mission Model loading diagnostics, scenario reference diagnostics and scenario execution failures. |
+
+---
+
+## Ground generation note
+
+v0.8.0 does not add a dedicated ground-specific diagnostic family.
+
+Ground artifact generation consumes the already validated Mission Model and aborts when lint errors exist.
+
+This is intentional.
+
+Ground-facing generated artifacts must not reinterpret raw YAML, bypass validation or invent new semantics outside the Mission Data Contract.
 
 ---
 
@@ -422,3 +159,5 @@ When adding a new diagnostic or lint rule:
 8. update this rule catalog.
 
 Do not document a rule as implemented until it exists in code and is covered by tests.
+
+The full rule tables are intentionally kept in the source history and tests as the implementation evolves toward v1.0. This page documents the current family coverage and command behavior for the v0.8.0 development preview.

--- a/docs/reference/lint-rules-v0.1.md
+++ b/docs/reference/lint-rules-v0.1.md
@@ -93,7 +93,17 @@ OrbitFabric diagnostics expose a common diagnostic shape across Mission Model lo
 
 ---
 
-## Current required Mission Model files
+## `OF-SYN-*` - Syntax and file loading diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-SYN-001` | `ERROR` | mission path | Mission path does not exist or is not a directory. | Pass an existing Mission Model directory. |
+| `OF-SYN-002` | `ERROR` | mission file | A required Mission Model file is missing. | Add the required YAML file. |
+| `OF-SYN-003` | `ERROR` | YAML | A YAML file is syntactically invalid. | Fix YAML syntax. |
+| `OF-SYN-004` | `ERROR` | YAML | A YAML file is empty. | Add the required top-level content. |
+| `OF-SYN-005` | `ERROR` | YAML | A YAML file does not contain a top-level mapping. | Use a YAML mapping at the top level. |
+
+Current required Mission Model files:
 
 ```text
 spacecraft.yaml
@@ -118,6 +128,272 @@ commandability.yaml
 
 ---
 
+## `OF-STR-*` - Structural diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-STR-001` | `ERROR` | top-level key | A required top-level key is missing from a Mission Model YAML file. | Add the expected top-level key. |
+| `OF-STR-002` | `ERROR` | top-level key | An unexpected top-level key was found in a Mission Model YAML file. | Remove or rename the unexpected key. |
+| `OF-STR-003` | `ERROR` | typed model validation | Pydantic model validation failed. | Fix the field type, required field or invalid value. |
+
+---
+
+## `OF-ID-*` - Identifier diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-ID-001` | `ERROR` | model domain | Duplicate IDs are not allowed within the same domain. | Rename or remove the duplicate object. |
+
+Domains currently checked for duplicate IDs:
+
+```text
+subsystems
+modes
+telemetry
+commands
+events
+faults
+packets
+payloads
+data_products
+contact_profiles
+link_profiles
+contact_windows
+downlink_flows
+command_sources
+commandability_rules
+autonomous_actions
+recovery_intents
+```
+
+---
+
+## `OF-REF-*` - Cross-reference diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-REF-001` | `ERROR` | telemetry | Telemetry source does not reference an existing subsystem. | Add the subsystem or fix telemetry `source`. |
+| `OF-REF-002` | `ERROR` | commands | Command target does not reference an existing subsystem. | Add the subsystem or fix command `target`. |
+| `OF-REF-003` | `ERROR` | events | Event source does not reference an existing subsystem. | Add the subsystem or fix event `source`. |
+| `OF-REF-004` | `ERROR` | faults | Fault source does not reference an existing subsystem. | Add the subsystem or fix fault `source`. |
+| `OF-REF-005` | `ERROR` | faults | Fault condition references unknown telemetry. | Add the telemetry item or fix the fault condition. |
+| `OF-REF-006` | `ERROR` | commands | Command emits an unknown event. | Add the event or fix command `emits`. |
+| `OF-REF-007` | `ERROR` | faults | Fault emits an unknown event. | Add the event or fix fault `emits`. |
+| `OF-REF-008` | `ERROR` | commands | Command allowed mode does not reference an existing mode. | Add the mode or fix `allowed_modes`. |
+| `OF-REF-009` | `ERROR` | faults | Fault recovery references an unknown target mode. | Add the mode or fix `recovery.mode_transition`. |
+| `OF-REF-010` | `ERROR` | packets | Packet references unknown telemetry. | Add the telemetry item or fix packet `telemetry`. |
+
+---
+
+## `OF-TLM-*` - Telemetry rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-TLM-001` | `ERROR` | telemetry | High or critical numeric telemetry must define operational limits. | Add warning or critical limits. |
+| `OF-TLM-006` | `ERROR` | telemetry | Enum telemetry must define enum values. | Add a non-empty `enum` list. |
+| `OF-TLM-007` | `WARNING` | telemetry | Telemetry quality policy should be defined. | Add a `quality` policy with required/default fields. |
+
+---
+
+## `OF-CMD-*` - Command rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-CMD-005` | `WARNING` | commands | Command should define `timeout_ms`. | Add `timeout_ms` to make command behavior testable. |
+| `OF-CMD-006` | `WARNING` | commands | Command should define expected effects. | Add `expected_effects` or explicitly justify no expected effects. |
+| `OF-CMD-007` | `ERROR` | commands | A medium, high or critical-risk command is allowed in `SAFE` mode. | Remove `SAFE` from `allowed_modes` or lower the command risk. |
+| `OF-CMD-008` | `ERROR` | commands | `expected_effects.data_products` is not a list or contains a non-string entry. | Set `expected_effects.data_products` to a list of data product IDs declared in `data_products.yaml`. |
+| `OF-CMD-009` | `ERROR` | commands | Command expected effects reference an unknown data product. | Add the data product to `data_products.yaml` or fix `expected_effects.data_products`. |
+
+The data-flow evidence path starts from command expected effects such as:
+
+```yaml
+expected_effects:
+  data_products:
+    - payload.radiation_histogram
+```
+
+These rules ensure that the command-to-data-product link is explicit and valid before scenario evidence, generated data-flow documentation, runtime-facing contract bindings or ground-facing artifacts depend on it.
+
+---
+
+## `OF-EVT-*` - Event rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-EVT-002` | `WARNING` | events | Event should define downlink priority. | Add `downlink_priority`. |
+| `OF-EVT-003` | `WARNING` | events | Event should define persistence policy. | Add `persistence`. |
+
+---
+
+## `OF-FLT-*` - Fault rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-FLT-003` | `ERROR` | faults | Fault must emit at least one event. | Add at least one event ID to the fault `emits` list. |
+| `OF-FLT-005` | `ERROR` | faults | Fault recovery references an unknown command. | Add the command or fix `recovery.auto_commands`. |
+
+---
+
+## `OF-MODE-*` - Mode rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-MODE-001` | `ERROR` | modes | Exactly one initial mode must be defined. | Set `initial: true` on exactly one mode. |
+| `OF-MODE-003` | `ERROR` | mode transitions | Mode transition source or target is not a known mode. | Add the referenced mode or fix the transition. |
+
+---
+
+## `OF-PKT-*` - Packet rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-PKT-002` | `ERROR` | packets | Packet must not be empty. | Add at least one telemetry item to the packet. |
+| `OF-PKT-003` | `ERROR` | packets | Packet `max_payload_bytes` must be positive. | Set `max_payload_bytes` to a positive integer. |
+
+---
+
+## `OF-PAY-*` - Payload Contract rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-PAY-001` | `ERROR` | payloads | Payload subsystem reference must exist. | Add the subsystem or fix `payload.subsystem`. |
+| `OF-PAY-002` | `ERROR` | payloads | Payload subsystem must have type `payload`. | Link the payload contract to a payload subsystem. |
+| `OF-PAY-003` | `ERROR` | payloads | Payload lifecycle must define an initial state. | Add `lifecycle.initial_state`. |
+| `OF-PAY-004` | `ERROR` | payloads | Payload lifecycle initial state must exist in lifecycle states. | Add the state or fix `initial_state`. |
+| `OF-PAY-005` | `ERROR` | payloads | Payload telemetry reference must exist. | Add the telemetry or fix the reference. |
+| `OF-PAY-006` | `ERROR` | payloads | Payload command reference must exist. | Add the command or fix the reference. |
+| `OF-PAY-007` | `ERROR` | payloads | Payload event reference must exist. | Add the event or fix the reference. |
+| `OF-PAY-008` | `ERROR` | payloads | Payload fault reference must exist. | Add the fault or fix the reference. |
+| `OF-PAY-009` | `ERROR` | commands | Command payload lifecycle precondition references an unknown payload or state. | Fix the payload lifecycle precondition. |
+| `OF-PAY-010` | `ERROR` | commands | Command expected payload lifecycle effect references an unknown payload or state. | Fix the expected payload lifecycle effect. |
+
+Payload rules are contract-level rules. They do not validate payload firmware, drivers, buses or physical payload behavior.
+
+---
+
+## `OF-DP-*` - Data Product Contract rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-DP-002` | `ERROR` | data_products | Data product producer reference must exist. | Add the producer payload/subsystem or fix `producer`. |
+| `OF-DP-003` | `ERROR` | data_products | Optional data product payload reference must exist. | Add the payload contract or fix `payload`. |
+| `OF-DP-006` | `WARNING` | data_products | Data product storage intent should define retention. | Set `storage.retention` or remove storage intent if not retained. |
+| `OF-DP-007` | `WARNING` | data_products | Data product storage intent should define overflow policy. | Set `storage.overflow_policy` for retained data products. |
+| `OF-DP-008` | `WARNING` | data_products | High or critical priority data product should define downlink intent. | Set `downlink.policy`. |
+
+Structural validation covers additional data product constraints such as duplicate IDs, positive estimated size and known literal values for product type, storage class, overflow policy and downlink policy.
+
+Data Product rules are contract-level rules. They do not validate real storage, compression, contact scheduling or downlink runtime behavior.
+
+---
+
+## `OF-CON-*` - Contact assumption rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-CON-001` | `ERROR` | contact_windows | Contact window references an unknown contact profile. | Add the contact profile or fix `contact_window.contact_profile`. |
+| `OF-CON-002` | `ERROR` | contact_windows | Contact window references an unknown link profile. | Add the link profile or fix `contact_window.link_profile`. |
+
+---
+
+## `OF-DL-*` - Downlink flow assumption rules
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-DL-001` | `ERROR` | downlink_flows | Downlink flow references an unknown contact profile. | Add the contact profile or fix `downlink_flow.contact_profile`. |
+| `OF-DL-002` | `ERROR` | downlink_flows | Downlink flow references an unknown link profile. | Add the link profile or fix `downlink_flow.link_profile`. |
+| `OF-DL-003` | `ERROR` | downlink_flows | Downlink flow references an unknown eligible data product. | Add the data product or fix `downlink_flow.eligible_data_products`. |
+| `OF-DL-004` | `WARNING` | data_products | High-priority data product has downlink intent but is not eligible in any downlink flow. | Add the data product to a downlink flow or revise its downlink intent. |
+| `OF-DL-005` | `WARNING` | downlink_flows | Estimated eligible data product volume may exceed declared contact capacity. | Increase capacity, reduce eligible volume or split the flow. |
+
+---
+
+## `OF-CAB-*` - Commandability rule diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-CAB-001` | `ERROR` | commandability_rules | Commandability rule references an unknown command. | Add the command to `commands.yaml` or fix `rule.command`. |
+| `OF-CAB-002` | `ERROR` | commandability_rules | Commandability rule references an unknown mode. | Add the mode to `modes.yaml` or fix `rule.allowed_modes`. |
+| `OF-CAB-003` | `ERROR` | commandability_rules | Commandability rule references an unknown source. | Add the source to `commandability.sources` or fix `rule.sources`. |
+| `OF-CAB-004` | `WARNING` | command_sources | Ground command source requires contact but has no contact profile. | Set `contact_profile` or set `requires_contact` to false. |
+| `OF-CAB-005` | `ERROR` | command_sources | Command source references an unknown contact profile. | Add the contact profile to `contacts.yaml` or fix `source.contact_profile`. |
+| `OF-CAB-006` | `ERROR` | commandability_rules | Commandability rule references an unknown expected event. | Add the event to `events.yaml` or fix `rule.expected_events`. |
+| `OF-CAB-007` | `WARNING` | commandability_rules | Risky command lacks explicit required confirmation intent. | Add a commandability rule with `confirmation: required`, or lower the command risk if appropriate. |
+
+---
+
+## `OF-AUT-*` - Autonomous action diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-AUT-001` | `ERROR` | autonomous_actions | Autonomous action dispatches an unknown command. | Add the command to `commands.yaml` or fix `dispatches.command`. |
+| `OF-AUT-002` | `ERROR` | autonomous_actions | Autonomous action references an unknown source. | Add the source to `commandability.sources` or fix `dispatches.source`. |
+| `OF-AUT-003` | `ERROR` | autonomous_actions | Autonomous action trigger references an unknown event, fault, telemetry item or mode. | Add the referenced object to the Mission Model or fix `action.trigger`. |
+| `OF-AUT-004` | `ERROR` | autonomous_actions | Autonomous action references an unknown expected event. | Add the event to `events.yaml` or fix `expected_events`. |
+| `OF-AUT-005` | `WARNING` | autonomous_actions | Autonomous action lacks expected events or effects. | Add `expected_events` or `expected_effects` to make the assumption testable. |
+
+---
+
+## `OF-REC-*` - Recovery intent diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-REC-001` | `ERROR` | recovery_intents | Recovery intent references an unknown command. | Add the command to `commands.yaml` or fix `recovery_intent.commands`. |
+| `OF-REC-002` | `ERROR` | recovery_intents | Recovery intent references an unknown fault, event or mode. | Add the referenced object to the Mission Model or fix `recovery_intent`. |
+| `OF-REC-003` | `ERROR` | recovery_intents | Recovery intent references an unknown expected event. | Add the event to `events.yaml` or fix `recovery_intent.expected_events`. |
+
+---
+
+## `OF-SCN-*` - Scenario diagnostics
+
+| Rule | Severity | Domain | Description | Suggested fix |
+|---|---|---|---|---|
+| `OF-SCN-000` | `ERROR` | scenario path | Scenario path does not exist or is not a file. | Pass an existing scenario YAML file. |
+| `OF-SCN-001` | `ERROR` | scenario | Scenario command or expected command references an unknown command. | Use a command defined in `commands.yaml`. |
+| `OF-SCN-002` | `ERROR` | scenario | Scenario event expectation references an unknown event. | Use an event defined in `events.yaml`. |
+| `OF-SCN-003` | `ERROR` | scenario | Scenario mode expectation references an unknown mode. | Use a mode defined in `modes.yaml`. |
+| `OF-SCN-004` | `ERROR` | scenario | Scenario telemetry injection or expectation references unknown telemetry. | Use telemetry defined in `telemetry.yaml`. |
+| `OF-SCN-005` | `ERROR` | scenario | Scenario timeline must be monotonic. | Sort scenario steps by non-decreasing time. |
+| `OF-SCN-006` | `ERROR` | scenario | Scenario initial mode references unknown mode. | Use a mode defined in `modes.yaml`. |
+| `OF-SCN-007` | `ERROR` | scenario | Scenario initial telemetry references unknown telemetry. | Use telemetry defined in `telemetry.yaml`. |
+| `OF-SCN-008` | `ERROR` | scenario YAML | Scenario YAML is syntactically invalid. | Fix YAML syntax. |
+| `OF-SCN-009` | `ERROR` | scenario YAML | Scenario YAML file is empty. | Add scenario content. |
+| `OF-SCN-010` | `ERROR` | scenario YAML | Scenario YAML does not contain a top-level mapping. | Use a YAML mapping at the top level. |
+| `OF-SCN-011` | `ERROR` | scenario | A required scenario top-level key is missing. | Add the required key. |
+| `OF-SCN-012` | `ERROR` | scenario | An unexpected scenario top-level key was found. | Remove or rename the unexpected key. |
+| `OF-SCN-013` | `ERROR` | scenario model validation | Scenario typed model validation failed. | Fix the invalid field, missing field or invalid value. |
+| `OF-SCN-014` | `ERROR` | scenario | Scenario data-flow expectation references an unknown data product. | Use a data product defined in `data_products.yaml`. |
+| `OF-SCN-015` | `ERROR` | scenario | Scenario data-flow expectation references an unknown command. | Use a command defined in `commands.yaml`. |
+| `OF-SCN-016` | `ERROR` | scenario | Scenario data-flow expectation references an unknown downlink flow. | Use a downlink flow defined in `contacts.yaml`. |
+| `OF-SCN-017` | `ERROR` | scenario | Scenario data-flow expectation references an unknown contact window. | Use a contact window defined in `contacts.yaml`. |
+
+Required scenario top-level keys:
+
+```text
+scenario
+mission
+initial_state
+steps
+```
+
+Data-flow expectations use this shape:
+
+```yaml
+expect:
+  data_flow:
+    data_product: payload.radiation_histogram
+    triggered_by_command: payload.start_acquisition
+    storage_intent_declared: true
+    downlink_intent_declared: true
+    eligible_downlink_flow: science_next_available_contact
+    contact_window: demo_contact_001
+```
+
+These expectations validate contract-level evidence only. They do not execute real storage, downlink, contact scheduling or ground integration behavior.
+
+---
+
 ## Current command coverage
 
 Current behavior:
@@ -131,17 +407,7 @@ Current behavior:
 | `orbitfabric gen ground <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric sim <scenario-file>` | Scenario loading diagnostics, Mission Model loading diagnostics, scenario reference diagnostics and scenario execution failures. |
 
----
-
-## Ground generation note
-
-v0.8.0 does not add a dedicated ground-specific diagnostic family.
-
-Ground artifact generation consumes the already validated Mission Model and aborts when lint errors exist.
-
-This is intentional.
-
-Ground-facing generated artifacts must not reinterpret raw YAML, bypass validation or invent new semantics outside the Mission Data Contract.
+Ground artifact generation consumes the already validated Mission Model and aborts when lint errors exist. It does not add a dedicated ground-specific diagnostic family in v0.8.0.
 
 ---
 
@@ -159,5 +425,3 @@ When adding a new diagnostic or lint rule:
 8. update this rule catalog.
 
 Do not document a rule as implemented until it exists in code and is covered by tests.
-
-The full rule tables are intentionally kept in the source history and tests as the implementation evolves toward v1.0. This page documents the current family coverage and command behavior for the v0.8.0 development preview.

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -7,7 +7,8 @@ OrbitFabric currently distinguishes between:
 - the OrbitFabric tool/package version;
 - the Mission Model version declared by a mission;
 - the version field written into generated JSON reports;
-- the generated runtime contract manifest version context.
+- the generated runtime contract manifest context;
+- the generated ground contract manifest context.
 
 These versions are related, but they are not the same thing.
 
@@ -33,7 +34,7 @@ orbitfabric --version
 Current example:
 
 ```text
-orbitfabric 0.7.0
+orbitfabric 0.8.0
 ```
 
 This version answers the question:
@@ -42,9 +43,7 @@ This version answers the question:
 Which version of the OrbitFabric tool generated, validated or executed this artifact?
 ```
 
-Generated JSON reports use this version in their top-level `version` field.
-
-Generated runtime contract manifests also record the generation profile and contract metadata produced by the tool.
+Generated JSON reports and generated manifests record this tool context where applicable.
 
 ---
 
@@ -88,7 +87,7 @@ Current example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "mission": "demo-3u",
   "model_version": "0.1.0"
 }
@@ -102,7 +101,7 @@ The `model_version` identifies the Mission Model version declared by the mission
 
 ## Runtime contract manifest context
 
-v0.7.0 introduces runtime-facing contract bindings.
+v0.7.0 introduced runtime-facing contract bindings.
 
 The generated runtime manifest is written to:
 
@@ -126,6 +125,38 @@ It is not a separate schema version promise for v1.0 compatibility.
 
 ---
 
+## Ground contract manifest context
+
+v0.8.0 introduced ground-facing contract exports.
+
+The generated ground manifest is written to:
+
+```text
+generated/ground/generic/ground_contract_manifest.json
+```
+
+It records the generated ground-facing package, artifact paths and architectural boundary flags.
+
+It also records generation metadata such as:
+
+```text
+generation profile
+generated_artifacts_are_disposable = true
+contains_ground_runtime = false
+contains_operator_console = false
+contains_transport = false
+contains_database = false
+claims_yamcs_compatibility = false
+claims_openc3_compatibility = false
+claims_xtce_compliance = false
+```
+
+The ground manifest is generated from the current OrbitFabric tool and the declared Mission Model.
+
+It is not a ground segment schema, mission database compatibility promise or v1.0 compatibility guarantee.
+
+---
+
 ## Why the versions differ
 
 During development previews, OrbitFabric may evolve faster than the Mission Model contract.
@@ -133,7 +164,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.7.0
+OrbitFabric tool/package version: 0.8.0
 Mission Model version:           0.1.0
 ```
 
@@ -141,13 +172,13 @@ This is valid.
 
 It means:
 
-- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence and Runtime Contract Bindings;
+- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings and Ground Integration Artifacts;
 - the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record the relevant tool and model context.
 
 ---
 
-## Current v0.7 rule
+## Current v0.8 rule
 
 For the current development preview:
 
@@ -159,6 +190,9 @@ For the current development preview:
 | JSON report `model_version` | Mission Model version copied from mission YAML. |
 | Runtime manifest `generation.profile` | Runtime generation profile, currently `cpp17`. |
 | Runtime manifest `contains_flight_runtime` | Explicit boundary flag, currently `false`. |
+| Ground manifest `generation.profile` | Ground generation profile, currently `generic`. |
+| Ground manifest `contains_ground_runtime` | Explicit boundary flag, currently `false`. |
+| Ground manifest `claims_*` compatibility fields | Explicit tool-specific claim flags, currently `false`. |
 
 ---
 
@@ -170,7 +204,8 @@ Do not assume that:
 - a Mission Model version bump always requires a Python package major/minor bump;
 - a Python package patch/dev version always changes the Mission Model contract;
 - generated artifacts are valid without checking both tool version and mission model version;
-- generated runtime-facing bindings are flight protocol IDs or flight software ABI guarantees.
+- generated runtime-facing bindings are flight protocol IDs or flight software ABI guarantees;
+- generated ground-facing artifacts imply ground runtime behavior or tool-specific compatibility.
 
 ---
 
@@ -182,9 +217,10 @@ Possible future additions include:
 
 - a dedicated Mission Model schema version field;
 - a dedicated RuntimeContract schema version;
+- a dedicated GroundContract schema version;
 - schema migration helpers;
 - compatibility checks between tool version and Mission Model version;
 - JSON Schema export for Mission Model validation;
 - compatibility checks for generated artifact profiles.
 
-These are not part of the current v0.7.0 development preview.
+These are not part of the current v0.8.0 development preview.

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,275 @@
+# OrbitFabric v0.8.0 - Ground Integration Artifacts
+
+Status: Released  
+Scope: Ground-facing Mission Data Contract exports
+
+---
+
+## Summary
+
+OrbitFabric v0.8.0 introduces the first ground-facing generated artifact slice.
+
+This release turns the validated Mission Model into a deterministic, inspectable and tool-neutral ground-facing mission data package.
+
+The feature remains deliberately bounded.
+
+It does not generate a ground segment, mission control system, telemetry archive, command uplink service, operator console, decoder runtime, database schema or tool-specific Yamcs/OpenC3/XTCE integration.
+
+It generates contract-aligned artifacts that ground software engineers, mission control engineers and integration teams can review, adapt or consume downstream.
+
+---
+
+## Architectural meaning
+
+v0.8.0 is the first OrbitFabric release where the Mission Model produces a ground-facing artifact package.
+
+The intended chain is:
+
+```text
+Mission Model
+        -> validation and linting
+        -> GroundContract
+        -> generic ground-facing dictionaries
+        -> JSON / CSV / Markdown review artifacts
+        -> downstream ground-system integration outside OrbitFabric
+```
+
+The important rule is:
+
+```text
+generated ground artifacts are disposable;
+the Mission Model remains the source of truth;
+real ground behavior lives outside OrbitFabric;
+tool-specific claims require explicit implementation and tests.
+```
+
+---
+
+## Added
+
+v0.8.0 adds:
+
+```text
+GroundContract intermediate model
+orbitfabric gen ground command
+ground_contract_manifest.json
+generic ground generation profile
+JSON dictionaries for telemetry, commands, events, faults, data products and packets
+CSV dictionaries for review workflows
+README.md generated for the ground artifact directory
+ground_dictionaries.md generated for human engineering review
+manifest boundary flags for ground runtime, database, transport and tool-specific compatibility claims
+```
+
+---
+
+## Ground generator command
+
+Ground artifacts are generated with:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+The default output is:
+
+```text
+generated/ground/generic/
+```
+
+The current supported profile is:
+
+```text
+generic
+```
+
+---
+
+## Generated artifacts
+
+The generic profile generates:
+
+```text
+generated/ground/generic/
+├── ground_contract_manifest.json
+├── README.md
+├── dictionaries/
+│   ├── telemetry_dictionary.json
+│   ├── command_dictionary.json
+│   ├── event_dictionary.json
+│   ├── fault_dictionary.json
+│   ├── data_product_dictionary.json
+│   └── packet_dictionary.json
+├── csv/
+│   ├── telemetry_dictionary.csv
+│   ├── command_dictionary.csv
+│   ├── event_dictionary.csv
+│   ├── fault_dictionary.csv
+│   ├── data_product_dictionary.csv
+│   └── packet_dictionary.csv
+└── ground_dictionaries.md
+```
+
+These files are generated artifacts.
+
+They are reproducible and disposable.
+
+They are not committed as source files.
+
+---
+
+## GroundContract manifest
+
+The manifest records the generated ground-facing package and its architectural boundary.
+
+It includes mission identity, generation profile, contract counts, artifact paths and boundary flags.
+
+It explicitly records:
+
+```text
+generated_artifacts_are_disposable = true
+contains_ground_runtime = false
+contains_operator_console = false
+contains_transport = false
+contains_database = false
+claims_yamcs_compatibility = false
+claims_openc3_compatibility = false
+claims_xtce_compliance = false
+```
+
+These flags are part of the public v0.8.0 boundary.
+
+---
+
+## JSON dictionaries
+
+The JSON dictionaries expose machine-readable ground-facing views for:
+
+```text
+telemetry
+commands
+events
+faults
+data products
+packets
+```
+
+They are intended for scripts, review automation and downstream tool adaptation.
+
+They do not implement decoders, encoders, telemetry archives, command uplinks or live ground behavior.
+
+---
+
+## CSV dictionaries
+
+The CSV dictionaries provide review-friendly tabular views of the same contract metadata.
+
+Scalar fields are written directly as columns.
+
+Nested metadata is serialized into stable compact JSON cells.
+
+CSV files are intended for spreadsheet-style review, not as the primary machine-readable contract artifact.
+
+---
+
+## Markdown review artifacts
+
+The generated `README.md` orients users opening the ground artifact directory.
+
+The generated `ground_dictionaries.md` is a human-reviewable engineering document with sections for telemetry, commands, events, faults, data products and packets.
+
+The Markdown output avoids HTML table line-break tags to stay portable across common Markdown editors.
+
+---
+
+## Validation baseline
+
+The release baseline is:
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+
+orbitfabric lint examples/demo-3u/mission/ \
+  --json generated/reports/lint_report.json
+
+orbitfabric gen docs examples/demo-3u/mission/
+
+orbitfabric gen data-flow examples/demo-3u/mission/ \
+  --output-file generated/docs/data_flow.md
+
+orbitfabric gen runtime examples/demo-3u/mission/
+
+cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
+cmake --build generated/runtime/cpp17/build
+
+orbitfabric gen ground examples/demo-3u/mission/
+
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+
+orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
+  --json generated/reports/payload_data_flow_evidence_report.json \
+  --log generated/logs/payload_data_flow_evidence.log
+```
+
+Expected result:
+
+```text
+all checks passing
+lint result: PASSED
+docs generation: PASSED
+runtime generation: PASSED
+C++17 host-build smoke: PASSED
+ground generation: PASSED
+scenario result: PASSED
+```
+
+---
+
+## Non-goals
+
+v0.8.0 intentionally does not introduce:
+
+```text
+live ground segment
+mission control system
+operator console
+telemetry archive
+telemetry database
+command uplink service
+telecommand transport
+telemetry downlink runtime
+network/session/routing behavior
+command authentication or authorization
+security enforcement
+Yamcs integration
+OpenC3 integration
+XTCE compliance
+CCSDS/PUS/CFDP implementation
+binary packet decoder
+binary telecommand encoder
+offset/bitfield layout model
+calibration model
+RF/link-budget behavior
+pass scheduling
+station automation
+```
+
+These are not missing pieces of v0.8.0.
+
+They remain intentionally outside the Ground Integration Artifacts boundary.
+
+---
+
+## Final position
+
+OrbitFabric v0.8.0 remains a Mission Data Contract framework.
+
+Ground Integration Artifacts are ground-facing contract exports.
+
+They are not ground software.
+
+They provide a reproducible, inspectable and tool-neutral mission data package derived from the Mission Model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - v0.5.0 Commandability and Autonomy Contracts: releases/v0.5.0.md
       - v0.6.0 End-to-End Mission Data Flow Evidence: releases/v0.6.0.md
       - v0.7.0 Generated Runtime Skeletons: releases/v0.7.0.md
+      - v0.8.0 Ground Integration Artifacts: releases/v0.8.0.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.7.0"
+version = "0.8.0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
## Summary

Align the public project documentation and package version with `v0.8.0 - Ground Integration Artifacts`.

This PR follows the completion of the v0.8.0 implementation PRs and turns the documentation baseline from `v0.7.0 - Generated Runtime Skeletons` to `v0.8.0 - Ground Integration Artifacts`.

## Documentation pass performed

Reviewed and aligned the main project-facing documentation set:

- `README.md`
- `CHANGELOG.md`
- `CONTRIBUTING.md`
- `docs/index.md`
- `docs/PROJECT_CHARTER.md`
- `docs/ARCHITECTURE.md`
- `docs/ROADMAP.md`
- `docs/QUICKSTART.md`
- `docs/DEVELOPMENT.md`
- `docs/DEMO_WALKTHROUGH.md`
- `docs/reference/ground-integration-artifacts.md`
- `docs/reference/versioning.md`
- `docs/reference/json-reports-v0.1.md`
- `docs/reference/lint-rules-v0.1.md`
- `docs/reference/data-flow-evidence.md`
- `mkdocs.yml`

Added:

- `docs/releases/v0.8.0.md`

Updated package/tool version:

- `pyproject.toml`
- `src/orbitfabric/__init__.py`

## Main alignment points

- Mark `v0.8.0 - Ground Integration Artifacts` as the current development preview.
- Mark `v0.8.0` as completed in the roadmap.
- Move the next roadmap focus to `v0.9 - Plugin and Extensibility Layer`.
- Add release notes for v0.8.0.
- Add `v0.8.0` release notes to MkDocs navigation.
- Update README and public site home page with `orbitfabric gen ground`.
- Update architecture docs with `GroundContract`, `orbitfabric gen ground` and ground-facing artifact boundaries.
- Update quickstart and development guides with ground artifact generation and expected output tree.
- Update demo walkthrough to include the ground-facing artifact package generated from the same `demo-3u` Mission Model.
- Update the Ground Integration Artifacts reference from planned to introduced.
- Update versioning and JSON report references from v0.7.0 to v0.8.0 where they describe the current tool/package version.
- Preserve the detailed lint rule catalog while adding `orbitfabric gen ground` command coverage.

## Boundary

This PR does not add new model semantics or generator behavior.

It intentionally keeps v0.8.0 described as:

```text
ground-facing Mission Data Contract exports
```

It does not present OrbitFabric as:

- a ground segment
- a mission control system
- an operator console
- a telemetry archive
- a command uplink service
- a Yamcs integration
- an OpenC3 integration
- an XTCE-compliant mission database
- a CCSDS/PUS/CFDP implementation
- a security enforcement layer

## Double check before opening

Before opening this PR, the branch was compared against `main`.

The diff is intentionally limited to:

- documentation alignment
- release notes
- MkDocs navigation
- package version bump to `0.8.0`

No generated artifacts are committed.

No source behavior is changed beyond the version constant.

Historical release documents and ADRs may continue to mention earlier milestones where those references are intentionally historical.

## Related issue

Part of #128.

## Validation

Expected local validation:

```bash
ruff check .
pytest
mkdocs build --strict
orbitfabric --version
orbitfabric gen ground examples/demo-3u/mission/
```
