### PR TITLE
Add model summary export CLI command

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from orbitfabric import __version__
+from orbitfabric.export import write_model_summary
 from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.gen.ground import (
@@ -46,6 +47,9 @@ app.add_typer(validate_app, name="validate")
 
 inspect_app = typer.Typer(help="Inspect OrbitFabric models and inputs.")
 app.add_typer(inspect_app, name="inspect")
+
+export_app = typer.Typer(help="Export Core-owned machine-readable contract surfaces.")
+app.add_typer(export_app, name="export")
 
 
 @app.callback()
@@ -351,6 +355,43 @@ def gen_ground(
     typer.echo(f"  faults: {len(contract.faults)}")
     typer.echo(f"  data products: {len(contract.data_products)}")
     typer.echo(f"  packets: {len(contract.packets)}")
+    typer.echo("\nResult: PASSED")
+
+
+@export_app.command("model-summary")
+def export_model_summary(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory used to export the model summary.",
+        ),
+    ],
+    json_output: Annotated[
+        Path,
+        typer.Option(
+            "--json",
+            help="Write the machine-readable model summary to this JSON file.",
+        ),
+    ] = Path("generated/reports/model_summary.json"),
+) -> None:
+    """Export a Core-owned read-only Mission Model summary."""
+    typer.echo(f"OrbitFabric Model Summary Export {__version__}")
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    written_file = write_model_summary(model, mission_dir, json_output)
+
+    typer.echo(f"\nMission: {model.spacecraft.id}")
+    typer.echo(f"Model version: {model.spacecraft.model_version}")
+    typer.echo(f"JSON report written to: {written_file}")
     typer.echo("\nResult: PASSED")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,60 @@ def test_gen_ground_rejects_unsupported_profile(tmp_path: Path) -> None:
     assert not output_dir.exists()
 
 
+def test_export_model_summary_writes_json_report(tmp_path: Path) -> None:
+    output_file = tmp_path / "model_summary.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "model-summary",
+            "examples/demo-3u/mission",
+            "--json",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Model Summary Export {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Model version: 0.1.0" in result.output
+    assert f"JSON report written to: {output_file}" in result.output
+    assert "Result: PASSED" in result.output
+    assert output_file.exists()
+
+    summary = json.loads(output_file.read_text(encoding="utf-8"))
+    assert summary["kind"] == "orbitfabric.model_summary"
+    assert summary["mission"]["id"] == "demo-3u"
+    assert summary["counts"]["spacecraft"] == 1
+    assert summary["counts"]["payloads"] == 1
+    assert summary["boundaries"]["contains_entity_index"] is False
+    assert summary["boundaries"]["contains_relationship_manifest"] is False
+    assert summary["boundaries"]["contains_plugin_api"] is False
+
+
+def test_export_model_summary_rejects_invalid_mission(tmp_path: Path) -> None:
+    mission_dir = _copy_demo_mission_missing_required_file(tmp_path)
+    output_file = tmp_path / "model_summary.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "model-summary",
+            str(mission_dir),
+            "--json",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "OF-SYN-002" in result.output
+    assert "required Mission Model file is missing" in result.output
+    assert "Result: FAILED" in result.output
+    assert not output_file.exists()
+
+
 def test_inspect_mission_loads_demo_mission() -> None:
     result = runner.invoke(app, ["inspect", "mission", "examples/demo-3u/mission"])
 


### PR DESCRIPTION
## Summary

This PR exposes the v0.8.1 model summary surface through the CLI.

It adds:

```bash
orbitfabric export model-summary <mission_dir> --json <output_file>
```

Default output:

```text
generated/reports/model_summary.json
```

## Changes

- Added a new `export` CLI group for Core-owned machine-readable contract surfaces.
- Added `export model-summary` command.
- The command loads the Mission Model through the canonical loader.
- The command writes the deterministic `orbitfabric.model_summary` JSON report.
- Added CLI tests for successful JSON export.
- Added CLI tests for invalid Mission Model failure handling.

## Boundaries

This PR intentionally does not introduce:

- version bump;
- release documentation;
- generated artifact command;
- entity index;
- relationship manifest;
- plugin API;
- plugin discovery;
- Studio-specific API;
- new Mission Model semantics.

## Validation

Not run in this environment.

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
