### PR TITLE
Document contract introspection surface

### DIFF
--- a/docs/reference/contract-introspection-surface.md
+++ b/docs/reference/contract-introspection-surface.md
@@ -1,0 +1,232 @@
+# Contract Introspection Surface
+
+OrbitFabric v0.8.1 introduces the first Core-owned contract introspection surface.
+
+The initial surface is:
+
+```text
+model_summary.json
+```
+
+It answers one deliberately narrow question:
+
+```text
+What contract domains are present in this mission?
+```
+
+---
+
+## Purpose
+
+The Contract Introspection Surface gives downstream tools a stable, machine-readable way to inspect the loaded Mission Model at domain level.
+
+Downstream tools should not reconstruct Mission Model semantics by independently parsing:
+
+```text
+raw YAML files
+generated documentation
+generated runtime artifacts
+generated ground artifacts
+human-oriented CLI output
+```
+
+The Core loads and validates the Mission Model.
+
+The Core owns the meaning of Mission Model domains.
+
+The Core exports the introspection surface.
+
+---
+
+## CLI
+
+Generate a model summary report with:
+
+```bash
+orbitfabric export model-summary examples/demo-3u/mission/ \
+  --json generated/reports/model_summary.json
+```
+
+Default output:
+
+```text
+generated/reports/model_summary.json
+```
+
+---
+
+## Output kind
+
+The generated JSON report uses:
+
+```json
+{
+  "kind": "orbitfabric.model_summary",
+  "summary_version": "0.1"
+}
+```
+
+---
+
+## Top-level structure
+
+The report contains:
+
+```text
+summary_version
+kind
+orbitfabric_version
+mission
+source
+boundaries
+counts
+domains
+```
+
+### mission
+
+The `mission` section includes:
+
+```text
+id
+name
+model_version
+```
+
+### source
+
+The `source` section includes:
+
+```text
+mission_dir
+```
+
+This path identifies the Mission Model directory used to produce the report.
+
+### boundaries
+
+The `boundaries` section explicitly declares what this report is and is not.
+
+Current boundary flags include:
+
+```text
+source_of_truth: mission_model
+core_derived_report: true
+contains_entity_index: false
+contains_relationship_manifest: false
+contains_plugin_api: false
+contains_runtime_behavior: false
+contains_ground_behavior: false
+```
+
+### counts
+
+The `counts` section contains domain-level counts derived from the loaded Mission Model.
+
+### domains
+
+The `domains` section contains one record per contract domain.
+
+Each domain record includes:
+
+```text
+id
+display_name
+source_file
+required
+present
+count
+count_provenance
+```
+
+---
+
+## Domain scope
+
+The v0.8.1 model summary includes Core-owned contract domains such as:
+
+```text
+spacecraft
+subsystems
+modes
+mode_transitions
+telemetry
+commands
+events
+faults
+packets
+policies
+payloads
+data_products
+contact_profiles
+link_profiles
+contact_windows
+downlink_flows
+command_sources
+commandability_rules
+autonomous_actions
+recovery_intents
+```
+
+The exact content is derived from the loaded Mission Model and the canonical Mission Model file registry.
+
+---
+
+## Boundary
+
+The Contract Introspection Surface is not:
+
+```text
+a generated runtime binding
+a generated ground artifact
+an entity index
+a relationship graph
+a source map
+a YAML AST export
+a plugin API
+a Studio-specific API
+```
+
+It does not expose entity-level records.
+
+It does not expose relationship records.
+
+It does not expose line or column locations.
+
+It does not introduce new Mission Model semantics.
+
+---
+
+## Relationship to v0.8.2 and v0.9
+
+The planned sequence is:
+
+```text
+v0.8.1 - Contract Introspection Surface
+v0.8.2 - Entity Index Surface
+v0.9   - Plugin and Extensibility Layer
+```
+
+v0.8.1 answers:
+
+```text
+What contract domains are present in this mission?
+```
+
+v0.8.2 should answer:
+
+```text
+What contract entities are defined in this mission?
+```
+
+v0.9 should introduce controlled extension points only after Core-owned introspection and entity surfaces exist.
+
+---
+
+## Final position
+
+`model_summary.json` is a Core-derived report.
+
+It is deterministic, inspectable and machine-readable.
+
+It exists so downstream tools consume OrbitFabric Core surfaces instead of inferring contract semantics privately.

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,142 @@
+# v0.8.1 - Contract Introspection Surface
+
+OrbitFabric v0.8.1 introduces the first Core-owned contract introspection surface.
+
+The release adds a deterministic `model_summary.json` report generated from the loaded Mission Model.
+
+It is a narrow release.
+
+It does not introduce entity indexing, relationship manifests or plugin behavior.
+
+---
+
+## Purpose
+
+The v0.8.1 goal is to let downstream tools ask a first stable question:
+
+```text
+What contract domains are present in this mission?
+```
+
+That answer must come from OrbitFabric Core.
+
+It must not be reconstructed by downstream tools from raw YAML, generated files or human-oriented CLI output.
+
+---
+
+## Added
+
+v0.8.1 adds:
+
+```text
+orbitfabric.export package
+model_summary_to_dict(model, mission_dir)
+write_model_summary(model, mission_dir, output_file)
+orbitfabric export model-summary command
+model_summary.json output
+contract domain counts
+contract domain source file metadata
+required/present domain status
+explicit boundary flags
+CLI tests
+model summary export tests
+```
+
+---
+
+## CLI
+
+Generate the model summary report with:
+
+```bash
+orbitfabric export model-summary examples/demo-3u/mission/ \
+  --json generated/reports/model_summary.json
+```
+
+Default output:
+
+```text
+generated/reports/model_summary.json
+```
+
+---
+
+## Output
+
+The generated report uses:
+
+```text
+kind: orbitfabric.model_summary
+summary_version: 0.1
+```
+
+It contains:
+
+```text
+mission identity
+source mission directory
+boundary flags
+domain counts
+domain records
+```
+
+---
+
+## Boundary
+
+v0.8.1 intentionally does not introduce:
+
+```text
+new Mission Model semantics
+entity index
+entity records
+relationship manifest
+relationship graph
+source line or column tracking
+YAML node location tracking
+plugin API
+plugin discovery
+Studio-specific API
+runtime behavior
+ground behavior
+versioned plugin surface
+```
+
+---
+
+## Why this matters
+
+This release prepares OrbitFabric Core for downstream tools and future plugin boundaries.
+
+The important architectural decision is:
+
+```text
+Core exports structured surfaces.
+Downstream tools consume them.
+Downstream tools do not infer contract semantics privately.
+```
+
+---
+
+## Validation
+
+The release validation baseline is:
+
+```bash
+ruff check .
+pytest
+mkdocs build --strict
+```
+
+Manual smoke command:
+
+```bash
+orbitfabric export model-summary examples/demo-3u/mission/ \
+  --json generated/reports/model_summary.json
+```
+
+Expected result:
+
+```text
+Result: PASSED
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - Data Flow Evidence: reference/data-flow-evidence.md
       - Runtime Contract Bindings: reference/runtime-contract-bindings.md
       - Ground Integration Artifacts: reference/ground-integration-artifacts.md
+      - Contract Introspection Surface: reference/contract-introspection-surface.md
   - Releases:
       - v0.2.2 Payload Contract Release Alignment: releases/v0.2.2.md
       - v0.3.0 Data Product and Storage Contracts: releases/v0.3.0.md
@@ -39,6 +40,7 @@ nav:
       - v0.6.0 End-to-End Mission Data Flow Evidence: releases/v0.6.0.md
       - v0.7.0 Generated Runtime Skeletons: releases/v0.7.0.md
       - v0.8.0 Ground Integration Artifacts: releases/v0.8.0.md
+      - v0.8.1 Contract Introspection Surface: releases/v0.8.1.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 


### PR DESCRIPTION
## Summary

This PR documents the v0.8.1 Contract Introspection Surface after the model summary export surface and CLI command were merged.

## Changes

- Added `docs/reference/contract-introspection-surface.md`.
- Added `docs/releases/v0.8.1.md`.
- Added both pages to `mkdocs.yml` navigation.

## Scope

This PR documents:

```text
orbitfabric export model-summary <mission_dir> --json <output_file>
model_summary.json
kind: orbitfabric.model_summary
summary_version: 0.1
```

## Boundaries

This PR intentionally does not introduce:

- code changes;
- CLI changes;
- version bump;
- release tag;
- entity index;
- relationship manifest;
- plugin API;
- Studio-specific API;
- new Mission Model semantics.

README, CHANGELOG and final version alignment are intentionally left for the final v0.8.1 release alignment PR.

## Validation

Not run in this environment.

Recommended local checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
