### PR TITLE
Add pure entity index export surface

### DIFF
--- a/src/orbitfabric/export/__init__.py
+++ b/src/orbitfabric/export/__init__.py
@@ -1,3 +1,9 @@
+from orbitfabric.export.entity_index import entity_index_to_dict, write_entity_index
 from orbitfabric.export.model_summary import model_summary_to_dict, write_model_summary
 
-__all__ = ["model_summary_to_dict", "write_model_summary"]
+__all__ = [
+    "entity_index_to_dict",
+    "model_summary_to_dict",
+    "write_entity_index",
+    "write_model_summary",
+]

--- a/src/orbitfabric/export/entity_index.py
+++ b/src/orbitfabric/export/entity_index.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric import __version__
-from orbitfabric.model.loader import OPTIONAL_FILES, REQUIRED_FILES
+from orbitfabric.model.loader import REQUIRED_FILES, OPTIONAL_FILES
 from orbitfabric.model.mission import MissionModel
 
 

--- a/src/orbitfabric/export/entity_index.py
+++ b/src/orbitfabric/export/entity_index.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orbitfabric import __version__
+from orbitfabric.model.loader import OPTIONAL_FILES, REQUIRED_FILES
+from orbitfabric.model.mission import MissionModel
+
+
+EntityPair = tuple[str, Any]
+
+
+def entity_index_to_dict(model: MissionModel, mission_dir: Path) -> dict[str, Any]:
+    """Return a deterministic read-only Mission Model entity index."""
+    mission_dir = mission_dir.resolve()
+    domains = [_domain_record(model, mission_dir, spec) for spec in _domain_specs()]
+    entities = [
+        entity
+        for spec in _domain_specs()
+        for entity in _entity_records(model, mission_dir, spec)
+    ]
+
+    return {
+        "index_version": "0.1",
+        "kind": "orbitfabric.entity_index",
+        "orbitfabric_version": __version__,
+        "mission": {
+            "id": model.spacecraft.id,
+            "name": model.spacecraft.name,
+            "model_version": model.spacecraft.model_version,
+        },
+        "source": {
+            "mission_dir": str(mission_dir),
+        },
+        "boundaries": {
+            "source_of_truth": "mission_model",
+            "core_derived_report": True,
+            "read_only": True,
+            "contains_entity_index": True,
+            "contains_entity_records": True,
+            "contains_relationship_manifest": False,
+            "contains_relationship_graph": False,
+            "contains_dependency_graph": False,
+            "contains_yaml_ast": False,
+            "contains_source_locations": False,
+            "contains_plugin_api": False,
+            "contains_studio_api": False,
+            "contains_runtime_behavior": False,
+            "contains_ground_behavior": False,
+        },
+        "counts": {
+            "total_entities": len(entities),
+            "domains": {domain["id"]: domain["entity_count"] for domain in domains},
+        },
+        "domains": domains,
+        "entities": entities,
+    }
+
+
+def write_entity_index(
+    model: MissionModel,
+    mission_dir: Path,
+    output_file: Path,
+) -> Path:
+    """Write a deterministic Mission Model entity index JSON file."""
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(entity_index_to_dict(model, mission_dir), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_file
+
+
+def _domain_record(
+    model: MissionModel,
+    mission_dir: Path,
+    spec: dict[str, Any],
+) -> dict[str, Any]:
+    entities = _entity_records(model, mission_dir, spec)
+    source_file = spec["source_file"]
+
+    return {
+        "id": spec["id"],
+        "display_name": spec["display_name"],
+        "source_file": source_file,
+        "required": spec["required"],
+        "present": (mission_dir / source_file).exists(),
+        "indexed": spec["indexed"],
+        "model_count": _domain_count(model, spec["id"]),
+        "entity_count": len(entities),
+        "count_provenance": "loaded_mission_model",
+    }
+
+
+def _entity_records(
+    model: MissionModel,
+    mission_dir: Path,
+    spec: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if not spec["indexed"]:
+        return []
+
+    source_file = spec["source_file"]
+    present = (mission_dir / source_file).exists()
+
+    return [
+        _entity_record(
+            item_id=item_id,
+            item=item,
+            domain=spec["id"],
+            entity_type=spec["entity_type"],
+            source_file=source_file,
+            required_domain=spec["required"],
+            present=present,
+        )
+        for item_id, item in sorted(_domain_entities(model, spec["id"]), key=lambda pair: pair[0])
+    ]
+
+
+def _entity_record(
+    item_id: str,
+    item: Any,
+    domain: str,
+    entity_type: str,
+    source_file: str,
+    required_domain: bool,
+    present: bool,
+) -> dict[str, Any]:
+    display_name = getattr(item, "name", None) or item_id
+
+    return {
+        "id": item_id,
+        "domain": domain,
+        "entity_type": entity_type,
+        "display_name": display_name,
+        "source_file": source_file,
+        "provenance": "loaded_mission_model",
+        "required_domain": required_domain,
+        "present": present,
+    }
+
+
+def _domain_entities(model: MissionModel, domain_id: str) -> list[EntityPair]:
+    if domain_id == "spacecraft":
+        return [(model.spacecraft.id, model.spacecraft)]
+    if domain_id == "subsystems":
+        return [(item.id, item) for item in model.subsystems]
+    if domain_id == "modes":
+        return [(item_id, item) for item_id, item in model.modes.items()]
+    if domain_id == "telemetry":
+        return [(item.id, item) for item in model.telemetry]
+    if domain_id == "commands":
+        return [(item.id, item) for item in model.commands]
+    if domain_id == "events":
+        return [(item.id, item) for item in model.events]
+    if domain_id == "faults":
+        return [(item.id, item) for item in model.faults]
+    if domain_id == "packets":
+        return [(item.id, item) for item in model.packets]
+    if domain_id == "payloads":
+        return [(item.id, item) for item in model.payloads]
+    if domain_id == "data_products":
+        return [(item.id, item) for item in model.data_products]
+    if domain_id == "contact_profiles":
+        return [(item.id, item) for item in model.contacts.contact_profiles]
+    if domain_id == "link_profiles":
+        return [(item.id, item) for item in model.contacts.link_profiles]
+    if domain_id == "contact_windows":
+        return [(item.id, item) for item in model.contacts.contact_windows]
+    if domain_id == "downlink_flows":
+        return [(item.id, item) for item in model.contacts.downlink_flows]
+    if domain_id == "command_sources":
+        return [(item.id, item) for item in model.commandability.sources]
+    if domain_id == "commandability_rules":
+        return [(item.id, item) for item in model.commandability.rules]
+    if domain_id == "autonomous_actions":
+        return [(item.id, item) for item in model.commandability.autonomous_actions]
+    if domain_id == "recovery_intents":
+        return [(item.id, item) for item in model.commandability.recovery_intents]
+    return []
+
+
+def _domain_specs() -> list[dict[str, Any]]:
+    return [
+        _domain_spec("spacecraft", "Spacecraft", "spacecraft.yaml", True, True, "spacecraft"),
+        _domain_spec("subsystems", "Subsystems", "subsystems.yaml", True, True, "subsystem"),
+        _domain_spec("modes", "Modes", "modes.yaml", True, True, "mode"),
+        _domain_spec(
+            "mode_transitions",
+            "Mode Transitions",
+            "modes.yaml",
+            True,
+            False,
+            None,
+        ),
+        _domain_spec("telemetry", "Telemetry", "telemetry.yaml", True, True, "telemetry"),
+        _domain_spec("commands", "Commands", "commands.yaml", True, True, "command"),
+        _domain_spec("events", "Events", "events.yaml", True, True, "event"),
+        _domain_spec("faults", "Faults", "faults.yaml", True, True, "fault"),
+        _domain_spec("packets", "Packets", "packets.yaml", True, True, "packet"),
+        _domain_spec("policies", "Policies", "policies.yaml", True, False, None),
+        _domain_spec("payloads", "Payloads", "payloads.yaml", False, True, "payload"),
+        _domain_spec(
+            "data_products",
+            "Data Products",
+            "data_products.yaml",
+            False,
+            True,
+            "data_product",
+        ),
+        _domain_spec(
+            "contact_profiles",
+            "Contact Profiles",
+            "contacts.yaml",
+            False,
+            True,
+            "contact_profile",
+        ),
+        _domain_spec(
+            "link_profiles",
+            "Link Profiles",
+            "contacts.yaml",
+            False,
+            True,
+            "link_profile",
+        ),
+        _domain_spec(
+            "contact_windows",
+            "Contact Windows",
+            "contacts.yaml",
+            False,
+            True,
+            "contact_window",
+        ),
+        _domain_spec(
+            "downlink_flows",
+            "Downlink Flows",
+            "contacts.yaml",
+            False,
+            True,
+            "downlink_flow",
+        ),
+        _domain_spec(
+            "command_sources",
+            "Command Sources",
+            "commandability.yaml",
+            False,
+            True,
+            "command_source",
+        ),
+        _domain_spec(
+            "commandability_rules",
+            "Commandability Rules",
+            "commandability.yaml",
+            False,
+            True,
+            "commandability_rule",
+        ),
+        _domain_spec(
+            "autonomous_actions",
+            "Autonomous Actions",
+            "commandability.yaml",
+            False,
+            True,
+            "autonomous_action",
+        ),
+        _domain_spec(
+            "recovery_intents",
+            "Recovery Intents",
+            "commandability.yaml",
+            False,
+            True,
+            "recovery_intent",
+        ),
+    ]
+
+
+def _domain_spec(
+    domain_id: str,
+    display_name: str,
+    source_file: str,
+    required: bool,
+    indexed: bool,
+    entity_type: str | None,
+) -> dict[str, Any]:
+    return {
+        "id": domain_id,
+        "display_name": display_name,
+        "source_file": source_file,
+        "required": required,
+        "indexed": indexed,
+        "entity_type": entity_type,
+    }
+
+
+def _domain_count(model: MissionModel, domain_id: str) -> int:
+    counts = {
+        "spacecraft": 1,
+        "subsystems": len(model.subsystems),
+        "modes": len(model.modes),
+        "mode_transitions": len(model.mode_transitions),
+        "telemetry": len(model.telemetry),
+        "commands": len(model.commands),
+        "events": len(model.events),
+        "faults": len(model.faults),
+        "packets": len(model.packets),
+        "policies": 1,
+        "payloads": len(model.payloads),
+        "data_products": len(model.data_products),
+        "contact_profiles": len(model.contacts.contact_profiles),
+        "link_profiles": len(model.contacts.link_profiles),
+        "contact_windows": len(model.contacts.contact_windows),
+        "downlink_flows": len(model.contacts.downlink_flows),
+        "command_sources": len(model.commandability.sources),
+        "commandability_rules": len(model.commandability.rules),
+        "autonomous_actions": len(model.commandability.autonomous_actions),
+        "recovery_intents": len(model.commandability.recovery_intents),
+    }
+    return counts[domain_id]
+
+
+def _assert_domain_specs_match_loader() -> None:
+    expected_files = set(REQUIRED_FILES) | set(OPTIONAL_FILES)
+    actual_files = {domain["source_file"] for domain in _domain_specs()}
+
+    if actual_files != expected_files:
+        raise AssertionError("entity index domain specs must match loader files")

--- a/src/orbitfabric/export/entity_index.py
+++ b/src/orbitfabric/export/entity_index.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric import __version__
-from orbitfabric.model.loader import REQUIRED_FILES, OPTIONAL_FILES
+from orbitfabric.model.loader import OPTIONAL_FILES, REQUIRED_FILES
 from orbitfabric.model.mission import MissionModel
-
 
 EntityPair = tuple[str, Any]
 

--- a/tests/test_entity_index_export.py
+++ b/tests/test_entity_index_export.py
@@ -95,15 +95,15 @@ def test_entity_index_contains_id_bearing_entities() -> None:
     assert entities[("commands", "payload.start_acquisition")]["display_name"] == (
         "payload.start_acquisition"
     )
-    assert entities[("telemetry", "eps.battery_voltage")]["entity_type"] == "telemetry"
-    assert entities[("payloads", "radiation_monitor")]["entity_type"] == "payload"
+    assert entities[("telemetry", "eps.battery.voltage")]["entity_type"] == "telemetry"
+    assert entities[("payloads", "demo_iod_payload")]["entity_type"] == "payload"
     assert entities[("data_products", "payload.radiation_histogram")]["entity_type"] == (
         "data_product"
     )
     assert entities[("contact_windows", "demo_contact_001")]["entity_type"] == (
         "contact_window"
     )
-    assert entities[("command_sources", "ground_station")]["entity_type"] == (
+    assert entities[("command_sources", "ground_operator")]["entity_type"] == (
         "command_source"
     )
 

--- a/tests/test_entity_index_export.py
+++ b/tests/test_entity_index_export.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orbitfabric import __version__
+from orbitfabric.export.entity_index import (
+    _assert_domain_specs_match_loader,
+    entity_index_to_dict,
+    write_entity_index,
+)
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_entity_index_contains_mission_identity_and_boundaries() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    index = entity_index_to_dict(model, DEMO_MISSION)
+
+    assert index["index_version"] == "0.1"
+    assert index["kind"] == "orbitfabric.entity_index"
+    assert index["orbitfabric_version"] == __version__
+    assert index["mission"] == {
+        "id": "demo-3u",
+        "name": "Demo 3U Spacecraft",
+        "model_version": "0.1.0",
+    }
+    assert index["source"]["mission_dir"] == str(DEMO_MISSION.resolve())
+    assert index["boundaries"] == {
+        "source_of_truth": "mission_model",
+        "core_derived_report": True,
+        "read_only": True,
+        "contains_entity_index": True,
+        "contains_entity_records": True,
+        "contains_relationship_manifest": False,
+        "contains_relationship_graph": False,
+        "contains_dependency_graph": False,
+        "contains_yaml_ast": False,
+        "contains_source_locations": False,
+        "contains_plugin_api": False,
+        "contains_studio_api": False,
+        "contains_runtime_behavior": False,
+        "contains_ground_behavior": False,
+    }
+
+
+def test_entity_index_contains_domain_summaries() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    index = entity_index_to_dict(model, DEMO_MISSION)
+    domains = {domain["id"]: domain for domain in index["domains"]}
+
+    assert domains["spacecraft"] == {
+        "id": "spacecraft",
+        "display_name": "Spacecraft",
+        "source_file": "spacecraft.yaml",
+        "required": True,
+        "present": True,
+        "indexed": True,
+        "model_count": 1,
+        "entity_count": 1,
+        "count_provenance": "loaded_mission_model",
+    }
+    assert domains["mode_transitions"]["indexed"] is False
+    assert domains["mode_transitions"]["model_count"] == len(model.mode_transitions)
+    assert domains["mode_transitions"]["entity_count"] == 0
+    assert domains["policies"]["indexed"] is False
+    assert domains["policies"]["model_count"] == 1
+    assert domains["policies"]["entity_count"] == 0
+    assert domains["payloads"]["required"] is False
+    assert domains["payloads"]["present"] is True
+    assert domains["payloads"]["indexed"] is True
+    assert domains["payloads"]["entity_count"] == len(model.payloads)
+
+
+def test_entity_index_contains_id_bearing_entities() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    index = entity_index_to_dict(model, DEMO_MISSION)
+    entities = {(entity["domain"], entity["id"]): entity for entity in index["entities"]}
+
+    assert entities[("spacecraft", "demo-3u")] == {
+        "id": "demo-3u",
+        "domain": "spacecraft",
+        "entity_type": "spacecraft",
+        "display_name": "Demo 3U Spacecraft",
+        "source_file": "spacecraft.yaml",
+        "provenance": "loaded_mission_model",
+        "required_domain": True,
+        "present": True,
+    }
+    assert entities[("commands", "payload.start_acquisition")]["entity_type"] == "command"
+    assert entities[("commands", "payload.start_acquisition")]["display_name"] == (
+        "payload.start_acquisition"
+    )
+    assert entities[("telemetry", "eps.battery_voltage")]["entity_type"] == "telemetry"
+    assert entities[("payloads", "radiation_monitor")]["entity_type"] == "payload"
+    assert entities[("data_products", "payload.radiation_histogram")]["entity_type"] == (
+        "data_product"
+    )
+    assert entities[("contact_windows", "demo_contact_001")]["entity_type"] == (
+        "contact_window"
+    )
+    assert entities[("command_sources", "ground_station")]["entity_type"] == (
+        "command_source"
+    )
+
+
+def test_entity_index_does_not_create_synthetic_records_for_non_id_domains() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    index = entity_index_to_dict(model, DEMO_MISSION)
+    entity_domains = {entity["domain"] for entity in index["entities"]}
+
+    assert "mode_transitions" not in entity_domains
+    assert "policies" not in entity_domains
+
+
+def test_entity_index_counts_total_entities_and_domains() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    index = entity_index_to_dict(model, DEMO_MISSION)
+
+    expected_domain_counts = {
+        "spacecraft": 1,
+        "subsystems": len(model.subsystems),
+        "modes": len(model.modes),
+        "mode_transitions": 0,
+        "telemetry": len(model.telemetry),
+        "commands": len(model.commands),
+        "events": len(model.events),
+        "faults": len(model.faults),
+        "packets": len(model.packets),
+        "policies": 0,
+        "payloads": len(model.payloads),
+        "data_products": len(model.data_products),
+        "contact_profiles": len(model.contacts.contact_profiles),
+        "link_profiles": len(model.contacts.link_profiles),
+        "contact_windows": len(model.contacts.contact_windows),
+        "downlink_flows": len(model.contacts.downlink_flows),
+        "command_sources": len(model.commandability.sources),
+        "commandability_rules": len(model.commandability.rules),
+        "autonomous_actions": len(model.commandability.autonomous_actions),
+        "recovery_intents": len(model.commandability.recovery_intents),
+    }
+
+    assert index["counts"]["domains"] == expected_domain_counts
+    assert index["counts"]["total_entities"] == sum(expected_domain_counts.values())
+    assert index["counts"]["total_entities"] == len(index["entities"])
+
+
+def test_entity_index_marks_absent_optional_domains(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+
+    for source_file in DEMO_MISSION.glob("*.yaml"):
+        if source_file.name in {
+            "payloads.yaml",
+            "data_products.yaml",
+            "contacts.yaml",
+            "commandability.yaml",
+        }:
+            continue
+        (mission_dir / source_file.name).write_text(
+            source_file.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    model = MissionModelLoader().load(mission_dir)
+    index = entity_index_to_dict(model, mission_dir)
+    domains = {domain["id"]: domain for domain in index["domains"]}
+
+    assert domains["payloads"]["present"] is False
+    assert domains["payloads"]["entity_count"] == 0
+    assert domains["data_products"]["present"] is False
+    assert domains["data_products"]["entity_count"] == 0
+    assert domains["contact_profiles"]["present"] is False
+    assert domains["contact_profiles"]["entity_count"] == 0
+    assert domains["command_sources"]["present"] is False
+    assert domains["command_sources"]["entity_count"] == 0
+    assert not any(entity["source_file"] == "payloads.yaml" for entity in index["entities"])
+
+
+def test_write_entity_index_is_deterministic_json(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    output_file = tmp_path / "entity_index.json"
+
+    written_file = write_entity_index(model, DEMO_MISSION, output_file)
+
+    assert written_file == output_file
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert content.endswith("\n")
+
+    parsed = json.loads(content)
+    assert parsed == entity_index_to_dict(model, DEMO_MISSION)
+
+
+def test_entity_index_domain_specs_match_loader_files() -> None:
+    _assert_domain_specs_match_loader()


### PR DESCRIPTION
## Summary

Introduces the first pure Core-owned Entity Index export surface for `v0.8.2`.

This PR adds:

- `src/orbitfabric/export/entity_index.py`
- `entity_index_to_dict(model, mission_dir)`
- `write_entity_index(model, mission_dir, output_file)`
- package-level exports in `orbitfabric.export`
- dedicated unit tests for the pure export surface

The exported structure answers:

```text
What contract entities are defined in this mission?
```

It derives records from the loaded `MissionModel`, not from raw YAML scanning.

## Entity Index Shape

The new surface emits:

- `index_version`
- `kind = orbitfabric.entity_index`
- OrbitFabric version
- mission identity
- source mission directory
- explicit boundary flags
- per-domain summaries
- total/domain entity counts
- entity records

Entity records include:

- `id`
- `domain`
- `entity_type`
- `display_name`
- `source_file`
- `provenance = loaded_mission_model`
- `required_domain`
- `present`

## Scope Boundary

This PR intentionally does not introduce:

- CLI command
- documentation
- version bump
- relationship graph
- relationship manifest
- dependency graph
- source line/column tracking
- YAML AST export
- plugin API
- plugin discovery
- Studio-specific API
- runtime behavior
- ground behavior
- new Mission Model semantics

`mode_transitions` and `policies` remain visible in domain summaries, but do not produce synthetic entity records because they do not currently expose stable entity IDs in the Mission Model.

## Validation

Static review performed through GitHub API.

I could not run local validation from this environment because DNS resolution for `github.com` failed while attempting to clone the branch.

Required validation before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```

No generated artifacts are committed.