### PR TITLE
Add entity index export CLI command

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 
 from orbitfabric import __version__
-from orbitfabric.export import write_model_summary
+from orbitfabric.export import write_entity_index, write_model_summary
 from orbitfabric.gen.data_flow import generate_data_flow_markdown_doc
 from orbitfabric.gen.docs import generate_markdown_docs
 from orbitfabric.gen.ground import (
@@ -388,6 +388,43 @@ def export_model_summary(
         raise typer.Exit(code=1) from exc
 
     written_file = write_model_summary(model, mission_dir, json_output)
+
+    typer.echo(f"\nMission: {model.spacecraft.id}")
+    typer.echo(f"Model version: {model.spacecraft.model_version}")
+    typer.echo(f"JSON report written to: {written_file}")
+    typer.echo("\nResult: PASSED")
+
+
+@export_app.command("entity-index")
+def export_entity_index(
+    mission_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            help="Mission Model directory used to export the entity index.",
+        ),
+    ],
+    json_output: Annotated[
+        Path,
+        typer.Option(
+            "--json",
+            help="Write the machine-readable entity index to this JSON file.",
+        ),
+    ] = Path("generated/reports/entity_index.json"),
+) -> None:
+    """Export a Core-owned read-only Mission Model entity index."""
+    typer.echo(f"OrbitFabric Entity Index Export {__version__}")
+
+    try:
+        model = MissionModelLoader().load(mission_dir)
+    except MissionModelError as exc:
+        _print_model_error(exc)
+        raise typer.Exit(code=1) from exc
+
+    written_file = write_entity_index(model, mission_dir, json_output)
 
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")

--- a/tests/test_entity_index_cli.py
+++ b/tests/test_entity_index_cli.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from orbitfabric import __version__
+from orbitfabric.cli import app
+
+runner = CliRunner()
+
+
+def test_export_entity_index_writes_json_report(tmp_path: Path) -> None:
+    output_file = tmp_path / "entity_index.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "entity-index",
+            "examples/demo-3u/mission",
+            "--json",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert f"OrbitFabric Entity Index Export {__version__}" in result.output
+    assert "Mission: demo-3u" in result.output
+    assert "Model version: 0.1.0" in result.output
+    assert f"JSON report written to: {output_file}" in result.output
+    assert "Result: PASSED" in result.output
+    assert output_file.exists()
+
+    index = json.loads(output_file.read_text(encoding="utf-8"))
+    assert index["kind"] == "orbitfabric.entity_index"
+    assert index["mission"]["id"] == "demo-3u"
+    assert index["counts"]["total_entities"] == len(index["entities"])
+    assert index["counts"]["domains"]["commands"] == 4
+    assert index["counts"]["domains"]["mode_transitions"] == 0
+    assert index["counts"]["domains"]["policies"] == 0
+    assert index["boundaries"]["contains_entity_index"] is True
+    assert index["boundaries"]["contains_entity_records"] is True
+    assert index["boundaries"]["contains_relationship_manifest"] is False
+    assert index["boundaries"]["contains_plugin_api"] is False
+
+
+def test_export_entity_index_rejects_invalid_mission(tmp_path: Path) -> None:
+    mission_dir = tmp_path / "mission"
+    mission_dir.mkdir()
+    output_file = tmp_path / "entity_index.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "entity-index",
+            str(mission_dir),
+            "--json",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "OF-SYN-002" in result.output
+    assert "required Mission Model file is missing" in result.output
+    assert "Result: FAILED" in result.output
+    assert not output_file.exists()


### PR DESCRIPTION
## Summary

Adds the CLI surface for the v0.8.2 Entity Index export.

This PR adds:

- `orbitfabric export entity-index`
- default output path `generated/reports/entity_index.json`
- CLI smoke tests for valid and invalid Mission Model input

The command delegates to the Core-owned export helper introduced in PR #138:

```text
write_entity_index(model, mission_dir, json_output)
```

## Scope Boundary

This PR intentionally does not introduce:

- documentation updates
- version bump
- generated artifacts
- relationship graph
- relationship manifest
- dependency graph
- YAML AST export
- source line/column tracking
- plugin API
- plugin discovery
- Studio-specific API
- runtime behavior
- ground behavior
- new Mission Model semantics

## Validation

Required before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```
