### PR TITLE
Align release baseline for v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ### Next
 
-- Prepare final release alignment for `v0.8.2 - Entity Index Surface`, including package version bump and current-baseline documentation updates.
+- Prepare `v0.9 - Plugin and Extensibility Layer` as the next controlled extension milestone after Core-owned introspection and entity index surfaces.
 
 ---
 
@@ -38,7 +38,10 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ### Changed
 
+- Updated the package and CLI version to `0.8.2`.
 - Extended the Core-owned structured surfaces from domain-level model summary to entity-level indexing.
+- Aligned the public roadmap so `v0.8.2 - Entity Index Surface` is completed and `v0.9 - Plugin and Extensibility Layer` is the next milestone.
+- Updated README, architecture, project charter, quickstart, development guide, contributing guide and versioning documentation for v0.8.2.
 - Reinforced that downstream tools should consume Core-generated structured surfaces instead of reconstructing Mission Model entities from YAML, generated files or textual CLI output.
 - Clarified the relationship between `model_summary.json` and `entity_index.json`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.8.1 - Contract Introspection Surface`.
+The current public baseline is `v0.8.2 - Entity Index Surface`.
 
-In v0.8.1, Contract Introspection Surface means the first Core-owned read-only model summary surface derived from the loaded Mission Model.
+In v0.8.2, Entity Index Surface means the first Core-owned read-only entity index surface derived from the loaded Mission Model.
 
-The next development focus is `v0.8.2 - Entity Index Surface`.
+The next development focus is `v0.9 - Plugin and Extensibility Layer`.
 
 The current baseline proves this Mission Data Chain:
 
@@ -30,6 +30,7 @@ Payload Contract
   -> Runtime-Facing Contract Bindings
   -> Ground-Facing Integration Artifacts
   -> Contract Introspection Surface
+  -> Entity Index Surface
 ```
 
 Do not add large integrations before the contract model is coherent.
@@ -67,6 +68,8 @@ Runtime-facing contract bindings must remain generated, deterministic and dispos
 Ground-facing integration artifacts must remain generated, deterministic, tool-neutral and disposable.
 
 Contract introspection reports must remain Core-owned, deterministic, read-only and disposable.
+
+Entity index reports must remain Core-owned, deterministic, read-only and disposable.
 
 User implementation code and downstream integration code must live outside `generated/`.
 
@@ -126,7 +129,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.8.1
+orbitfabric 0.8.2
 ```
 
 ---
@@ -149,6 +152,9 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
+
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
 
 orbitfabric gen docs examples/demo-3u/mission/
 
@@ -179,6 +185,7 @@ pytest                -> passing
 mkdocs                -> passing
 lint                  -> Result: PASSED
 export model-summary  -> Result: PASSED
+export entity-index   -> Result: PASSED
 gen docs              -> Result: PASSED
 gen data-flow         -> Result: PASSED
 gen runtime           -> Result: PASSED
@@ -264,7 +271,7 @@ Good examples:
 ```text
 Add contact downlink consistency rules
 Generate ground dictionaries
-Align public documentation with v0.8.1
+Align public documentation with v0.8.2
 Fix scenario command validation
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts and Core-owned introspection surfaces once.
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces once.
 Validate them, document them, simulate them and generate deterministic integration and inspection artifacts from the same source of truth.
 
 </div>
@@ -19,7 +19,7 @@ Validate them, document them, simulate them and generate deterministic integrati
 
 OrbitFabric is a **model-first Mission Data Fabric** for small spacecraft.
 
-It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation, runtime-facing bindings, ground-facing integration artifacts and Core-owned introspection surfaces.
+It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation, runtime-facing bindings, ground-facing integration artifacts, Core-owned introspection surfaces and downstream inspection tools.
 
 OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
 
@@ -42,11 +42,13 @@ downstream inspection tools
 
 ## Current Status
 
-OrbitFabric is currently at `v0.8.1 - Contract Introspection Surface`.
+OrbitFabric is currently at `v0.8.2 - Entity Index Surface`.
 
-In v0.8.1, **Contract Introspection Surface** means the first Core-owned read-only machine-readable surface for inspecting the loaded Mission Model at contract-domain level.
+In v0.8.2, **Entity Index Surface** means the first Core-owned read-only machine-readable surface for inspecting the loaded Mission Model at contract-entity level.
 
-It introduces `model_summary.json` and the `orbitfabric export model-summary` command.
+It introduces `entity_index.json` and the `orbitfabric export entity-index` command.
+
+It builds on v0.8.1, which introduced `model_summary.json` and the `orbitfabric export model-summary` command.
 
 OrbitFabric does not generate a ground segment, mission control system, telemetry archive, command uplink service, operator console, decoder runtime, database, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
 
@@ -62,7 +64,8 @@ The current repository includes:
 - the `v0.6.0 - End-to-End Mission Data Flow Evidence` vertical slice;
 - the `v0.7.0 - Generated Runtime Skeletons` vertical slice;
 - the `v0.8.0 - Ground Integration Artifacts` vertical slice;
-- the `v0.8.1 - Contract Introspection Surface` vertical slice.
+- the `v0.8.1 - Contract Introspection Surface` vertical slice;
+- the `v0.8.2 - Entity Index Surface` vertical slice.
 
 The current vertical slice is functional:
 
@@ -85,6 +88,8 @@ The current vertical slice is functional:
 - human-reviewable ground Markdown artifacts;
 - `orbitfabric export model-summary` generation;
 - Core-owned `model_summary.json` contract introspection report;
+- `orbitfabric export entity-index` generation;
+- Core-owned `entity_index.json` entity index report;
 - synthetic demo mission: `demo-3u`.
 
 The repository also includes a growing set of example mission slices:
@@ -118,6 +123,9 @@ orbitfabric gen ground examples/demo-3u/mission/
 
 orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
 -> passing
+
+orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
+-> passing
 ```
 
 ---
@@ -143,7 +151,8 @@ It models:
 - contract-level Mission Data Flow Evidence;
 - generated runtime-facing contract bindings;
 - generated ground-facing integration artifacts;
-- Core-owned contract introspection surfaces.
+- Core-owned contract introspection surfaces;
+- Core-owned entity index surfaces.
 
 The data-flow evidence chain connects:
 
@@ -159,31 +168,22 @@ command expected effect
         -> JSON report evidence
         -> runtime-facing bindings
         -> ground-facing artifacts
-        -> Core-owned introspection surfaces
+        -> model summary surface
+        -> entity index surface
 ```
 
-The v0.8 ground-facing generation chain is:
-
-```text
-Mission Model
-        -> validation and linting
-        -> GroundContract
-        -> generic ground-facing dictionaries
-        -> JSON / CSV / Markdown artifacts
-        -> downstream ground-system integration outside OrbitFabric
-```
-
-The v0.8.1 introspection chain is:
+The v0.8.2 introspection and indexing chain is:
 
 ```text
 Mission Model
         -> canonical loader
         -> validated MissionModel
         -> model_summary.json
+        -> entity_index.json
         -> downstream tools consume Core-owned structured surfaces
 ```
 
-Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts and Contract Introspection Surfaces are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
+Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts, Contract Introspection Surfaces and Entity Index Surfaces are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
 
 ---
 
@@ -216,6 +216,8 @@ OrbitFabric is not:
 - a command dispatch runtime;
 - an onboard scheduler;
 - a HAL or RTOS abstraction;
+- a relationship graph;
+- a plugin API;
 - a Studio-specific backend API.
 
 Generated Runtime Skeletons in v0.7.0 are runtime-facing contract bindings.
@@ -223,6 +225,8 @@ Generated Runtime Skeletons in v0.7.0 are runtime-facing contract bindings.
 Ground Integration Artifacts in v0.8.0 are ground-facing contract exports.
 
 Contract Introspection Surface in v0.8.1 is a Core-derived read-only model summary.
+
+Entity Index Surface in v0.8.2 is a Core-derived read-only entity index.
 
 None of them is flight software, ground software or a visual modeling tool.
 
@@ -268,6 +272,7 @@ Payload Contract
         -> Runtime-Facing Contract Bindings
         -> Ground-Facing Integration Artifacts
         -> Contract Introspection Surface
+        -> Entity Index Surface
 ```
 
 ---
@@ -293,7 +298,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.8.1
+orbitfabric 0.8.2
 ```
 
 ---
@@ -313,24 +318,42 @@ Result: PASSED
 
 ---
 
-## Export the Model Summary
+## Export Core-Owned Structured Surfaces
 
-Generate the Core-owned contract introspection report:
+Generate the domain-level model summary report:
 
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
 ```
 
-Generated file:
+Generate the entity-level index report:
+
+```bash
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
+```
+
+Generated files:
 
 ```text
 generated/reports/model_summary.json
+generated/reports/entity_index.json
 ```
 
-This report is a read-only Core-derived summary of the contract domains present in the loaded Mission Model.
+`model_summary.json` answers:
 
-It is not an entity index, relationship graph, plugin API or Studio-specific API.
+```text
+What contract domains are present in this mission?
+```
+
+`entity_index.json` answers:
+
+```text
+What contract entities are defined in this mission?
+```
+
+Neither surface is a relationship graph, plugin API or Studio-specific API.
 
 ---
 
@@ -342,23 +365,6 @@ Generate Markdown documentation from the Mission Model:
 orbitfabric gen docs examples/demo-3u/mission/
 ```
 
-Generated files:
-
-```text
-generated/docs/
-├── telemetry.md
-├── commands.md
-├── events.md
-├── faults.md
-├── modes.md
-├── packets.md
-├── payloads.md
-├── data_products.md
-├── contacts.md
-├── commandability.md
-└── data_flow.md
-```
-
 ---
 
 ## Generate Runtime Contract Bindings
@@ -367,22 +373,6 @@ Generate C++17 runtime-facing contract bindings:
 
 ```bash
 orbitfabric gen runtime examples/demo-3u/mission/
-```
-
-Generated files:
-
-```text
-generated/runtime/cpp17/
-├── runtime_contract_manifest.json
-├── CMakeLists.txt
-├── include/orbitfabric/generated/
-│   ├── mission_ids.hpp
-│   ├── mission_enums.hpp
-│   ├── mission_registries.hpp
-│   ├── command_args.hpp
-│   └── adapter_interfaces.hpp
-└── src/
-    └── orbitfabric_runtime_contract_smoke.cpp
 ```
 
 Validate the generated C++17 contract surface with CMake:
@@ -404,29 +394,6 @@ Generate the generic ground-facing mission data package:
 
 ```bash
 orbitfabric gen ground examples/demo-3u/mission/
-```
-
-Generated files:
-
-```text
-generated/ground/generic/
-├── ground_contract_manifest.json
-├── README.md
-├── dictionaries/
-│   ├── telemetry_dictionary.json
-│   ├── command_dictionary.json
-│   ├── event_dictionary.json
-│   ├── fault_dictionary.json
-│   ├── data_product_dictionary.json
-│   └── packet_dictionary.json
-├── csv/
-│   ├── telemetry_dictionary.csv
-│   ├── command_dictionary.csv
-│   ├── event_dictionary.csv
-│   ├── fault_dictionary.csv
-│   ├── data_product_dictionary.csv
-│   └── packet_dictionary.csv
-└── ground_dictionaries.md
 ```
 
 These files are ground-facing contract exports.
@@ -487,7 +454,8 @@ The current vertical slice can produce:
 generated/
 ├── docs/
 ├── reports/
-│   └── model_summary.json
+│   ├── model_summary.json
+│   └── entity_index.json
 ├── logs/
 ├── runtime/
 │   └── cpp17/
@@ -526,7 +494,8 @@ Useful entry points:
 - `docs/reference/runtime-contract-bindings.md`
 - `docs/reference/ground-integration-artifacts.md`
 - `docs/reference/contract-introspection-surface.md`
-- `docs/releases/v0.8.1.md`
+- `docs/reference/entity-index-surface.md`
+- `docs/releases/v0.8.2.md`
 - `docs/adr/`
 
 Build the documentation site locally:
@@ -585,6 +554,9 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
+
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
 
 orbitfabric gen docs examples/demo-3u/mission/
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Architecture
 
-Version: 0.8.1  
+Version: 0.8.2  
 Status: Development preview  
-Scope: Mission Data Contract architecture through Contract Introspection Surface
+Scope: Mission Data Contract architecture through Entity Index Surface
 
 ---
 
@@ -16,7 +16,7 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, documentation and scenario evidence from one source of truth.
+It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, documentation and scenario evidence from one source of truth.
 
 OrbitFabric is not designed as:
 
@@ -36,13 +36,13 @@ Studio-specific backend API
 
 Its architectural role is:
 
-> define, validate, simulate, document, introspect and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration and downstream inspection tools.
+> define, validate, simulate, document, introspect, index and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration and downstream inspection tools.
 
-The current architectural baseline is `v0.8.1 - Contract Introspection Surface`.
+The current architectural baseline is `v0.8.2 - Entity Index Surface`.
 
-In v0.8.1, Contract Introspection Surface means the first Core-owned read-only model summary surface derived from the loaded Mission Model.
+v0.8.1 introduced the first Core-owned read-only model summary surface derived from the loaded Mission Model.
 
-The next architectural step is `v0.8.2 - Entity Index Surface`.
+v0.8.2 introduces the first Core-owned read-only entity index surface derived from the loaded Mission Model.
 
 ---
 
@@ -52,7 +52,7 @@ The next architectural step is `v0.8.2 - Entity Index Surface`.
 
 The Mission Model is the source of truth.
 
-Runtime-facing bindings, ground-facing artifacts, contract introspection reports, simulation behavior and generated documentation must derive from the model.
+Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, simulation behavior and generated documentation must derive from the model.
 
 No important mission behavior should live only in Python code, documentation, generated files, simulator internals or downstream tools.
 
@@ -66,7 +66,9 @@ v0.7.0 introduced generated runtime-facing contract bindings, not onboard behavi
 
 v0.8.0 introduced generated ground-facing contract exports, not ground behavior.
 
-v0.8.1 introduced a Core-owned model summary report, not entity indexing, relationship graphs or plugins.
+v0.8.1 introduced a Core-owned model summary report, not relationship graphs or plugins.
+
+v0.8.2 introduced a Core-owned entity index report, not relationship graphs or plugins.
 
 ### 2.3 Chain Before Generated Artifacts
 
@@ -85,6 +87,7 @@ Payload behavior
         -> Runtime-Facing Contract Bindings
         -> Ground-Facing Integration Artifacts
         -> Contract Introspection Surface
+        -> Entity Index Surface
 ```
 
 ### 2.4 Generated Bindings, Exports and Reports Are Not Behavior
@@ -95,9 +98,11 @@ Generated Ground Integration Artifacts are contract exports.
 
 Generated Contract Introspection reports are Core-owned read-only summaries.
 
-They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents and domain-level model summaries.
+Generated Entity Index reports are Core-owned read-only entity indexes.
 
-They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, entity indexing, relationship graphs or plugin behavior unless those surfaces are explicitly implemented and tested in a later milestone.
+They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries and entity-level records.
+
+They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graphs or plugin behavior unless those surfaces are explicitly implemented and tested in a later milestone.
 
 ### 2.5 Lint as Engineering Judgment
 
@@ -105,7 +110,7 @@ They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS
 
 It must detect mission consistency issues, not merely invalid YAML.
 
-A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing or introspection artifacts depend on it.
+A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection or entity-index artifacts depend on it.
 
 ### 2.6 Docs from Model
 
@@ -135,7 +140,7 @@ They must not reconstruct Mission Model semantics from raw YAML, generated files
 
 v0.8.1 establishes this principle with `model_summary.json`.
 
-v0.8.2 should extend it with an entity index surface.
+v0.8.2 extends it with `entity_index.json`.
 
 ---
 
@@ -161,6 +166,7 @@ OrbitFabric
 │   ├── runtime-facing contract binding inputs
 │   ├── ground-facing contract export inputs
 │   ├── contract introspection inputs
+│   ├── entity index inputs
 │   └── scenarios
 │
 ├── Toolchain
@@ -172,6 +178,7 @@ OrbitFabric
 │   ├── orbitfabric gen runtime
 │   ├── orbitfabric gen ground
 │   ├── orbitfabric export model-summary
+│   ├── orbitfabric export entity-index
 │   └── orbitfabric sim
 │
 ├── Model Layer
@@ -186,9 +193,9 @@ OrbitFabric
 
 ---
 
-## 4. Current Capability Boundary - v0.8.1
+## 4. Current Capability Boundary - v0.8.2
 
-OrbitFabric v0.8.1 includes:
+OrbitFabric v0.8.2 includes:
 
 ```text
 Mission Model YAML
@@ -219,10 +226,12 @@ CSV ground dictionaries
 human-reviewable ground Markdown artifacts
 orbitfabric export model-summary command
 model_summary.json contract introspection report
+orbitfabric export entity-index command
+entity_index.json entity index report
 synthetic demo mission
 ```
 
-OrbitFabric v0.8.1 excludes:
+OrbitFabric v0.8.2 excludes:
 
 ```text
 flight runtime
@@ -253,7 +262,6 @@ real command authorization
 live uplink services
 flight autonomy runtime
 real FDIR or safing logic
-entity index
 relationship manifest
 relationship graph
 plugin API
@@ -288,7 +296,7 @@ Typed Mission Model
       │
       ├──────────────► GroundContract Builder ──► Ground-Facing Integration Artifacts
       │
-      └──────────────► Export Layer ────────────► Contract Introspection Reports
+      └──────────────► Export Layer ────────────► Core-Owned Structured Surfaces
 ```
 
 The model is loaded once and consumed by multiple downstream layers.
@@ -333,6 +341,9 @@ Ground-Facing Integration Artifacts
       │
       ▼
 Contract Introspection Surface
+      │
+      ▼
+Entity Index Surface
 ```
 
 This is the architectural reason OrbitFabric did not jump directly from payload contracts to plugins.
@@ -353,6 +364,7 @@ orbitfabric gen data-flow examples/demo-3u/mission/
 orbitfabric gen runtime examples/demo-3u/mission/
 orbitfabric gen ground examples/demo-3u/mission/
 orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
+orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 orbitfabric inspect mission examples/demo-3u/mission/
@@ -370,7 +382,8 @@ orbitfabric
 │   ├── runtime <mission-dir>
 │   └── ground <mission-dir>
 ├── export
-│   └── model-summary <mission-dir>
+│   ├── model-summary <mission-dir>
+│   └── entity-index <mission-dir>
 ├── sim <scenario-file>
 ├── inspect
 │   └── mission <mission-dir>
@@ -378,7 +391,7 @@ orbitfabric
     └── scenario <scenario-file>
 ```
 
-Future commands may include entity index export and tool-specific exporters only after their semantics are implemented and tested explicitly.
+Future commands may include relationship manifest export and tool-specific exporters only after their semantics are implemented and tested explicitly.
 
 ---
 
@@ -438,10 +451,16 @@ It is not the source of truth.
 
 ## 10. Export Layer Architecture
 
-v0.8.1 introduces the first export layer surface:
+v0.8.1 introduced the first export layer surface:
 
 ```text
 model_summary.json
+```
+
+v0.8.2 introduced the second export layer surface:
+
+```text
+entity_index.json
 ```
 
 The required dependency direction is:
@@ -452,6 +471,7 @@ Mission Model
         -> validated MissionModel
         -> export layer
         -> model_summary.json
+        -> entity_index.json
 ```
 
 The disallowed direction is:
@@ -467,7 +487,9 @@ export layer
 
 The model summary report contains domain-level information only.
 
-It does not contain entity-level records, relationship records, source locations, plugin definitions or Studio-specific formatting.
+The entity index report contains entity-level records only.
+
+Neither surface contains relationship records, source locations, plugin definitions or Studio-specific formatting.
 
 ---
 
@@ -519,7 +541,7 @@ User implementation code must live outside `generated/`.
 
 ---
 
-## 13. Host-Build, Ground Export and Introspection Validation
+## 13. Host-Build, Ground Export and Structured Surface Validation
 
 Runtime-facing bindings can be validated with:
 
@@ -542,9 +564,16 @@ orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
 ```
 
+The entity index surface can be validated with:
+
+```bash
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
+```
+
 These commands confirm that the generated contract surfaces are syntactically valid and reproducible on the host.
 
-They do not validate flight behavior, live ground behavior, entity indexing, relationship graphs or plugin behavior.
+They do not validate flight behavior, live ground behavior, relationship graphs or plugin behavior.
 
 ---
 
@@ -574,7 +603,7 @@ Ground-facing review artifacts are generated under:
 generated/ground/generic/
 ```
 
-Contract introspection reports are generated under:
+Core-owned structured reports are generated under:
 
 ```text
 generated/reports/
@@ -631,6 +660,7 @@ runtime contract manifest
 ground contract manifest
 ground dictionaries
 model summary report
+entity index report
 ```
 
 Reports and manifests must remain stable enough for tests and CI, but they are still development-preview artifacts before v1.0.
@@ -711,6 +741,8 @@ ground JSON export tests
 ground CSV export tests
 ground Markdown export tests
 model summary export tests
+entity index export tests
+entity index CLI tests
 CLI smoke tests
 ```
 
@@ -732,6 +764,8 @@ Release validation additionally includes:
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
 orbitfabric gen runtime examples/demo-3u/mission/
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
@@ -747,11 +781,11 @@ Future extensions should be added as generators, plugins or adapters.
 Possible future layers:
 
 ```text
-Entity Index Surface
 Custom Ground Exporters
 Custom Lint Rule Plugins
 Custom Mission Model Extensions
 Runtime Adapter SDK
+Relationship Manifest Surface
 Yamcs Export Generator
 OpenC3 Export Generator
 XTCE Export Generator
@@ -786,9 +820,9 @@ proprietary example contamination
 
 ---
 
-## 21. v0.8.1 Acceptance Architecture
+## 21. v0.8.2 Acceptance Architecture
 
-OrbitFabric v0.8.1 is architecturally acceptable when this flow works end-to-end:
+OrbitFabric v0.8.2 is architecturally acceptable when this flow works end-to-end:
 
 ```bash
 ruff check .
@@ -800,6 +834,9 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
+
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
 
 orbitfabric gen docs examples/demo-3u/mission/
 
@@ -827,6 +864,7 @@ And produces:
 ```text
 valid lint output
 model_summary.json
+entity_index.json
 Markdown mission documentation
 scenario execution logs
 scenario JSON reports
@@ -840,19 +878,19 @@ CSV ground dictionaries
 human-reviewable ground Markdown artifacts
 ```
 
-No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, entity index, relationship graph or plugin API is required for v0.8.1.
+No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph or plugin API is required for v0.8.2.
 
 ---
 
-## 22. Next Architectural Step - v0.8.2
+## 22. Next Architectural Step - v0.9
 
 The next architectural step is:
 
 ```text
-v0.8.2 - Entity Index Surface
+v0.9 - Plugin and Extensibility Layer
 ```
 
-The purpose is to introduce a Core-owned read-only entity index surface without introducing relationship graphs, plugin APIs or Studio-specific APIs.
+The purpose is to introduce controlled extension points after Core-owned domain and entity surfaces exist.
 
 ---
 
@@ -874,7 +912,9 @@ The v0.7 runtime-facing binding layer exposes that contract to implementation co
 
 The v0.8.0 ground-facing artifact layer exposes that contract to ground integration work without generating ground behavior.
 
-The v0.8.1 contract introspection surface exposes a Core-owned model summary for downstream tools without introducing entity indexing, relationship graphs or plugins.
+The v0.8.1 contract introspection surface exposes a Core-owned model summary for downstream tools without introducing relationship graphs or plugins.
+
+The v0.8.2 entity index surface exposes Core-owned entity records for downstream tools without introducing relationship graphs or plugins.
 
 Future plugins must consume the contract.
 

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -20,7 +20,7 @@ Define once. Validate. Simulate. Test. Document. Integrate.
 
 The goal is not to model a real CubeSat.
 
-The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution, runtime-facing contract bindings, ground-facing integration artifacts and Core-owned introspection surfaces.
+The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces.
 
 ---
 
@@ -184,7 +184,7 @@ It is not real payload file generation, onboard storage, downlink queue executio
 
 ---
 
-## 7. Export the model summary
+## 7. Export Core-owned structured surfaces
 
 v0.8.1 adds the first Core-owned Contract Introspection Surface for the same `demo-3u` Mission Model.
 
@@ -207,9 +207,28 @@ The report answers:
 What contract domains are present in this mission?
 ```
 
-It includes domain-level counts, required/present status, source file metadata and explicit boundary flags.
+v0.8.2 adds the first Core-owned Entity Index Surface for the same `demo-3u` Mission Model.
 
-It does not expose entity records, relationship graphs, plugin APIs or Studio-specific APIs.
+Run:
+
+```bash
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
+```
+
+Generated file:
+
+```text
+generated/reports/entity_index.json
+```
+
+The report answers:
+
+```text
+What contract entities are defined in this mission?
+```
+
+Neither report exposes relationship graphs, plugin APIs or Studio-specific APIs.
 
 ---
 
@@ -441,6 +460,7 @@ command accepted
   -> runtime-facing bindings generated from the same model
   -> ground-facing artifacts generated from the same model
   -> model summary exported from the same model
+  -> entity index exported from the same model
 ```
 
 ---

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -50,7 +50,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.8.1
+orbitfabric 0.8.2
 ```
 
 ---
@@ -75,7 +75,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.8.1 Vertical Slice
+## Verify the Current v0.8.2 Vertical Slice
 
 Run mission lint:
 
@@ -89,6 +89,13 @@ Export the Core-owned model summary report:
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
+```
+
+Export the Core-owned entity index report:
+
+```bash
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
 ```
 
 Generate documentation:
@@ -144,6 +151,7 @@ Expected results:
 ```text
 lint                  -> Result: PASSED
 export model-summary  -> Result: PASSED
+export entity-index   -> Result: PASSED
 gen docs              -> Result: PASSED
 gen data-flow         -> Result: PASSED
 gen runtime           -> Result: PASSED
@@ -152,10 +160,11 @@ gen ground            -> Result: PASSED
 sim                   -> Result: PASSED
 ```
 
-The generated model summary report should include:
+The generated Core-owned structured reports should include:
 
 ```text
 generated/reports/model_summary.json
+generated/reports/entity_index.json
 ```
 
 The generated mission documentation should include:
@@ -243,6 +252,8 @@ Generated ground-facing integration artifacts are disposable.
 
 Generated contract introspection reports are disposable.
 
+Generated entity index reports are disposable.
+
 User implementation code and downstream integration code must live outside `generated/`.
 
 ---
@@ -290,7 +301,9 @@ Do not put user code inside generated runtime bindings.
 
 Do not present generated ground artifacts as live ground behavior.
 
-Do not present contract introspection reports as entity indexes, relationship graphs or Studio-specific APIs.
+Do not present contract introspection reports as relationship graphs or Studio-specific APIs.
+
+Do not present entity index reports as relationship graphs, dependency graphs, plugin APIs or Studio-specific APIs.
 
 ---
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Project Charter
 
-Version: 0.8.1
+Version: 0.8.2
 Status: Draft
 Scope: Mission Data Contract foundation, Mission Data Chain and generated contract-facing artifacts
 
@@ -10,7 +10,7 @@ Scope: Mission Data Contract foundation, Mission Data Chain and generated contra
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts and Core-owned introspection surfaces once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground and downstream tooling.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground and downstream tooling.
 
 OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework or a visual modeling backend.
 
@@ -47,7 +47,8 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - validation and linting rules;
 - runtime-facing generated contract bindings;
 - ground-facing generated integration artifacts;
-- Core-owned contract introspection surfaces.
+- Core-owned contract introspection surfaces;
+- Core-owned entity index surfaces.
 
 The Mission Data Contract is the single source of truth for all derived artifacts.
 
@@ -77,7 +78,7 @@ This creates drift.
 
 A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize. A generated software boundary may diverge from the mission model it was supposed to represent. A downstream tool may infer contract semantics differently from the Core.
 
-OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable and introspectable through Core-owned structured surfaces.
+OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable and indexable through Core-owned structured surfaces.
 
 ---
 
@@ -129,17 +130,17 @@ The correct long-term role is:
 
 OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system or a visual tool.
 
-The runtime-facing bindings, ground-facing artifacts, contract introspection reports, simulator and documentation must be derived from the model, not the other way around.
+The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, simulator and documentation must be derived from the model, not the other way around.
 
 ### 6.2 Contract Before Code
 
 The first valuable artifact is the contract.
 
-Code generation, runtime execution, ground integration, inspection surfaces and integration bridges are secondary and must not redefine the model.
+Code generation, runtime execution, ground integration, inspection surfaces, entity surfaces and integration bridges are secondary and must not redefine the model.
 
 ### 6.3 Mission Data Chain Before Generated Artifacts
 
-OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection or plugin-facing artifacts.
+OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index or plugin-facing artifacts.
 
 The current chain is:
 
@@ -155,13 +156,14 @@ payload behavior
         -> runtime-facing contract bindings
         -> ground-facing integration artifacts
         -> contract introspection surface
+        -> entity index surface
 ```
 
-Only after these concepts are sufficiently clear should OrbitFabric derive entity index, plugin, tool-specific or external integration layers from them.
+Only after these concepts are sufficiently clear should OrbitFabric derive plugin, tool-specific or external integration layers from them.
 
 ### 6.4 Generated Artifacts Are Disposable
 
-Generated runtime-facing contract bindings, ground-facing integration artifacts and contract introspection reports are reproducible outputs.
+Generated runtime-facing contract bindings, ground-facing integration artifacts, contract introspection reports and entity index reports are reproducible outputs.
 
 They are not the source of truth.
 
@@ -211,7 +213,9 @@ They must not reconstruct Mission Model semantics from raw YAML, generated artif
 
 v0.8.1 introduces `model_summary.json` as the first such surface.
 
-v0.8.2 should introduce an entity index surface before plugin extensibility is implemented.
+v0.8.2 introduces `entity_index.json` as the second such surface.
+
+v0.9 may introduce plugin extensibility only after these Core-owned surfaces exist.
 
 ### 6.9 Clean-Room Development
 
@@ -235,7 +239,7 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 ## 7. Completed Early Scope
 
-The current v0.8.1 baseline includes:
+The current v0.8.2 baseline includes:
 
 - Mission Model YAML files;
 - model loading;
@@ -258,6 +262,7 @@ The current v0.8.1 baseline includes:
 - generated CSV ground dictionaries;
 - generated ground Markdown review artifacts;
 - Core-owned model summary export;
+- Core-owned entity index export;
 - readable logs;
 - JSON reports;
 - one complete demo mission named `demo-3u`.
@@ -267,6 +272,7 @@ The current baseline supports these commands:
 ```bash
 orbitfabric lint examples/demo-3u/mission/
 orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
+orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
 orbitfabric gen docs examples/demo-3u/mission/
 orbitfabric gen data-flow examples/demo-3u/mission/
 orbitfabric gen runtime examples/demo-3u/mission/
@@ -291,11 +297,11 @@ They are the foundation for later tool-specific exporters and plugin extensibili
 
 ---
 
-## 9. Contract Introspection Direction
+## 9. Contract Introspection and Entity Index Direction
 
-The Contract Introspection Surface makes the loaded Mission Model visible to downstream tools without letting those tools infer Core semantics privately.
+Core-owned structured surfaces make the loaded Mission Model visible to downstream tools without letting those tools infer Core semantics privately.
 
-The v0.8.1 model summary report may describe:
+The v0.8.1 model summary report describes:
 
 - mission identity;
 - source mission directory;
@@ -305,9 +311,20 @@ The v0.8.1 model summary report may describe:
 - source file metadata;
 - explicit boundary flags.
 
-The v0.8.1 model summary report must not describe or implement:
+The v0.8.2 entity index report describes:
 
-- entity index;
+- mission identity;
+- source mission directory;
+- contract entities;
+- entity IDs;
+- entity domains;
+- entity types;
+- display names;
+- source file metadata;
+- explicit boundary flags.
+
+These reports must not describe or implement:
+
 - relationship graph;
 - dependency graph;
 - source line or column tracking;
@@ -334,7 +351,8 @@ Payload or subsystem activity
         -> runtime-facing contract bindings
         -> ground-facing integration artifacts
         -> contract introspection surface
-        -> future entity index and plugins
+        -> entity index surface
+        -> future plugins
 ```
 
 This direction is essential for small spacecraft and CubeSat missions because the value of mission data depends on the full path from onboard generation to ground consumption and downstream inspection.
@@ -391,7 +409,7 @@ The initial demo mission is `demo-3u`.
 
 It is a synthetic 3U CubeSat-like mission used only to demonstrate OrbitFabric concepts.
 
-It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts and contract introspection surface.
+It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface and entity index surface.
 
 The demo assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
 
@@ -412,7 +430,7 @@ The recommended technical baseline is:
 - C++17 for the first generated runtime-facing binding profile;
 - CMake for host-build smoke validation;
 - JSON, CSV and Markdown for the first generated ground-facing artifact package;
-- JSON for Core-owned introspection reports;
+- JSON for Core-owned introspection and entity index reports;
 - GitHub Actions for CI;
 - Apache-2.0 license.
 
@@ -426,7 +444,9 @@ It is not a ground runtime.
 
 The generated model summary report is intentionally Core-owned and read-only.
 
-It is not an entity index, relationship graph, plugin API or Studio-specific API.
+The generated entity index report is intentionally Core-owned and read-only.
+
+Neither is a relationship graph, plugin API or Studio-specific API.
 
 ---
 
@@ -476,10 +496,11 @@ OrbitFabric is successful in the early public preview if a user can:
 8. validate those generated bindings through a host-side C++17 smoke build;
 9. generate ground-facing JSON, CSV and Markdown artifacts from the same Mission Model;
 10. export a Core-owned model summary report from the same Mission Model;
-11. understand the project positioning from the README in less than one minute;
-12. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
-13. understand how payload contracts fit into the Mission Data Contract;
-14. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts and Core-owned surfaces fit into the roadmap before plugin extensibility.
+11. export a Core-owned entity index report from the same Mission Model;
+12. understand the project positioning from the README in less than one minute;
+13. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
+14. understand how payload contracts fit into the Mission Data Contract;
+15. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts and Core-owned surfaces fit into the roadmap before plugin extensibility.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 
@@ -536,7 +557,7 @@ The project should prefer:
 - generated contract-facing artifacts over hidden implementation assumptions;
 - Core-owned structured surfaces over downstream semantic inference;
 - clean interfaces over premature integrations;
-- mission data chain modeling before runtime-facing, ground-facing, introspection and plugin generation.
+- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing and plugin generation.
 
 The project should reject:
 
@@ -563,8 +584,8 @@ The first versions must prove one thing convincingly:
 
 > A small spacecraft mission can be described once, validated semantically, simulated operationally, tested through scenarios, documented automatically, exposed through generated contract-facing artifacts and inspected through Core-owned structured surfaces from a single source of truth.
 
-The current version extends that proof to contract introspection:
+The current version extends that proof to entity indexing:
 
-> Payload behavior, data products, onboard storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations, runtime-facing contract bindings and ground-facing integration artifacts can feed a Core-owned model summary without duplicating or redefining the mission contract.
+> Payload behavior, data products, onboard storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations, runtime-facing contract bindings and ground-facing integration artifacts can feed Core-owned model summary and entity index reports without duplicating or redefining the mission contract.
 
 That is the core of OrbitFabric.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,6 +27,7 @@ Mission Model YAML
   -> ground-facing CSV dictionaries
   -> human-reviewable ground Markdown artifacts
   -> model_summary.json contract introspection report
+  -> entity_index.json entity index report
   -> JSON lint reports
   -> JSON simulation reports with data-flow evidence
   -> simulation logs
@@ -38,7 +39,7 @@ Generated runtime-facing contract bindings are not flight software.
 
 Generated ground integration artifacts are not ground software.
 
-Contract introspection surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.
+Contract introspection and entity index surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.
 
 ---
 
@@ -106,7 +107,7 @@ orbitfabric --help
 Expected version for the current development preview:
 
 ```text
-orbitfabric 0.8.1
+orbitfabric 0.8.2
 ```
 
 ---
@@ -173,28 +174,42 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 ---
 
-## 10. Export the model summary
+## 10. Export Core-owned structured surfaces
+
+Generate the domain-level model summary:
 
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
 ```
 
+Generate the entity-level index:
+
+```bash
+orbitfabric export entity-index examples/demo-3u/mission/ \
+  --json generated/reports/entity_index.json
+```
+
 Generated output:
 
 ```text
 generated/reports/model_summary.json
+generated/reports/entity_index.json
 ```
 
-This report is the first Core-owned Contract Introspection Surface.
-
-It answers:
+`model_summary.json` answers:
 
 ```text
 What contract domains are present in this mission?
 ```
 
-It does not expose entity records, relationship graphs, plugin APIs or Studio-specific APIs.
+`entity_index.json` answers:
+
+```text
+What contract entities are defined in this mission?
+```
+
+Neither surface exposes relationship graphs, plugin APIs or Studio-specific APIs.
 
 ---
 
@@ -202,23 +217,6 @@ It does not expose entity records, relationship graphs, plugin APIs or Studio-sp
 
 ```bash
 orbitfabric gen docs examples/demo-3u/mission/
-```
-
-Generated output:
-
-```text
-generated/docs/
-├── telemetry.md
-├── commands.md
-├── events.md
-├── faults.md
-├── modes.md
-├── packets.md
-├── payloads.md
-├── data_products.md
-├── contacts.md
-├── commandability.md
-└── data_flow.md
 ```
 
 Generate only the data-flow evidence reference:
@@ -238,22 +236,6 @@ Do not edit generated files manually.
 
 ```bash
 orbitfabric gen runtime examples/demo-3u/mission/
-```
-
-Generated output:
-
-```text
-generated/runtime/cpp17/
-├── runtime_contract_manifest.json
-├── CMakeLists.txt
-├── include/orbitfabric/generated/
-│   ├── mission_ids.hpp
-│   ├── mission_enums.hpp
-│   ├── mission_registries.hpp
-│   ├── command_args.hpp
-│   └── adapter_interfaces.hpp
-└── src/
-    └── orbitfabric_runtime_contract_smoke.cpp
 ```
 
 The generated C++17 files are runtime-facing contract bindings.
@@ -289,29 +271,6 @@ It does not validate flight behavior.
 
 ```bash
 orbitfabric gen ground examples/demo-3u/mission/
-```
-
-Generated output:
-
-```text
-generated/ground/generic/
-├── ground_contract_manifest.json
-├── README.md
-├── dictionaries/
-│   ├── telemetry_dictionary.json
-│   ├── command_dictionary.json
-│   ├── event_dictionary.json
-│   ├── fault_dictionary.json
-│   ├── data_product_dictionary.json
-│   └── packet_dictionary.json
-├── csv/
-│   ├── telemetry_dictionary.csv
-│   ├── command_dictionary.csv
-│   ├── event_dictionary.csv
-│   ├── fault_dictionary.csv
-│   ├── data_product_dictionary.csv
-│   └── packet_dictionary.csv
-└── ground_dictionaries.md
 ```
 
 The generated ground files are ground-facing contract exports.
@@ -382,6 +341,7 @@ The current demo proves that OrbitFabric can:
 - run semantic lint rules;
 - generate Markdown documentation;
 - inspect a Mission Model summary;
+- export an entity index from the loaded Mission Model;
 - validate scenarios without executing them;
 - execute deterministic operational sequences;
 - record contract-level data-flow evidence;
@@ -392,7 +352,7 @@ The current demo proves that OrbitFabric can:
 - validate generated C++17 contract bindings with a host-build smoke target;
 - build a GroundContract from the validated Mission Model;
 - generate deterministic JSON, CSV and Markdown ground-facing contract artifacts;
-- export a deterministic Core-owned model summary report for downstream inspection tools.
+- export deterministic Core-owned structured surfaces for downstream inspection tools.
 
 ---
 
@@ -420,7 +380,6 @@ The current demo does not prove:
 - command dispatch runtime behavior;
 - telemetry polling runtime behavior;
 - HAL or RTOS integration;
-- entity indexing;
 - relationship graph export;
 - plugin API behavior;
 - qualification for operational spacecraft use.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Roadmap
 
-Version: v0.8.1  
+Version: v0.8.2  
 Status: Development preview  
 Scope: v0.3 to v1.0 planning
 
@@ -63,16 +63,14 @@ v0.6.0  End-to-End Mission Data Flow Evidence                 completed
 v0.7.0  Generated Runtime Skeletons                           completed
 v0.8.0  Ground Integration Artifacts                          completed
 v0.8.1  Contract Introspection Surface                        completed
-v0.8.2  Entity Index Surface                                  next
-v0.9    Plugin and Extensibility Layer                        planned
+v0.8.2  Entity Index Surface                                  completed
+v0.9    Plugin and Extensibility Layer                        next
 v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target after v0.8.1 is now `v0.8.2 - Entity Index Surface`.
+The immediate target after v0.8.2 is now `v0.9 - Plugin and Extensibility Layer`.
 
-This is intentional. Contract introspection and entity indexing are Core-owned, read-only surfaces required before plugins and downstream tools can safely consume the Mission Data Contract.
-
-Ground integration artifacts remain downstream of the Mission Data Contract. v0.8.0 completed the first ground-facing contract export layer. v0.8.1 completed the first Core-owned domain-level introspection surface. v0.8.2 should expose the first Core-owned entity index before v0.9 introduces controlled extension points.
+This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9 can now introduce controlled extension points without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files or human-oriented CLI output.
 
 ---
 
@@ -88,168 +86,38 @@ v0.1 proved that a user can:
 
 ---
 
-## 4. Completed Slice - v0.2.1 Payload Contract Model
+## 4. Completed Model and Mission Data Chain Slices
 
-v0.2.1 introduced the first narrow vertical slice for Payload / IOD Payload Contracts.
-
-It added:
+OrbitFabric has completed the following model and Mission Data Chain slices:
 
 ```text
-optional payloads.yaml domain
-PayloadContract model
-minimal payload lifecycle model
-payload semantic lint rules
-generated payload contract documentation
-payload-aware scenario behavior
+v0.2.1  Payload Contract Model
+v0.2.2  Payload Contract Release Alignment
+v0.2.3  Mission Data Chain Roadmap Alignment
+v0.3.0  Data Product and Storage Contracts
+v0.4.0  Contact Windows and Downlink Flow Contracts
+v0.5.0  Commandability and Autonomy Contracts
+v0.6.0  End-to-End Mission Data Flow Evidence
 ```
 
-Payload contracts may describe expected mission-data behavior.
-
-They must not describe payload firmware, payload drivers, hardware buses, onboard runtime services, physical instrument simulation or scientific processing pipelines.
-
----
-
-## 5. Completed Alignment - v0.2.2 Payload Contract Release Alignment
-
-v0.2.2 aligned README, public documentation, roadmap, changelog, release notes and public communication with the Payload Contract Model.
-
-It did not introduce new model semantics.
-
----
-
-## 6. Completed Alignment - v0.2.3 Mission Data Chain Roadmap Alignment
-
-v0.2.3 formalized the post-payload direction:
+Together, these slices formalized the chain:
 
 ```text
 Payload behavior
         -> data products
-        -> onboard storage and retention
+        -> onboard storage and retention intent
         -> downlink queue intent
         -> contact window assumptions
         -> commandability constraints
         -> autonomy and recovery expectations
         -> end-to-end scenario evidence
-        -> future runtime and ground artifacts
 ```
 
-It remained architecture-first and documentation-first.
+They intentionally did not implement payload firmware, physical payload simulation, real onboard storage, real downlink execution, RF behavior, live command uplink, real FDIR or live spacecraft operations.
 
 ---
 
-## 7. Completed Slice - v0.3.0 Data Product and Storage Contracts
-
-v0.3.0 introduced data products as first-class mission data artifacts.
-
-It added:
-
-```text
-optional data_products.yaml domain
-DataProductContract model
-data product producer reference
-data product type
-estimated size
-priority
-storage intent
-retention intent
-overflow policy
-downlink intent
-data product semantic lint rules
-generated data product documentation
-synthetic demo mission data product
-```
-
-v0.3.0 did not implement real storage, file systems, compression, payload processing pipelines, contact windows or downlink runtime behavior.
-
----
-
-## 8. Completed Slice - v0.4.0 Contact Windows and Downlink Flow Contracts
-
-v0.4.0 modeled contact windows and downlink flow assumptions without becoming a ground segment, an orbital dynamics simulator, an RF simulator or a downlink runtime.
-
-It added:
-
-```text
-optional contacts.yaml domain
-contact profile model
-link profile model
-contact window model
-declared contact capacity assumption
-downlink flow contract model
-data product downlink eligibility
-contact/downlink reference validation
-minimal contact/downlink semantic lint rules
-generated contact/downlink documentation
-one synthetic demo contact/downlink slice
-```
-
-It did not implement real contact scheduling, real downlink execution, RF behavior, CCSDS/PUS/CFDP, Yamcs/OpenC3 services or runtime skeleton generation.
-
----
-
-## 9. Completed Slice - v0.5.0 Commandability and Autonomy Contracts
-
-v0.5.0 made command use and autonomous behavior explicit in the Mission Data Contract.
-
-It added:
-
-```text
-optional commandability.yaml domain
-CommandSource model
-CommandabilityRule model
-AutonomousActionContract model
-RecoveryIntent model
-commandability/autonomy semantic lint rules
-OF-CAB-* lint rule family
-OF-AUT-* lint rule family
-OF-REC-* lint rule family
-generated commandability/autonomy documentation
-generated commandability.md output
-one synthetic demo commandability/autonomy slice
-```
-
-v0.5.0 did not implement real command authentication, authorization, encryption, live uplink, operator consoles, command queues, onboard schedulers, autonomy runtime or real FDIR.
-
----
-
-## 10. Completed Slice - v0.6.0 End-to-End Mission Data Flow Evidence
-
-v0.6.0 combined payload contracts, data products, storage intent, downlink assumptions, contact windows and command effects into deterministic scenario evidence.
-
-It made this chain inspectable:
-
-```text
-payload acquisition command
-        -> data product declared as expected effect
-        -> storage intent inspectable
-        -> downlink intent inspectable
-        -> eligible downlink flow inspectable
-        -> matching contact window inspectable
-        -> scenario evidence generated
-        -> JSON evidence exported
-        -> Markdown evidence documented
-```
-
-v0.6.0 introduced:
-
-```text
-command expected_effects.data_products
-OF-CMD-008 / OF-CMD-009 lint rules
-simulation data-flow evidence records
-JSON data_flow_evidence report output
-scenario expect.data_flow assertions
-OF-SCN-014 through OF-SCN-017 scenario reference checks
-payload_data_flow_evidence demo scenario
-generated data_flow.md documentation
-orbitfabric gen data-flow command
-data_flow.md included in standard orbitfabric gen docs output
-```
-
-v0.6.0 did not implement real payload file generation, onboard storage runtime, downlink queues, contact scheduling, RF behavior, ground integration artifacts, CCSDS/PUS/CFDP runtime behavior or runtime skeleton generation.
-
----
-
-## 11. Completed Slice - v0.7.0 Generated Runtime Skeletons
+## 5. Completed Slice - v0.7.0 Generated Runtime Skeletons
 
 v0.7.0 introduced the first generated runtime-facing contract binding layer derived from the Mission Data Contract.
 
@@ -265,16 +133,10 @@ The precise architectural meaning is:
 runtime-facing contract bindings
 ```
 
-This is not flight software.
-
-It is a generated software boundary that implementation code can include, compile and implement against outside `generated/`.
-
 v0.7.0 introduced:
 
 ```text
 RuntimeContract intermediate model
-deterministic naming rules
-deterministic generated numeric identifiers
 orbitfabric gen runtime command
 cpp17 generation profile
 runtime_contract_manifest.json
@@ -283,7 +145,6 @@ generated static metadata registries
 generated command argument structs
 generated abstract adapter interfaces
 host-buildable CMake smoke target
-host-build smoke source including all generated headers
 Runtime Contract Bindings reference documentation
 v0.7.0 release notes
 ```
@@ -292,7 +153,7 @@ v0.7.0 intentionally did not implement flight-ready runtime, command dispatch ru
 
 ---
 
-## 12. Completed Slice - v0.8.0 Ground Integration Artifacts
+## 6. Completed Slice - v0.8.0 Ground Integration Artifacts
 
 v0.8.0 introduced the first generated ground-facing artifact package derived from the Mission Data Contract.
 
@@ -308,10 +169,6 @@ The precise architectural meaning is:
 ground-facing Mission Data Contract exports
 ```
 
-This is not a ground segment.
-
-It is a deterministic, inspectable, tool-neutral artifact package that ground software teams can review, adapt or consume downstream.
-
 v0.8.0 introduced:
 
 ```text
@@ -319,18 +176,8 @@ GroundContract intermediate model
 orbitfabric gen ground command
 generic generation profile
 ground_contract_manifest.json
-JSON telemetry dictionary
-JSON command dictionary
-JSON event dictionary
-JSON fault dictionary
-JSON data product dictionary
-JSON packet dictionary
-CSV telemetry dictionary
-CSV command dictionary
-CSV event dictionary
-CSV fault dictionary
-CSV data product dictionary
-CSV packet dictionary
+JSON ground dictionaries
+CSV ground dictionaries
 generated ground artifact README.md
 generated ground_dictionaries.md review document
 Ground Integration Artifacts reference documentation
@@ -338,46 +185,19 @@ ADR-0012 Ground Integration Artifacts Boundary
 v0.8.0 release notes
 ```
 
-v0.8.0 intentionally does not implement:
-
-```text
-live ground segment
-mission control system
-operator console
-telemetry archive
-telemetry database
-command uplink service
-telecommand transport
-telemetry downlink runtime
-network/session/routing behavior
-command authentication or authorization
-security enforcement
-Yamcs integration
-OpenC3 integration
-XTCE compliance
-CCSDS/PUS/CFDP implementation
-binary packet decoder
-binary telecommand encoder
-offset/bitfield layout model
-calibration model
-RF/link-budget behavior
-pass scheduling
-station automation
-```
+v0.8.0 intentionally did not implement a live ground segment, mission control system, telemetry archive, telemetry database, command uplink service, Yamcs integration, OpenC3 integration, XTCE compliance, CCSDS/PUS/CFDP implementation, binary packet decoder, binary telecommand encoder, RF behavior, pass scheduling or station automation.
 
 ---
 
-## 13. Completed Slice - v0.8.1 Contract Introspection Surface
+## 7. Completed Slice - v0.8.1 Contract Introspection Surface
 
 v0.8.1 introduced the first Core-owned read-only contract introspection surface.
 
-The purpose is to let downstream tools ask:
+It answers:
 
 ```text
 What contract domains are present in this mission?
 ```
-
-This is answered by the Core, not by downstream tools parsing YAML, generated files or human-oriented CLI output.
 
 v0.8.1 introduced:
 
@@ -398,89 +218,66 @@ Contract Introspection Surface reference documentation
 v0.8.1 release notes
 ```
 
-Command:
-
-```bash
-orbitfabric export model-summary examples/demo-3u/mission/ \
-  --json generated/reports/model_summary.json
-```
-
-v0.8.1 intentionally does not introduce:
-
-```text
-entity index
-entity list
-relationship manifest
-relationship graph
-source line or column tracking
-YAML node location tracking
-plugin mechanism
-plugin API
-Studio-specific API
-scenario evidence duplication
-generated artifact explorer
-new Mission Model semantics
-```
+v0.8.1 intentionally did not introduce entity records, relationship manifests, relationship graphs, source locations, YAML AST export, plugin API, Studio-specific API, runtime behavior, ground behavior or new Mission Model semantics.
 
 ---
 
-## 14. Next Slice - v0.8.2 Entity Index Surface
+## 8. Completed Slice - v0.8.2 Entity Index Surface
 
-v0.8.2 should introduce a Core-owned read-only entity index surface.
+v0.8.2 introduced the first Core-owned read-only entity index surface.
 
-The purpose is to let downstream tools ask:
+It answers:
 
 ```text
 What contract entities are defined in this mission?
 ```
 
-This surface must be built from the loaded and validated Mission Model, not from raw YAML scanning.
+v0.8.2 introduced:
 
-Candidate command:
+```text
+entity_index_to_dict(model, mission_dir)
+write_entity_index(model, mission_dir, output_file)
+orbitfabric export entity-index command
+entity_index.json report
+index_version 0.1
+kind orbitfabric.entity_index
+entity-level records
+per-domain entity counts
+per-domain model counts
+source file metadata
+required/present domain status
+indexed/not-indexed domain status
+explicit boundary flags
+Entity Index Surface reference documentation
+v0.8.2 release notes
+```
+
+Command:
 
 ```bash
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 ```
 
-Candidate output:
+v0.8.2 intentionally does not introduce:
 
 ```text
-entity_index.json
-```
-
-The initial surface should include:
-
-```text
-schema version
-OrbitFabric Core version
-mission identity
-entities
-domain
-entity id
-entity type
-display name when available
-source file
-provenance
-domain summary
-```
-
-v0.8.2 intentionally must not introduce:
-
-```text
+new Mission Model semantics
+relationship manifest
 relationship graph
 dependency graph
+source line or column tracking
+YAML AST export
 plugin API
 plugin discovery
-UI concerns
 Studio-specific API
-source line or column data unless the Core supports it reliably
-semantic expansion beyond the real Mission Model
+runtime behavior
+ground behavior
 ```
 
 ---
 
-## 15. Planned Milestone - v0.9 Plugin and Extensibility Layer
+## 9. Next Milestone - v0.9 Plugin and Extensibility Layer
 
 v0.9 should introduce controlled extension points only after the Core exposes the required introspection and entity surfaces.
 
@@ -520,7 +317,7 @@ The relationship manifest must remain partial or experimental if the Core does n
 
 ---
 
-## 16. Future Milestone - v1.0 Stable Mission Data Contract
+## 10. Future Milestone - v1.0 Stable Mission Data Contract
 
 v1.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
 
@@ -555,7 +352,7 @@ v1.0 should mean stable Mission Data Contract framework, not a complete space so
 
 ---
 
-## 17. Backlog Parking Lot
+## 11. Backlog Parking Lot
 
 These ideas are valid but must not distract from the active milestone.
 
@@ -597,7 +394,7 @@ example user implementation outside generated/
 
 ---
 
-## 18. Priority Rules
+## 12. Priority Rules
 
 When deciding what to implement next, use these rules.
 
@@ -619,33 +416,33 @@ When deciding what to implement next, use these rules.
 
 ---
 
-## 19. Immediate Work Plan
+## 13. Immediate Work Plan
 
 The immediate work package is:
 
 ```text
-v0.8.2 - Entity Index Surface
+v0.9 - Plugin and Extensibility Layer
 ```
 
 Required sequence:
 
 ```text
-1. define entity index shape
-2. keep the surface Core-owned and read-only
-3. derive entity records from the loaded Mission Model
-4. expose machine-readable JSON through an explicit export command
-5. avoid relationship output until v0.9 or later
-6. avoid plugin machinery until entity index semantics are clear
+1. classify public versus internal Core surfaces
+2. define plugin boundaries without allowing semantic override
+3. define discovery and metadata rules
+4. start with narrow, testable extension points
+5. require plugins to consume loaded MissionModel or Core-owned structured surfaces
+6. keep relationship manifests out unless they can be derived deterministically
 7. preserve the Mission Data Contract as source of truth
 ```
 
-Do not add plugin machinery before the entity index surface is clear.
+Do not let plugins reconstruct contract semantics from raw YAML, generated files or human-oriented CLI output.
 
-Do not let downstream tools reconstruct contract semantics from raw YAML, generated files or human-oriented CLI output.
+Do not let downstream tools become a second source of truth.
 
 ---
 
-## 20. Final Roadmap Statement
+## 14. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
@@ -659,7 +456,7 @@ The v0.8.0 roadmap step completed the first ground-facing contract export slice.
 
 The v0.8.1 roadmap step completed the first Core-owned contract introspection surface.
 
-The v0.8.2 roadmap step should add a stable Core-owned entity index surface for downstream tools.
+The v0.8.2 roadmap step completed the first Core-owned entity index surface for downstream tools.
 
 Only after the mission data chain, commandability, autonomy, end-to-end evidence, runtime-facing binding layer, ground-facing artifact layer, contract introspection and entity indexing are clear should OrbitFabric grow into plugin extensibility.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts and Core-owned introspection surfaces in a single Mission Data Contract.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces in a single Mission Data Contract.
 
 From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic integration and inspection artifacts.
 
@@ -11,10 +11,12 @@ From that contract, OrbitFabric validates consistency, generates documentation, 
 OrbitFabric is currently at:
 
 ```text
-v0.8.1 - Contract Introspection Surface
+v0.8.2 - Entity Index Surface
 ```
 
-In v0.8.1, Contract Introspection Surface means the first **Core-owned read-only model summary surface** derived from the loaded Mission Model.
+In v0.8.2, Entity Index Surface means the first **Core-owned read-only entity index surface** derived from the loaded Mission Model.
+
+It builds on v0.8.1, which introduced the domain-level `model_summary.json` surface.
 
 The current public preview includes:
 
@@ -46,6 +48,8 @@ The current public preview includes:
 - generated human-reviewable ground Markdown artifacts;
 - `orbitfabric export model-summary`;
 - generated `model_summary.json` contract introspection report;
+- `orbitfabric export entity-index`;
+- generated `entity_index.json` entity index report;
 - a clean-room synthetic `demo-3u` mission.
 
 ## Core Idea
@@ -65,6 +69,7 @@ Mission Model
   -> GroundContract
   -> generated ground-facing integration artifacts
   -> Core-owned contract introspection surfaces
+  -> Core-owned entity index surfaces
 ```
 
 OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
@@ -75,4 +80,4 @@ Generated runtime-facing contract bindings are not flight software.
 
 Generated ground integration artifacts are not ground software.
 
-Contract introspection surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.
+Contract introspection and entity index surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.

--- a/docs/reference/json-reports-v0.1.md
+++ b/docs/reference/json-reports-v0.1.md
@@ -47,7 +47,7 @@ Current lint report example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.8.1"
+  "version": "0.8.2"
 }
 ```
 
@@ -373,7 +373,7 @@ Compact example:
 ```json
 {
   "tool": "orbitfabric-sim",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mission": "demo-3u",
   "scenario": "payload_data_flow_evidence",
   "result": "passed",

--- a/docs/reference/lint-rules-v0.1.md
+++ b/docs/reference/lint-rules-v0.1.md
@@ -5,7 +5,7 @@ This page documents the diagnostics and lint rules currently implemented by Orbi
 Current documented baseline:
 
 ```text
-v0.8.1 - Contract Introspection Surface
+v0.8.2 - Entity Index Surface
 ```
 
 OrbitFabric diagnostics are intentionally actionable. A diagnostic should tell the user:
@@ -25,6 +25,8 @@ Diagnostics may be produced by different layers:
 Not every diagnostic listed here is produced by the same command.
 
 The `orbitfabric export model-summary` command consumes the already loaded Mission Model and reports loader diagnostics if the model cannot be loaded. It does not introduce a dedicated lint rule family in v0.8.1.
+
+The `orbitfabric export entity-index` command consumes the already loaded Mission Model and reports loader diagnostics if the model cannot be loaded. It does not introduce a dedicated lint rule family in v0.8.2.
 
 ---
 
@@ -215,7 +217,7 @@ expected_effects:
     - payload.radiation_histogram
 ```
 
-These rules ensure that the command-to-data-product link is explicit and valid before scenario evidence, generated data-flow documentation, runtime-facing contract bindings, ground-facing artifacts or contract introspection surfaces depend on it.
+These rules ensure that the command-to-data-product link is explicit and valid before scenario evidence, generated data-flow documentation, runtime-facing contract bindings, ground-facing artifacts or Core-owned structured surfaces depend on it.
 
 ---
 
@@ -404,6 +406,7 @@ Current behavior:
 |---|---|
 | `orbitfabric lint <mission-dir>` | Mission Model loading diagnostics, structural diagnostics, semantic lint findings. |
 | `orbitfabric export model-summary <mission-dir>` | Mission Model loading diagnostics before exporting the model summary report. |
+| `orbitfabric export entity-index <mission-dir>` | Mission Model loading diagnostics before exporting the entity index report. |
 | `orbitfabric gen docs <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric gen data-flow <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
 | `orbitfabric gen runtime <mission-dir>` | Mission Model loading diagnostics; generation aborts if lint errors exist. |
@@ -413,6 +416,8 @@ Current behavior:
 Ground artifact generation consumes the already validated Mission Model and aborts when lint errors exist. It does not add a dedicated ground-specific diagnostic family in v0.8.0.
 
 Model summary export consumes the loaded Mission Model and does not add a dedicated export-specific diagnostic family in v0.8.1.
+
+Entity index export consumes the loaded Mission Model and does not add a dedicated export-specific diagnostic family in v0.8.2.
 
 ---
 

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -9,7 +9,8 @@ OrbitFabric currently distinguishes between:
 - the version field written into generated JSON reports;
 - the generated runtime contract manifest context;
 - the generated ground contract manifest context;
-- the generated contract introspection report context.
+- the generated contract introspection report context;
+- the generated entity index report context.
 
 These versions are related, but they are not the same thing.
 
@@ -35,7 +36,7 @@ orbitfabric --version
 Current example:
 
 ```text
-orbitfabric 0.8.1
+orbitfabric 0.8.2
 ```
 
 This version answers the question:
@@ -88,7 +89,7 @@ Current lint report example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "mission": "demo-3u",
   "model_version": "0.1.0"
 }
@@ -189,6 +190,37 @@ It is not an entity index, relationship manifest, plugin API or Studio-specific 
 
 ---
 
+## Entity index report context
+
+v0.8.2 introduced the first Core-owned Entity Index Surface.
+
+The generated entity index report is written to:
+
+```text
+generated/reports/entity_index.json
+```
+
+It records the entity-level contract index derived from the loaded Mission Model.
+
+It includes:
+
+```text
+index_version
+kind = orbitfabric.entity_index
+OrbitFabric tool version
+mission identity
+source mission directory
+boundary flags
+domain summaries
+entity records
+```
+
+The entity index report is generated from the current OrbitFabric tool and the declared Mission Model.
+
+It is not a relationship manifest, dependency graph, plugin API or Studio-specific API.
+
+---
+
 ## Why the versions differ
 
 During development previews, OrbitFabric may evolve faster than the Mission Model contract.
@@ -196,7 +228,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.8.1
+OrbitFabric tool/package version: 0.8.2
 Mission Model version:           0.1.0
 ```
 
@@ -204,13 +236,13 @@ This is valid.
 
 It means:
 
-- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts and Contract Introspection Surfaces;
+- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts, Contract Introspection Surfaces and Entity Index Surfaces;
 - the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record the relevant tool and model context.
 
 ---
 
-## Current v0.8.1 rule
+## Current v0.8.2 rule
 
 For the current development preview:
 
@@ -227,6 +259,8 @@ For the current development preview:
 | Ground manifest `claims_*` compatibility fields | Explicit tool-specific claim flags, currently `false`. |
 | Model summary `summary_version` | Contract introspection report format version, currently `0.1`. |
 | Model summary `kind` | Contract introspection report kind, currently `orbitfabric.model_summary`. |
+| Entity index `index_version` | Entity index report format version, currently `0.1`. |
+| Entity index `kind` | Entity index report kind, currently `orbitfabric.entity_index`. |
 
 ---
 
@@ -240,7 +274,8 @@ Do not assume that:
 - generated artifacts are valid without checking both tool version and mission model version;
 - generated runtime-facing bindings are flight protocol IDs or flight software ABI guarantees;
 - generated ground-facing artifacts imply ground runtime behavior or tool-specific compatibility;
-- model summary reports imply entity-level indexing, relationship graphs or plugin APIs.
+- model summary reports imply entity-level indexing, relationship graphs or plugin APIs;
+- entity index reports imply relationship graphs, dependency graphs or plugin APIs.
 
 ---
 
@@ -259,4 +294,4 @@ Possible future additions include:
 - JSON Schema export for Mission Model validation;
 - compatibility checks for generated artifact profiles.
 
-These are not part of the current v0.8.1 development preview.
+These are not part of the current v0.8.2 development preview.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.8.1"
+version = "0.8.2"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"


### PR DESCRIPTION
## Summary

Aligns the public OrbitFabric baseline with `v0.8.2 - Entity Index Surface` after the functional and reference documentation PRs were merged.

This PR includes:

- package version bump to `0.8.2`
- runtime `__version__` bump to `0.8.2`
- README current-baseline alignment
- documentation home alignment
- roadmap alignment with `v0.8.2` completed and `v0.9` as next
- architecture alignment through Entity Index Surface
- project charter alignment through Entity Index Surface
- quickstart, development guide and contributing guide alignment
- demo walkthrough alignment
- versioning reference alignment
- JSON reports reference example alignment
- lint rules reference baseline and command coverage alignment
- changelog finalization for v0.8.2

## Scope Boundary

This is a release/version alignment PR.

It intentionally does not introduce:

- new Mission Model semantics
- new CLI commands
- new exporters
- new tests
- generated artifacts
- relationship manifest
- relationship graph
- dependency graph
- plugin API
- plugin discovery
- Studio-specific API
- runtime behavior
- ground behavior

The only code-level change is the package/runtime version string update.

## Validation

Required before merge:

```bash
ruff check .
pytest
mkdocs build --strict
```

Recommended release smoke checks:

```bash
orbitfabric --version

orbitfabric export model-summary examples/demo-3u/mission/ \
  --json generated/reports/model_summary.json

orbitfabric export entity-index examples/demo-3u/mission/ \
  --json generated/reports/entity_index.json

python -m json.tool generated/reports/model_summary.json > /tmp/model_summary_pretty.json
python -m json.tool generated/reports/entity_index.json > /tmp/entity_index_pretty.json
```

Expected CLI version:

```text
orbitfabric 0.8.2
```

Generated files under `generated/` must not be committed.