### PR TITLE
feat: add relationship manifest export skeleton

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orbitfabric import __version__
+from orbitfabric.export.entity_index import entity_index_to_dict
+from orbitfabric.model.mission import MissionModel
+
+
+def relationship_manifest_to_dict(
+    model: MissionModel,
+    mission_dir: Path,
+) -> dict[str, Any]:
+    """Return the candidate relationship manifest skeleton.
+
+    This function defines the deterministic envelope for the future
+    Relationship Manifest Surface.
+
+    It intentionally emits no relationship records yet.
+    Relationship types must be admitted one by one in later PRs, only when
+    they can be derived from explicit loaded Mission Model fields without
+    naming heuristics or downstream assumptions.
+    """
+    mission_dir = mission_dir.resolve()
+    entity_index = entity_index_to_dict(model, mission_dir)
+
+    return {
+        "manifest_version": "0.1-candidate",
+        "kind": "orbitfabric.relationship_manifest",
+        "orbitfabric_version": __version__,
+        "status": "candidate",
+        "mission": {
+            "id": model.spacecraft.id,
+            "name": model.spacecraft.name,
+            "model_version": model.spacecraft.model_version,
+        },
+        "source": {
+            "mission_dir": str(mission_dir),
+            "entity_index_kind": entity_index["kind"],
+            "entity_index_version": entity_index["index_version"],
+        },
+        "boundaries": {
+            "source_of_truth": "mission_model",
+            "core_derived_report": True,
+            "read_only": True,
+            "contains_entity_index": False,
+            "contains_entity_records": False,
+            "contains_relationship_manifest": True,
+            "contains_relationship_records": True,
+            "contains_relationship_graph": False,
+            "contains_dependency_graph": False,
+            "contains_yaml_ast": False,
+            "contains_source_locations": False,
+            "contains_plugin_api": False,
+            "contains_studio_api": False,
+            "contains_runtime_behavior": False,
+            "contains_ground_behavior": False,
+        },
+        "counts": {
+            "total_relationships": 0,
+            "relationship_types": {},
+        },
+        "relationship_types": [],
+        "relationships": [],
+        "derivation_policy": {
+            "requires_explicit_loaded_mission_model_fields": True,
+            "references_entity_index_entities": True,
+            "forbids_naming_heuristics": True,
+            "forbids_raw_yaml_scanning": True,
+            "forbids_downstream_assumptions": True,
+        },
+    }
+
+
+def write_relationship_manifest(
+    model: MissionModel,
+    mission_dir: Path,
+    output_file: Path,
+) -> Path:
+    """Write the candidate relationship manifest skeleton JSON file."""
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(
+        json.dumps(
+            relationship_manifest_to_dict(model, mission_dir),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return output_file

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orbitfabric import __version__
+from orbitfabric.export.relationship_manifest import (
+    relationship_manifest_to_dict,
+    write_relationship_manifest,
+)
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+
+
+def test_relationship_manifest_skeleton_contains_identity_and_boundaries() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
+
+    assert manifest["manifest_version"] == "0.1-candidate"
+    assert manifest["kind"] == "orbitfabric.relationship_manifest"
+    assert manifest["orbitfabric_version"] == __version__
+    assert manifest["status"] == "candidate"
+    assert manifest["mission"] == {
+        "id": "demo-3u",
+        "name": "Demo 3U Spacecraft",
+        "model_version": "0.1.0",
+    }
+    assert manifest["source"]["mission_dir"] == str(DEMO_MISSION.resolve())
+    assert manifest["source"]["entity_index_kind"] == "orbitfabric.entity_index"
+    assert manifest["source"]["entity_index_version"] == "0.1"
+    assert manifest["boundaries"] == {
+        "source_of_truth": "mission_model",
+        "core_derived_report": True,
+        "read_only": True,
+        "contains_entity_index": False,
+        "contains_entity_records": False,
+        "contains_relationship_manifest": True,
+        "contains_relationship_records": True,
+        "contains_relationship_graph": False,
+        "contains_dependency_graph": False,
+        "contains_yaml_ast": False,
+        "contains_source_locations": False,
+        "contains_plugin_api": False,
+        "contains_studio_api": False,
+        "contains_runtime_behavior": False,
+        "contains_ground_behavior": False,
+    }
+
+
+def test_relationship_manifest_skeleton_emits_no_relationship_records_yet() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
+
+    assert manifest["counts"] == {
+        "total_relationships": 0,
+        "relationship_types": {},
+    }
+    assert manifest["relationship_types"] == []
+    assert manifest["relationships"] == []
+
+
+def test_relationship_manifest_skeleton_declares_derivation_policy() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
+
+    assert manifest["derivation_policy"] == {
+        "requires_explicit_loaded_mission_model_fields": True,
+        "references_entity_index_entities": True,
+        "forbids_naming_heuristics": True,
+        "forbids_raw_yaml_scanning": True,
+        "forbids_downstream_assumptions": True,
+    }
+
+
+def test_write_relationship_manifest_is_deterministic_json(tmp_path: Path) -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    output_file = tmp_path / "relationship_manifest.json"
+
+    written_file = write_relationship_manifest(model, DEMO_MISSION, output_file)
+
+    assert written_file == output_file
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert content.endswith("\n")
+
+    parsed = json.loads(content)
+    assert parsed == relationship_manifest_to_dict(model, DEMO_MISSION)


### PR DESCRIPTION
## Summary

This PR adds the first code skeleton for the future Relationship Manifest Surface.

It introduces a deterministic candidate envelope for `orbitfabric.relationship_manifest`, but intentionally emits no relationship records yet.

The surface remains candidate and non-CLI-facing.

## Scope

Added:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`

## Boundary

This PR introduces:

- `relationship_manifest_to_dict(...)`
- `write_relationship_manifest(...)`
- manifest identity and boundary flags;
- explicit candidate status;
- empty `relationship_types`;
- empty `relationships`;
- deterministic JSON writer;
- derivation policy flags forbidding naming heuristics, raw YAML scanning and downstream assumptions.

## Intentional limitations

This PR intentionally does not:

- add CLI support;
- update `src/orbitfabric/export/__init__.py`;
- generate `generated/reports/relationship_manifest.json`;
- admit any relationship type;
- infer any relationship;
- scan raw YAML;
- add graph semantics;
- add plugin API;
- add Studio API;
- add runtime behavior;
- add ground behavior.

## Why this shape

The skeleton makes the future surface testable without pretending that relationship semantics already exist.

It also keeps the next implementation PR small: relationship families can be admitted one by one only after deterministic derivation from explicit loaded Mission Model fields is reviewed.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
