### PR TITLE
feat: add packet telemetry relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,11 +18,19 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface exists only as a candidate skeleton.
+At the current baseline, this surface emits one deliberately narrow relationship family:
 
-It can be exported by the CLI, but it intentionally emits no relationship records yet.
+```text
+packet_includes_telemetry
+```
 
-Relationship types must be admitted one by one in later PRs, only when they can be derived deterministically from explicit loaded Mission Model fields.
+This relationship is derived only from the explicit loaded Mission Model field:
+
+```text
+packets[].telemetry
+```
+
+No other relationship type is admitted yet.
 
 ---
 
@@ -52,19 +60,19 @@ It answers:
 What contract entities are defined in this mission?
 ```
 
-`relationship_manifest.json` is currently a candidate relationship surface skeleton.
+`relationship_manifest.json` is currently a candidate relationship surface.
 
-It answers no relationship question yet because no relationship types have been admitted.
+It emits only packet-to-telemetry inclusion records.
 
 `entity_index.json` contains nodes, not edges.
 
-The current candidate relationship manifest contains an empty edge set.
+The relationship manifest contains Core-owned edge records derived from explicit Mission Model references.
 
 ---
 
 ## CLI export
 
-The candidate skeleton can be exported with:
+The candidate manifest can be exported with:
 
 ```bash
 orbitfabric export relationship-manifest examples/demo-3u/mission
@@ -83,9 +91,7 @@ orbitfabric export relationship-manifest examples/demo-3u/mission \
   --json generated/reports/relationship_manifest.json
 ```
 
-The command exports a candidate skeleton only.
-
-It does not infer relationships.
+The command does not infer relationships.
 
 It does not generate a graph.
 
@@ -95,7 +101,7 @@ It does not expose plugin behavior.
 
 ## Surface classification
 
-The Relationship Manifest Surface candidate skeleton is:
+The Relationship Manifest Surface candidate is:
 
 ```text
 Core-derived
@@ -114,9 +120,9 @@ The relationship manifest is a derived inspection artifact.
 
 ---
 
-## Current skeleton shape
+## Current shape
 
-The current candidate skeleton contains:
+The current candidate manifest contains:
 
 ```json
 {
@@ -124,30 +130,36 @@ The current candidate skeleton contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 0,
-    "relationship_types": {}
+    "total_relationships": 5,
+    "relationship_types": {
+      "packet_includes_telemetry": 5
+    }
   },
-  "relationship_types": [],
+  "relationship_types": [
+    {
+      "relationship_type": "packet_includes_telemetry",
+      "display_name": "Packet includes telemetry",
+      "from_domain": "packets",
+      "to_domain": "telemetry",
+      "derived_from": {
+        "model_field": "packets[].telemetry"
+      },
+      "relationship_count": 5
+    }
+  ],
   "relationships": []
 }
 ```
 
-This is an intentionally empty relationship surface.
+The example count above reflects the demo mission.
 
-The empty relationship set means:
-
-```text
-relationship export envelope exists
-relationship semantics are not admitted yet
-no relationship records are emitted yet
-no graph is implied
-```
+The `relationships` list is populated deterministically from the loaded Mission Model.
 
 ---
 
 ## Boundary flags
 
-The candidate skeleton declares boundary flags equivalent to:
+The candidate manifest declares boundary flags equivalent to:
 
 ```json
 {
@@ -171,53 +183,66 @@ The candidate skeleton declares boundary flags equivalent to:
 
 These flags are part of the boundary definition.
 
-They do not mean that relationship semantics are complete.
+They do not make the manifest a graph, dependency graph, Studio API or plugin API.
 
 ---
 
-## Relationship records
+## Admitted relationship types
 
-A future relationship record must connect two indexed entities.
+### packet_includes_telemetry
 
-The conceptual shape is:
+This relationship states that a packet includes a telemetry item.
+
+It is derived from:
+
+```text
+packets[].telemetry
+```
+
+Relationship endpoints are:
+
+```text
+from: packets.<id>
+to: telemetry.<id>
+```
+
+Conceptual record shape:
 
 ```json
 {
-  "relationship_id": "command:payload.capture_image->target:payload.camera",
-  "relationship_type": "targets",
+  "relationship_id": "packets:hk_fast->packet_includes_telemetry:telemetry:obc.mode",
+  "relationship_type": "packet_includes_telemetry",
   "from": {
-    "domain": "commands",
-    "id": "payload.capture_image"
+    "domain": "packets",
+    "id": "hk_fast"
   },
   "to": {
-    "domain": "payloads",
-    "id": "payload.camera"
+    "domain": "telemetry",
+    "id": "obc.mode"
   },
   "derived_from": {
-    "model_field": "commands[].target"
+    "model_field": "packets[].telemetry"
   }
 }
 ```
 
-This example is illustrative only.
+This is a direct model reference.
 
-It is not a committed schema.
-
-The current candidate skeleton emits:
-
-```json
-[]
-```
-
-for `relationships`.
+It is not derived from naming conventions.
 
 ---
 
 ## Deterministic derivation rule
 
-Every future relationship record must be derived from an explicit field already present in the loaded Mission Model.
+Every relationship record must be derived from an explicit field already present in the loaded Mission Model.
 
-Allowed derivation sources may include explicit fields such as:
+Currently admitted derivation source:
+
+```text
+packets[].telemetry
+```
+
+Candidate future derivation sources may include explicit fields such as:
 
 ```text
 telemetry.source
@@ -228,7 +253,6 @@ event.source
 fault.source
 fault.emits
 fault.recovery.auto_commands
-packet.telemetry
 payload.subsystem
 payload.telemetry.produced
 payload.commands.accepted
@@ -259,9 +283,9 @@ recovery_intent.expected_events
 recovery_intent.expected_effects
 ```
 
-This list is illustrative.
+Candidate fields are illustrative only.
 
-A future implementation must admit relationship types one by one.
+Each new relationship type must be admitted one by one.
 
 Each admitted relationship type must be documented and tested.
 
@@ -269,7 +293,7 @@ Each admitted relationship type must be documented and tested.
 
 ## Forbidden derivation sources
 
-A future relationship manifest must not derive relationship records from:
+A relationship manifest must not derive relationship records from:
 
 ```text
 naming conventions
@@ -319,13 +343,13 @@ The semantic meaning of every rendered edge must still come from Core.
 
 ## Relationship manifest and entity index
 
-The relationship manifest must depend on the Entity Index Surface.
+The relationship manifest depends on the Entity Index Surface.
 
 A relationship record must refer to entities already indexed by `entity_index.json`.
 
 It must not create independent synthetic nodes.
 
-The current skeleton records its dependency on the entity index through:
+The current manifest records its dependency on the entity index through:
 
 ```json
 {
@@ -341,8 +365,6 @@ not be emitted
 be emitted only under an explicitly documented unresolved endpoint policy
 or remain unsupported
 ```
-
-The first relationship implementation should prefer not emitting unsupported or unresolved relationships.
 
 ---
 
@@ -360,7 +382,7 @@ A future plugin-contributed relationship-like artifact must be marked as plugin 
 
 ## Relationship manifest and Studio
 
-OrbitFabric Studio must not infer relationships before Core exposes them.
+OrbitFabric Studio must not infer relationships privately.
 
 The intended downstream chain is:
 
@@ -370,15 +392,15 @@ entity_index.json -> entity navigation
 relationship_manifest.json -> relationship navigation
 ```
 
-At the current baseline, Studio may inspect the candidate skeleton but must still treat relationship navigation as unavailable because the relationship set is empty and no relationship type has been admitted.
+Studio may consume admitted Core relationship records.
 
-Studio must not use the existence of the candidate skeleton as permission to infer graph edges privately.
+Studio must not invent missing relationship types or graph edges.
 
 ---
 
-## Candidate minimal relationship families
+## Candidate future relationship families
 
-A future first implementation may consider a small subset of explicit relationship families.
+A future implementation may consider additional explicit relationship families.
 
 Candidate families include:
 
@@ -386,7 +408,6 @@ Candidate families include:
 command targets subsystem or payload
 command emits event
 fault emits event
-packet includes telemetry item
 payload produces telemetry
 payload accepts command
 payload generates event
@@ -406,10 +427,9 @@ No relationship family is accepted until documented in an implementation PR.
 
 ## Non-goals
 
-The current candidate skeleton does not introduce:
+The current candidate manifest does not introduce:
 
 ```text
-relationship records
 relationship inference
 relationship graph
 relationship dependency analysis
@@ -428,7 +448,7 @@ ground behavior
 
 ## Acceptance criteria for future relationship records
 
-A future implementation PR that admits actual relationship records must satisfy all of the following:
+A future implementation PR that admits additional relationship records must satisfy all of the following:
 
 ```text
 admit a concrete relationship type
@@ -449,6 +469,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-The current implementation exposes only the deterministic candidate envelope.
+It currently emits only `packet_includes_telemetry` relationships.
 
-It may begin to carry relationship records in v0.9 only if Core can derive them deterministically from explicit Mission Model semantics.
+Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -453,7 +454,7 @@ def export_relationship_manifest(
         ),
     ] = Path("generated/reports/relationship_manifest.json"),
 ) -> None:
-    """Export a candidate Core-owned relationship manifest skeleton."""
+    """Export a candidate Core-owned relationship manifest."""
     typer.echo(f"OrbitFabric Relationship Manifest Export {__version__}")
 
     try:
@@ -463,11 +464,14 @@ def export_relationship_manifest(
         raise typer.Exit(code=1) from exc
 
     written_file = write_relationship_manifest(model, mission_dir, json_output)
+    relationship_count = json.loads(written_file.read_text(encoding="utf-8"))["counts"][
+        "total_relationships"
+    ]
 
     typer.echo(f"\nMission: {model.spacecraft.id}")
     typer.echo(f"Model version: {model.spacecraft.model_version}")
     typer.echo("Status: candidate")
-    typer.echo("Relationships emitted: 0")
+    typer.echo(f"Relationships emitted: {relationship_count}")
     typer.echo(f"JSON report written to: {written_file}")
     typer.echo("\nResult: PASSED")
 

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -6,25 +6,28 @@ from typing import Any
 
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
-from orbitfabric.model.mission import MissionModel
+from orbitfabric.model.mission import MissionModel, Packet
+
+REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 
 
 def relationship_manifest_to_dict(
     model: MissionModel,
     mission_dir: Path,
 ) -> dict[str, Any]:
-    """Return the candidate relationship manifest skeleton.
+    """Return a deterministic candidate relationship manifest.
 
     This function defines the deterministic envelope for the future
-    Relationship Manifest Surface.
+    Relationship Manifest Surface and emits only explicitly admitted
+    relationship families.
 
-    It intentionally emits no relationship records yet.
-    Relationship types must be admitted one by one in later PRs, only when
-    they can be derived from explicit loaded Mission Model fields without
-    naming heuristics or downstream assumptions.
+    Relationship records must be derived from explicit loaded Mission Model
+    fields without naming heuristics or downstream assumptions.
     """
     mission_dir = mission_dir.resolve()
     entity_index = entity_index_to_dict(model, mission_dir)
+    relationships = _relationship_records(model)
+    relationship_type_counts = _relationship_type_counts(relationships)
 
     return {
         "manifest_version": "0.1-candidate",
@@ -59,11 +62,11 @@ def relationship_manifest_to_dict(
             "contains_ground_behavior": False,
         },
         "counts": {
-            "total_relationships": 0,
-            "relationship_types": {},
+            "total_relationships": len(relationships),
+            "relationship_types": relationship_type_counts,
         },
-        "relationship_types": [],
-        "relationships": [],
+        "relationship_types": _relationship_types(relationship_type_counts),
+        "relationships": relationships,
         "derivation_policy": {
             "requires_explicit_loaded_mission_model_fields": True,
             "references_entity_index_entities": True,
@@ -79,7 +82,7 @@ def write_relationship_manifest(
     mission_dir: Path,
     output_file: Path,
 ) -> Path:
-    """Write the candidate relationship manifest skeleton JSON file."""
+    """Write the candidate relationship manifest JSON file."""
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output_file.write_text(
         json.dumps(
@@ -91,3 +94,65 @@ def write_relationship_manifest(
         encoding="utf-8",
     )
     return output_file
+
+
+def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
+    return [
+        record
+        for packet in sorted(model.packets, key=lambda item: item.id)
+        for record in _packet_telemetry_relationship_records(packet)
+    ]
+
+
+def _packet_telemetry_relationship_records(packet: Packet) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"packets:{packet.id}->{REL_PACKET_INCLUDES_TELEMETRY}:"
+                f"telemetry:{telemetry_id}"
+            ),
+            "relationship_type": REL_PACKET_INCLUDES_TELEMETRY,
+            "from": {
+                "domain": "packets",
+                "id": packet.id,
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": telemetry_id,
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        }
+        for telemetry_id in sorted(packet.telemetry)
+    ]
+
+
+def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for relationship in relationships:
+        relationship_type = relationship["relationship_type"]
+        counts[relationship_type] = counts.get(relationship_type, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
+    specs = {
+        REL_PACKET_INCLUDES_TELEMETRY: {
+            "relationship_type": REL_PACKET_INCLUDES_TELEMETRY,
+            "display_name": "Packet includes telemetry",
+            "from_domain": "packets",
+            "to_domain": "telemetry",
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+    }
+
+    return [
+        {
+            **specs[relationship_type],
+            "relationship_count": count,
+        }
+        for relationship_type, count in sorted(type_counts.items())
+    ]

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 0" in result.output
+    assert "Relationships emitted: 5" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,9 +40,12 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 0
-    assert manifest["relationship_types"] == []
-    assert manifest["relationships"] == []
+    assert manifest["counts"]["total_relationships"] == 5
+    assert manifest["counts"]["relationship_types"] == {
+        "packet_includes_telemetry": 5,
+    }
+    assert len(manifest["relationship_types"]) == 1
+    assert len(manifest["relationships"]) == 5
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -13,7 +13,7 @@ from orbitfabric.model.loader import MissionModelLoader
 DEMO_MISSION = Path("examples/demo-3u/mission")
 
 
-def test_relationship_manifest_skeleton_contains_identity_and_boundaries() -> None:
+def test_relationship_manifest_contains_identity_and_boundaries() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
@@ -49,20 +49,137 @@ def test_relationship_manifest_skeleton_contains_identity_and_boundaries() -> No
     }
 
 
-def test_relationship_manifest_skeleton_emits_no_relationship_records_yet() -> None:
+def test_relationship_manifest_emits_packet_telemetry_relationship_records() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 0,
-        "relationship_types": {},
+        "total_relationships": 5,
+        "relationship_types": {
+            "packet_includes_telemetry": 5,
+        },
     }
-    assert manifest["relationship_types"] == []
-    assert manifest["relationships"] == []
+    assert manifest["relationship_types"] == [
+        {
+            "relationship_type": "packet_includes_telemetry",
+            "display_name": "Packet includes telemetry",
+            "from_domain": "packets",
+            "to_domain": "telemetry",
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+            "relationship_count": 5,
+        }
+    ]
+    assert manifest["relationships"] == [
+        {
+            "relationship_id": (
+                "packets:comm_status->packet_includes_telemetry:"
+                "telemetry:radio.downlink.available"
+            ),
+            "relationship_type": "packet_includes_telemetry",
+            "from": {
+                "domain": "packets",
+                "id": "comm_status",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "radio.downlink.available",
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+        {
+            "relationship_id": (
+                "packets:hk_fast->packet_includes_telemetry:telemetry:eps.battery.current"
+            ),
+            "relationship_type": "packet_includes_telemetry",
+            "from": {
+                "domain": "packets",
+                "id": "hk_fast",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "eps.battery.current",
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+        {
+            "relationship_id": (
+                "packets:hk_fast->packet_includes_telemetry:telemetry:eps.battery.voltage"
+            ),
+            "relationship_type": "packet_includes_telemetry",
+            "from": {
+                "domain": "packets",
+                "id": "hk_fast",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "eps.battery.voltage",
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+        {
+            "relationship_id": "packets:hk_fast->packet_includes_telemetry:telemetry:obc.mode",
+            "relationship_type": "packet_includes_telemetry",
+            "from": {
+                "domain": "packets",
+                "id": "hk_fast",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "obc.mode",
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+        {
+            "relationship_id": (
+                "packets:payload_status->packet_includes_telemetry:"
+                "telemetry:payload.acquisition.active"
+            ),
+            "relationship_type": "packet_includes_telemetry",
+            "from": {
+                "domain": "packets",
+                "id": "payload_status",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "payload.acquisition.active",
+            },
+            "derived_from": {
+                "model_field": "packets[].telemetry",
+            },
+        },
+    ]
 
 
-def test_relationship_manifest_skeleton_declares_derivation_policy() -> None:
+def test_relationship_manifest_relationships_reference_indexed_entities() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+
+    manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
+    packet_ids = {packet.id for packet in model.packets}
+    telemetry_ids = {telemetry.id for telemetry in model.telemetry}
+
+    for relationship in manifest["relationships"]:
+        assert relationship["relationship_type"] == "packet_includes_telemetry"
+        assert relationship["from"]["domain"] == "packets"
+        assert relationship["from"]["id"] in packet_ids
+        assert relationship["to"]["domain"] == "telemetry"
+        assert relationship["to"]["id"] in telemetry_ids
+        assert relationship["derived_from"] == {
+            "model_field": "packets[].telemetry",
+        }
+
+
+def test_relationship_manifest_declares_derivation_policy() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)


### PR DESCRIPTION
## Summary

This PR admits the first deterministic relationship family into the candidate Relationship Manifest Surface:

```text
packet_includes_telemetry
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
packets[].telemetry
```

For the demo mission, this emits 5 relationship records.

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `src/orbitfabric/cli.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one admitted relationship type:

```text
packet_includes_telemetry
```

It does not add any other relationship family.

It does not use naming heuristics.

It does not scan raw YAML.

It does not infer graph edges from IDs, filenames, generated docs, CLI output or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 5,
    "relationship_types": {
      "packet_includes_telemetry": 5
    }
  }
}
```

for the demo mission.

Relationship records use:

```text
from.domain = packets
from.id = <packet id>
to.domain = telemetry
to.id = <telemetry id>
derived_from.model_field = packets[].telemetry
```

## Non-goals

This PR intentionally does not introduce:

- command relationships;
- fault relationships;
- payload relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
