### PR TITLE
feat: add payload telemetry relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,16 +18,18 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits one deliberately narrow relationship family:
+At the current baseline, this surface emits two deliberately narrow relationship families:
 
 ```text
 packet_includes_telemetry
+payload_produces_telemetry
 ```
 
-This relationship is derived only from the explicit loaded Mission Model field:
+These relationships are derived only from explicit loaded Mission Model fields:
 
 ```text
 packets[].telemetry
+payloads[].telemetry.produced
 ```
 
 No other relationship type is admitted yet.
@@ -62,7 +64,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits only packet-to-telemetry inclusion records.
+It emits packet-to-telemetry inclusion records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -130,9 +132,10 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 5,
+    "total_relationships": 6,
     "relationship_types": {
-      "packet_includes_telemetry": 5
+      "packet_includes_telemetry": 5,
+      "payload_produces_telemetry": 1
     }
   },
   "relationship_types": [
@@ -145,6 +148,16 @@ The current candidate manifest contains:
         "model_field": "packets[].telemetry"
       },
       "relationship_count": 5
+    },
+    {
+      "relationship_type": "payload_produces_telemetry",
+      "display_name": "Payload produces telemetry",
+      "from_domain": "payloads",
+      "to_domain": "telemetry",
+      "derived_from": {
+        "model_field": "payloads[].telemetry.produced"
+      },
+      "relationship_count": 1
     }
   ],
   "relationships": []
@@ -230,16 +243,58 @@ This is a direct model reference.
 
 It is not derived from naming conventions.
 
+### payload_produces_telemetry
+
+This relationship states that a payload produces a telemetry item.
+
+It is derived from:
+
+```text
+payloads[].telemetry.produced
+```
+
+Relationship endpoints are:
+
+```text
+from: payloads.<id>
+to: telemetry.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "payloads:demo_iod_payload->payload_produces_telemetry:telemetry:payload.acquisition.active",
+  "relationship_type": "payload_produces_telemetry",
+  "from": {
+    "domain": "payloads",
+    "id": "demo_iod_payload"
+  },
+  "to": {
+    "domain": "telemetry",
+    "id": "payload.acquisition.active"
+  },
+  "derived_from": {
+    "model_field": "payloads[].telemetry.produced"
+  }
+}
+```
+
+This is a direct payload contract reference.
+
+It is not derived from telemetry ID prefixes or payload naming conventions.
+
 ---
 
 ## Deterministic derivation rule
 
 Every relationship record must be derived from an explicit field already present in the loaded Mission Model.
 
-Currently admitted derivation source:
+Currently admitted derivation sources:
 
 ```text
 packets[].telemetry
+payloads[].telemetry.produced
 ```
 
 Candidate future derivation sources may include explicit fields such as:
@@ -254,7 +309,6 @@ fault.source
 fault.emits
 fault.recovery.auto_commands
 payload.subsystem
-payload.telemetry.produced
 payload.commands.accepted
 payload.events.generated
 payload.faults.possible
@@ -408,7 +462,6 @@ Candidate families include:
 command targets subsystem or payload
 command emits event
 fault emits event
-payload produces telemetry
 payload accepts command
 payload generates event
 payload may raise fault
@@ -469,6 +522,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits only `packet_includes_telemetry` relationships.
+It currently emits `packet_includes_telemetry` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -6,9 +6,10 @@ from typing import Any
 
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
-from orbitfabric.model.mission import MissionModel, Packet
+from orbitfabric.model.mission import MissionModel, Packet, PayloadContract
 
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
+REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
 
 
 def relationship_manifest_to_dict(
@@ -97,11 +98,17 @@ def write_relationship_manifest(
 
 
 def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
-    return [
+    records = [
         record
         for packet in sorted(model.packets, key=lambda item: item.id)
         for record in _packet_telemetry_relationship_records(packet)
     ]
+    records.extend(
+        record
+        for payload in sorted(model.payloads, key=lambda item: item.id)
+        for record in _payload_telemetry_relationship_records(payload)
+    )
+    return sorted(records, key=lambda item: item["relationship_id"])
 
 
 def _packet_telemetry_relationship_records(packet: Packet) -> list[dict[str, Any]]:
@@ -128,6 +135,32 @@ def _packet_telemetry_relationship_records(packet: Packet) -> list[dict[str, Any
     ]
 
 
+def _payload_telemetry_relationship_records(
+    payload: PayloadContract,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"payloads:{payload.id}->{REL_PAYLOAD_PRODUCES_TELEMETRY}:"
+                f"telemetry:{telemetry_id}"
+            ),
+            "relationship_type": REL_PAYLOAD_PRODUCES_TELEMETRY,
+            "from": {
+                "domain": "payloads",
+                "id": payload.id,
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": telemetry_id,
+            },
+            "derived_from": {
+                "model_field": "payloads[].telemetry.produced",
+            },
+        }
+        for telemetry_id in sorted(payload.telemetry.produced)
+    ]
+
+
 def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for relationship in relationships:
@@ -145,6 +178,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "telemetry",
             "derived_from": {
                 "model_field": "packets[].telemetry",
+            },
+        },
+        REL_PAYLOAD_PRODUCES_TELEMETRY: {
+            "relationship_type": REL_PAYLOAD_PRODUCES_TELEMETRY,
+            "display_name": "Payload produces telemetry",
+            "from_domain": "payloads",
+            "to_domain": "telemetry",
+            "derived_from": {
+                "model_field": "payloads[].telemetry.produced",
             },
         },
     }

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 5" in result.output
+    assert "Relationships emitted: 6" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,12 +40,13 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 5
+    assert manifest["counts"]["total_relationships"] == 6
     assert manifest["counts"]["relationship_types"] == {
         "packet_includes_telemetry": 5,
+        "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 1
-    assert len(manifest["relationships"]) == 5
+    assert len(manifest["relationship_types"]) == 2
+    assert len(manifest["relationships"]) == 6
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -49,15 +49,16 @@ def test_relationship_manifest_contains_identity_and_boundaries() -> None:
     }
 
 
-def test_relationship_manifest_emits_packet_telemetry_relationship_records() -> None:
+def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 5,
+        "total_relationships": 6,
         "relationship_types": {
             "packet_includes_telemetry": 5,
+            "payload_produces_telemetry": 1,
         },
     }
     assert manifest["relationship_types"] == [
@@ -70,7 +71,17 @@ def test_relationship_manifest_emits_packet_telemetry_relationship_records() -> 
                 "model_field": "packets[].telemetry",
             },
             "relationship_count": 5,
-        }
+        },
+        {
+            "relationship_type": "payload_produces_telemetry",
+            "display_name": "Payload produces telemetry",
+            "from_domain": "payloads",
+            "to_domain": "telemetry",
+            "derived_from": {
+                "model_field": "payloads[].telemetry.produced",
+            },
+            "relationship_count": 1,
+        },
     ]
     assert manifest["relationships"] == [
         {
@@ -158,6 +169,24 @@ def test_relationship_manifest_emits_packet_telemetry_relationship_records() -> 
                 "model_field": "packets[].telemetry",
             },
         },
+        {
+            "relationship_id": (
+                "payloads:demo_iod_payload->payload_produces_telemetry:"
+                "telemetry:payload.acquisition.active"
+            ),
+            "relationship_type": "payload_produces_telemetry",
+            "from": {
+                "domain": "payloads",
+                "id": "demo_iod_payload",
+            },
+            "to": {
+                "domain": "telemetry",
+                "id": "payload.acquisition.active",
+            },
+            "derived_from": {
+                "model_field": "payloads[].telemetry.produced",
+            },
+        },
     ]
 
 
@@ -166,17 +195,27 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
     packet_ids = {packet.id for packet in model.packets}
+    payload_ids = {payload.id for payload in model.payloads}
     telemetry_ids = {telemetry.id for telemetry in model.telemetry}
 
     for relationship in manifest["relationships"]:
-        assert relationship["relationship_type"] == "packet_includes_telemetry"
-        assert relationship["from"]["domain"] == "packets"
-        assert relationship["from"]["id"] in packet_ids
         assert relationship["to"]["domain"] == "telemetry"
         assert relationship["to"]["id"] in telemetry_ids
-        assert relationship["derived_from"] == {
-            "model_field": "packets[].telemetry",
-        }
+
+        if relationship["relationship_type"] == "packet_includes_telemetry":
+            assert relationship["from"]["domain"] == "packets"
+            assert relationship["from"]["id"] in packet_ids
+            assert relationship["derived_from"] == {
+                "model_field": "packets[].telemetry",
+            }
+        elif relationship["relationship_type"] == "payload_produces_telemetry":
+            assert relationship["from"]["domain"] == "payloads"
+            assert relationship["from"]["id"] in payload_ids
+            assert relationship["derived_from"] == {
+                "model_field": "payloads[].telemetry.produced",
+            }
+        else:
+            raise AssertionError("unexpected relationship type")
 
 
 def test_relationship_manifest_declares_derivation_policy() -> None:


### PR DESCRIPTION
## Summary

This PR admits the second deterministic relationship family into the candidate Relationship Manifest Surface:

```text
payload_produces_telemetry
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
payloads[].telemetry.produced
```

For the demo mission, this adds 1 payload-to-telemetry relationship record.

The demo manifest now emits 6 relationships total:

- 5 `packet_includes_telemetry`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
payload_produces_telemetry
```

It does not add any other payload relationship family.

It does not use telemetry ID prefixes, payload naming conventions, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 6,
    "relationship_types": {
      "packet_includes_telemetry": 5,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Payload telemetry relationship records use:

```text
from.domain = payloads
from.id = <payload id>
to.domain = telemetry
to.id = <telemetry id>
derived_from.model_field = payloads[].telemetry.produced
```

## Non-goals

This PR intentionally does not introduce:

- payload accepts command relationships;
- payload generates event relationships;
- payload may raise fault relationships;
- payload subsystem relationships;
- command relationships;
- fault relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
