### PR TITLE
feat: add payload command relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,10 +18,11 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits two deliberately narrow relationship families:
+At the current baseline, this surface emits three deliberately narrow relationship families:
 
 ```text
 packet_includes_telemetry
+payload_accepts_command
 payload_produces_telemetry
 ```
 
@@ -29,6 +30,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 
 ```text
 packets[].telemetry
+payloads[].commands.accepted
 payloads[].telemetry.produced
 ```
 
@@ -64,7 +66,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits packet-to-telemetry inclusion records and payload-to-telemetry production records.
+It emits packet-to-telemetry inclusion records, payload-to-command acceptance records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -132,9 +134,10 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 6,
+    "total_relationships": 8,
     "relationship_types": {
       "packet_includes_telemetry": 5,
+      "payload_accepts_command": 2,
       "payload_produces_telemetry": 1
     }
   },
@@ -148,6 +151,16 @@ The current candidate manifest contains:
         "model_field": "packets[].telemetry"
       },
       "relationship_count": 5
+    },
+    {
+      "relationship_type": "payload_accepts_command",
+      "display_name": "Payload accepts command",
+      "from_domain": "payloads",
+      "to_domain": "commands",
+      "derived_from": {
+        "model_field": "payloads[].commands.accepted"
+      },
+      "relationship_count": 2
     },
     {
       "relationship_type": "payload_produces_telemetry",
@@ -243,6 +256,47 @@ This is a direct model reference.
 
 It is not derived from naming conventions.
 
+### payload_accepts_command
+
+This relationship states that a payload accepts a command.
+
+It is derived from:
+
+```text
+payloads[].commands.accepted
+```
+
+Relationship endpoints are:
+
+```text
+from: payloads.<id>
+to: commands.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "payloads:demo_iod_payload->payload_accepts_command:commands:payload.start_acquisition",
+  "relationship_type": "payload_accepts_command",
+  "from": {
+    "domain": "payloads",
+    "id": "demo_iod_payload"
+  },
+  "to": {
+    "domain": "commands",
+    "id": "payload.start_acquisition"
+  },
+  "derived_from": {
+    "model_field": "payloads[].commands.accepted"
+  }
+}
+```
+
+This is a direct payload contract reference.
+
+It is not derived from command ID prefixes, payload naming conventions or command targets.
+
 ### payload_produces_telemetry
 
 This relationship states that a payload produces a telemetry item.
@@ -294,6 +348,7 @@ Currently admitted derivation sources:
 
 ```text
 packets[].telemetry
+payloads[].commands.accepted
 payloads[].telemetry.produced
 ```
 
@@ -309,7 +364,6 @@ fault.source
 fault.emits
 fault.recovery.auto_commands
 payload.subsystem
-payload.commands.accepted
 payload.events.generated
 payload.faults.possible
 data_product.producer
@@ -462,7 +516,6 @@ Candidate families include:
 command targets subsystem or payload
 command emits event
 fault emits event
-payload accepts command
 payload generates event
 payload may raise fault
 data product produced by payload or subsystem
@@ -522,6 +575,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `packet_includes_telemetry` and `payload_produces_telemetry` relationships.
+It currently emits `packet_includes_telemetry`, `payload_accepts_command` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -9,6 +9,7 @@ from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import MissionModel, Packet, PayloadContract
 
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
+REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
 
 
@@ -108,6 +109,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         for payload in sorted(model.payloads, key=lambda item: item.id)
         for record in _payload_telemetry_relationship_records(payload)
     )
+    records.extend(
+        record
+        for payload in sorted(model.payloads, key=lambda item: item.id)
+        for record in _payload_command_relationship_records(payload)
+    )
     return sorted(records, key=lambda item: item["relationship_id"])
 
 
@@ -161,6 +167,32 @@ def _payload_telemetry_relationship_records(
     ]
 
 
+def _payload_command_relationship_records(
+    payload: PayloadContract,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"payloads:{payload.id}->{REL_PAYLOAD_ACCEPTS_COMMAND}:"
+                f"commands:{command_id}"
+            ),
+            "relationship_type": REL_PAYLOAD_ACCEPTS_COMMAND,
+            "from": {
+                "domain": "payloads",
+                "id": payload.id,
+            },
+            "to": {
+                "domain": "commands",
+                "id": command_id,
+            },
+            "derived_from": {
+                "model_field": "payloads[].commands.accepted",
+            },
+        }
+        for command_id in sorted(payload.commands.accepted)
+    ]
+
+
 def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for relationship in relationships:
@@ -178,6 +210,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "telemetry",
             "derived_from": {
                 "model_field": "packets[].telemetry",
+            },
+        },
+        REL_PAYLOAD_ACCEPTS_COMMAND: {
+            "relationship_type": REL_PAYLOAD_ACCEPTS_COMMAND,
+            "display_name": "Payload accepts command",
+            "from_domain": "payloads",
+            "to_domain": "commands",
+            "derived_from": {
+                "model_field": "payloads[].commands.accepted",
             },
         },
         REL_PAYLOAD_PRODUCES_TELEMETRY: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 6" in result.output
+    assert "Relationships emitted: 8" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,13 +40,14 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 6
+    assert manifest["counts"]["total_relationships"] == 8
     assert manifest["counts"]["relationship_types"] == {
         "packet_includes_telemetry": 5,
+        "payload_accepts_command": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 2
-    assert len(manifest["relationships"]) == 6
+    assert len(manifest["relationship_types"]) == 3
+    assert len(manifest["relationships"]) == 8
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,9 +55,10 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 6,
+        "total_relationships": 8,
         "relationship_types": {
             "packet_includes_telemetry": 5,
+            "payload_accepts_command": 2,
             "payload_produces_telemetry": 1,
         },
     }
@@ -71,6 +72,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
                 "model_field": "packets[].telemetry",
             },
             "relationship_count": 5,
+        },
+        {
+            "relationship_type": "payload_accepts_command",
+            "display_name": "Payload accepts command",
+            "from_domain": "payloads",
+            "to_domain": "commands",
+            "derived_from": {
+                "model_field": "payloads[].commands.accepted",
+            },
+            "relationship_count": 2,
         },
         {
             "relationship_type": "payload_produces_telemetry",
@@ -171,6 +182,42 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         },
         {
             "relationship_id": (
+                "payloads:demo_iod_payload->payload_accepts_command:"
+                "commands:payload.start_acquisition"
+            ),
+            "relationship_type": "payload_accepts_command",
+            "from": {
+                "domain": "payloads",
+                "id": "demo_iod_payload",
+            },
+            "to": {
+                "domain": "commands",
+                "id": "payload.start_acquisition",
+            },
+            "derived_from": {
+                "model_field": "payloads[].commands.accepted",
+            },
+        },
+        {
+            "relationship_id": (
+                "payloads:demo_iod_payload->payload_accepts_command:"
+                "commands:payload.stop_acquisition"
+            ),
+            "relationship_type": "payload_accepts_command",
+            "from": {
+                "domain": "payloads",
+                "id": "demo_iod_payload",
+            },
+            "to": {
+                "domain": "commands",
+                "id": "payload.stop_acquisition",
+            },
+            "derived_from": {
+                "model_field": "payloads[].commands.accepted",
+            },
+        },
+        {
+            "relationship_id": (
                 "payloads:demo_iod_payload->payload_produces_telemetry:"
                 "telemetry:payload.acquisition.active"
             ),
@@ -197,20 +244,30 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     packet_ids = {packet.id for packet in model.packets}
     payload_ids = {payload.id for payload in model.payloads}
     telemetry_ids = {telemetry.id for telemetry in model.telemetry}
+    command_ids = {command.id for command in model.commands}
 
     for relationship in manifest["relationships"]:
-        assert relationship["to"]["domain"] == "telemetry"
-        assert relationship["to"]["id"] in telemetry_ids
-
         if relationship["relationship_type"] == "packet_includes_telemetry":
             assert relationship["from"]["domain"] == "packets"
             assert relationship["from"]["id"] in packet_ids
+            assert relationship["to"]["domain"] == "telemetry"
+            assert relationship["to"]["id"] in telemetry_ids
             assert relationship["derived_from"] == {
                 "model_field": "packets[].telemetry",
+            }
+        elif relationship["relationship_type"] == "payload_accepts_command":
+            assert relationship["from"]["domain"] == "payloads"
+            assert relationship["from"]["id"] in payload_ids
+            assert relationship["to"]["domain"] == "commands"
+            assert relationship["to"]["id"] in command_ids
+            assert relationship["derived_from"] == {
+                "model_field": "payloads[].commands.accepted",
             }
         elif relationship["relationship_type"] == "payload_produces_telemetry":
             assert relationship["from"]["domain"] == "payloads"
             assert relationship["from"]["id"] in payload_ids
+            assert relationship["to"]["domain"] == "telemetry"
+            assert relationship["to"]["id"] in telemetry_ids
             assert relationship["derived_from"] == {
                 "model_field": "payloads[].telemetry.produced",
             }


### PR DESCRIPTION
## Summary

This PR admits the third deterministic relationship family into the candidate Relationship Manifest Surface:

```text
payload_accepts_command
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
payloads[].commands.accepted
```

For the demo mission, this adds 2 payload-to-command relationship records.

The demo manifest now emits 8 relationships total:

- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
payload_accepts_command
```

It does not add any other payload relationship family.

It does not use command ID prefixes, payload naming conventions, command targets, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 8,
    "relationship_types": {
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Payload command relationship records use:

```text
from.domain = payloads
from.id = <payload id>
to.domain = commands
to.id = <command id>
derived_from.model_field = payloads[].commands.accepted
```

## Non-goals

This PR intentionally does not introduce:

- payload generates event relationships;
- payload may raise fault relationships;
- payload subsystem relationships;
- command target relationships;
- command emits event relationships;
- fault relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
