### PR TITLE
feat: add payload event relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,11 +18,12 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits three deliberately narrow relationship families:
+At the current baseline, this surface emits four deliberately narrow relationship families:
 
 ```text
 packet_includes_telemetry
 payload_accepts_command
+payload_generates_event
 payload_produces_telemetry
 ```
 
@@ -31,6 +32,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 ```text
 packets[].telemetry
 payloads[].commands.accepted
+payloads[].events.generated
 payloads[].telemetry.produced
 ```
 
@@ -66,7 +68,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits packet-to-telemetry inclusion records, payload-to-command acceptance records and payload-to-telemetry production records.
+It emits packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -134,10 +136,11 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 8,
+    "total_relationships": 10,
     "relationship_types": {
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
+      "payload_generates_event": 2,
       "payload_produces_telemetry": 1
     }
   },
@@ -159,6 +162,16 @@ The current candidate manifest contains:
       "to_domain": "commands",
       "derived_from": {
         "model_field": "payloads[].commands.accepted"
+      },
+      "relationship_count": 2
+    },
+    {
+      "relationship_type": "payload_generates_event",
+      "display_name": "Payload generates event",
+      "from_domain": "payloads",
+      "to_domain": "events",
+      "derived_from": {
+        "model_field": "payloads[].events.generated"
       },
       "relationship_count": 2
     },
@@ -297,6 +310,47 @@ This is a direct payload contract reference.
 
 It is not derived from command ID prefixes, payload naming conventions or command targets.
 
+### payload_generates_event
+
+This relationship states that a payload generates an event.
+
+It is derived from:
+
+```text
+payloads[].events.generated
+```
+
+Relationship endpoints are:
+
+```text
+from: payloads.<id>
+to: events.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
+  "relationship_type": "payload_generates_event",
+  "from": {
+    "domain": "payloads",
+    "id": "demo_iod_payload"
+  },
+  "to": {
+    "domain": "events",
+    "id": "payload.acquisition_started"
+  },
+  "derived_from": {
+    "model_field": "payloads[].events.generated"
+  }
+}
+```
+
+This is a direct payload contract reference.
+
+It is not derived from event ID prefixes, event sources or payload naming conventions.
+
 ### payload_produces_telemetry
 
 This relationship states that a payload produces a telemetry item.
@@ -349,6 +403,7 @@ Currently admitted derivation sources:
 ```text
 packets[].telemetry
 payloads[].commands.accepted
+payloads[].events.generated
 payloads[].telemetry.produced
 ```
 
@@ -364,7 +419,6 @@ fault.source
 fault.emits
 fault.recovery.auto_commands
 payload.subsystem
-payload.events.generated
 payload.faults.possible
 data_product.producer
 data_product.payload
@@ -516,7 +570,6 @@ Candidate families include:
 command targets subsystem or payload
 command emits event
 fault emits event
-payload generates event
 payload may raise fault
 data product produced by payload or subsystem
 downlink flow includes data product
@@ -575,6 +628,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `packet_includes_telemetry`, `payload_accepts_command` and `payload_produces_telemetry` relationships.
+It currently emits `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -10,6 +10,7 @@ from orbitfabric.model.mission import MissionModel, Packet, PayloadContract
 
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
+REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
 
 
@@ -114,6 +115,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         for payload in sorted(model.payloads, key=lambda item: item.id)
         for record in _payload_command_relationship_records(payload)
     )
+    records.extend(
+        record
+        for payload in sorted(model.payloads, key=lambda item: item.id)
+        for record in _payload_event_relationship_records(payload)
+    )
     return sorted(records, key=lambda item: item["relationship_id"])
 
 
@@ -193,6 +199,32 @@ def _payload_command_relationship_records(
     ]
 
 
+def _payload_event_relationship_records(
+    payload: PayloadContract,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"payloads:{payload.id}->{REL_PAYLOAD_GENERATES_EVENT}:"
+                f"events:{event_id}"
+            ),
+            "relationship_type": REL_PAYLOAD_GENERATES_EVENT,
+            "from": {
+                "domain": "payloads",
+                "id": payload.id,
+            },
+            "to": {
+                "domain": "events",
+                "id": event_id,
+            },
+            "derived_from": {
+                "model_field": "payloads[].events.generated",
+            },
+        }
+        for event_id in sorted(payload.events.generated)
+    ]
+
+
 def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for relationship in relationships:
@@ -219,6 +251,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "commands",
             "derived_from": {
                 "model_field": "payloads[].commands.accepted",
+            },
+        },
+        REL_PAYLOAD_GENERATES_EVENT: {
+            "relationship_type": REL_PAYLOAD_GENERATES_EVENT,
+            "display_name": "Payload generates event",
+            "from_domain": "payloads",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "payloads[].events.generated",
             },
         },
         REL_PAYLOAD_PRODUCES_TELEMETRY: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 8" in result.output
+    assert "Relationships emitted: 10" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,14 +40,15 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 8
+    assert manifest["counts"]["total_relationships"] == 10
     assert manifest["counts"]["relationship_types"] == {
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
+        "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 3
-    assert len(manifest["relationships"]) == 8
+    assert len(manifest["relationship_types"]) == 4
+    assert len(manifest["relationships"]) == 10
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,10 +55,11 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 8,
+        "total_relationships": 10,
         "relationship_types": {
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
+            "payload_generates_event": 2,
             "payload_produces_telemetry": 1,
         },
     }
@@ -84,6 +85,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "relationship_count": 2,
         },
         {
+            "relationship_type": "payload_generates_event",
+            "display_name": "Payload generates event",
+            "from_domain": "payloads",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "payloads[].events.generated",
+            },
+            "relationship_count": 2,
+        },
+        {
             "relationship_type": "payload_produces_telemetry",
             "display_name": "Payload produces telemetry",
             "from_domain": "payloads",
@@ -94,147 +105,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "relationship_count": 1,
         },
     ]
-    assert manifest["relationships"] == [
-        {
-            "relationship_id": (
-                "packets:comm_status->packet_includes_telemetry:"
-                "telemetry:radio.downlink.available"
-            ),
-            "relationship_type": "packet_includes_telemetry",
-            "from": {
-                "domain": "packets",
-                "id": "comm_status",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "radio.downlink.available",
-            },
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-        },
-        {
-            "relationship_id": (
-                "packets:hk_fast->packet_includes_telemetry:telemetry:eps.battery.current"
-            ),
-            "relationship_type": "packet_includes_telemetry",
-            "from": {
-                "domain": "packets",
-                "id": "hk_fast",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "eps.battery.current",
-            },
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-        },
-        {
-            "relationship_id": (
-                "packets:hk_fast->packet_includes_telemetry:telemetry:eps.battery.voltage"
-            ),
-            "relationship_type": "packet_includes_telemetry",
-            "from": {
-                "domain": "packets",
-                "id": "hk_fast",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "eps.battery.voltage",
-            },
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-        },
-        {
-            "relationship_id": "packets:hk_fast->packet_includes_telemetry:telemetry:obc.mode",
-            "relationship_type": "packet_includes_telemetry",
-            "from": {
-                "domain": "packets",
-                "id": "hk_fast",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "obc.mode",
-            },
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-        },
-        {
-            "relationship_id": (
-                "packets:payload_status->packet_includes_telemetry:"
-                "telemetry:payload.acquisition.active"
-            ),
-            "relationship_type": "packet_includes_telemetry",
-            "from": {
-                "domain": "packets",
-                "id": "payload_status",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "payload.acquisition.active",
-            },
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-        },
-        {
-            "relationship_id": (
-                "payloads:demo_iod_payload->payload_accepts_command:"
-                "commands:payload.start_acquisition"
-            ),
-            "relationship_type": "payload_accepts_command",
-            "from": {
-                "domain": "payloads",
-                "id": "demo_iod_payload",
-            },
-            "to": {
-                "domain": "commands",
-                "id": "payload.start_acquisition",
-            },
-            "derived_from": {
-                "model_field": "payloads[].commands.accepted",
-            },
-        },
-        {
-            "relationship_id": (
-                "payloads:demo_iod_payload->payload_accepts_command:"
-                "commands:payload.stop_acquisition"
-            ),
-            "relationship_type": "payload_accepts_command",
-            "from": {
-                "domain": "payloads",
-                "id": "demo_iod_payload",
-            },
-            "to": {
-                "domain": "commands",
-                "id": "payload.stop_acquisition",
-            },
-            "derived_from": {
-                "model_field": "payloads[].commands.accepted",
-            },
-        },
-        {
-            "relationship_id": (
-                "payloads:demo_iod_payload->payload_produces_telemetry:"
-                "telemetry:payload.acquisition.active"
-            ),
-            "relationship_type": "payload_produces_telemetry",
-            "from": {
-                "domain": "payloads",
-                "id": "demo_iod_payload",
-            },
-            "to": {
-                "domain": "telemetry",
-                "id": "payload.acquisition.active",
-            },
-            "derived_from": {
-                "model_field": "payloads[].telemetry.produced",
-            },
-        },
-    ]
+
+    relationships = manifest["relationships"]
+    assert len(relationships) == 10
+    assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
+    assert {
+        relationship["relationship_id"] for relationship in relationships
+    } >= {
+        "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
+        "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
+    }
 
 
 def test_relationship_manifest_relationships_reference_indexed_entities() -> None:
@@ -245,6 +125,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     payload_ids = {payload.id for payload in model.payloads}
     telemetry_ids = {telemetry.id for telemetry in model.telemetry}
     command_ids = {command.id for command in model.commands}
+    event_ids = {event.id for event in model.events}
 
     for relationship in manifest["relationships"]:
         if relationship["relationship_type"] == "packet_includes_telemetry":
@@ -262,6 +143,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in command_ids
             assert relationship["derived_from"] == {
                 "model_field": "payloads[].commands.accepted",
+            }
+        elif relationship["relationship_type"] == "payload_generates_event":
+            assert relationship["from"]["domain"] == "payloads"
+            assert relationship["from"]["id"] in payload_ids
+            assert relationship["to"]["domain"] == "events"
+            assert relationship["to"]["id"] in event_ids
+            assert relationship["derived_from"] == {
+                "model_field": "payloads[].events.generated",
             }
         elif relationship["relationship_type"] == "payload_produces_telemetry":
             assert relationship["from"]["domain"] == "payloads"


### PR DESCRIPTION
## Summary

This PR admits the fourth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
payload_generates_event
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
payloads[].events.generated
```

For the demo mission, this adds 2 payload-to-event relationship records.

The demo manifest now emits 10 relationships total:

- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
payload_generates_event
```

It does not add any other payload relationship family.

It does not use event ID prefixes, event sources, payload naming conventions, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 10,
    "relationship_types": {
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Payload event relationship records use:

```text
from.domain = payloads
from.id = <payload id>
to.domain = events
to.id = <event id>
derived_from.model_field = payloads[].events.generated
```

## Non-goals

This PR intentionally does not introduce:

- payload may raise fault relationships;
- payload subsystem relationships;
- command target relationships;
- command emits event relationships;
- fault relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
