### PR TITLE
feat: add command event relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,9 +18,10 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits four deliberately narrow relationship families:
+At the current baseline, this surface emits five deliberately narrow relationship families:
 
 ```text
+command_emits_event
 packet_includes_telemetry
 payload_accepts_command
 payload_generates_event
@@ -30,6 +31,7 @@ payload_produces_telemetry
 These relationships are derived only from explicit loaded Mission Model fields:
 
 ```text
+commands[].emits
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].events.generated
@@ -68,7 +70,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -136,8 +138,9 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 10,
+    "total_relationships": 14,
     "relationship_types": {
+      "command_emits_event": 4,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
       "payload_generates_event": 2,
@@ -145,6 +148,16 @@ The current candidate manifest contains:
     }
   },
   "relationship_types": [
+    {
+      "relationship_type": "command_emits_event",
+      "display_name": "Command emits event",
+      "from_domain": "commands",
+      "to_domain": "events",
+      "derived_from": {
+        "model_field": "commands[].emits"
+      },
+      "relationship_count": 4
+    },
     {
       "relationship_type": "packet_includes_telemetry",
       "display_name": "Packet includes telemetry",
@@ -227,6 +240,47 @@ They do not make the manifest a graph, dependency graph, Studio API or plugin AP
 ---
 
 ## Admitted relationship types
+
+### command_emits_event
+
+This relationship states that a command emits an event.
+
+It is derived from:
+
+```text
+commands[].emits
+```
+
+Relationship endpoints are:
+
+```text
+from: commands.<id>
+to: events.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
+  "relationship_type": "command_emits_event",
+  "from": {
+    "domain": "commands",
+    "id": "payload.start_acquisition"
+  },
+  "to": {
+    "domain": "events",
+    "id": "payload.acquisition_started"
+  },
+  "derived_from": {
+    "model_field": "commands[].emits"
+  }
+}
+```
+
+This is a direct command contract reference.
+
+It is not derived from command ID prefixes, event ID prefixes, command targets or expected effects.
 
 ### packet_includes_telemetry
 
@@ -401,6 +455,7 @@ Every relationship record must be derived from an explicit field already present
 Currently admitted derivation sources:
 
 ```text
+commands[].emits
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].events.generated
@@ -412,7 +467,6 @@ Candidate future derivation sources may include explicit fields such as:
 ```text
 telemetry.source
 command.target
-command.emits
 command.expected_effects
 event.source
 fault.source
@@ -568,7 +622,6 @@ Candidate families include:
 
 ```text
 command targets subsystem or payload
-command emits event
 fault emits event
 payload may raise fault
 data product produced by payload or subsystem
@@ -628,6 +681,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -6,8 +6,9 @@ from typing import Any
 
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
-from orbitfabric.model.mission import MissionModel, Packet, PayloadContract
+from orbitfabric.model.mission import Command, MissionModel, Packet, PayloadContract
 
+REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
@@ -102,9 +103,14 @@ def write_relationship_manifest(
 def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     records = [
         record
+        for command in sorted(model.commands, key=lambda item: item.id)
+        for record in _command_event_relationship_records(command)
+    ]
+    records.extend(
+        record
         for packet in sorted(model.packets, key=lambda item: item.id)
         for record in _packet_telemetry_relationship_records(packet)
-    ]
+    )
     records.extend(
         record
         for payload in sorted(model.payloads, key=lambda item: item.id)
@@ -121,6 +127,29 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         for record in _payload_event_relationship_records(payload)
     )
     return sorted(records, key=lambda item: item["relationship_id"])
+
+
+def _command_event_relationship_records(command: Command) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"commands:{command.id}->{REL_COMMAND_EMITS_EVENT}:events:{event_id}"
+            ),
+            "relationship_type": REL_COMMAND_EMITS_EVENT,
+            "from": {
+                "domain": "commands",
+                "id": command.id,
+            },
+            "to": {
+                "domain": "events",
+                "id": event_id,
+            },
+            "derived_from": {
+                "model_field": "commands[].emits",
+            },
+        }
+        for event_id in sorted(command.emits)
+    ]
 
 
 def _packet_telemetry_relationship_records(packet: Packet) -> list[dict[str, Any]]:
@@ -235,6 +264,15 @@ def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, 
 
 def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
     specs = {
+        REL_COMMAND_EMITS_EVENT: {
+            "relationship_type": REL_COMMAND_EMITS_EVENT,
+            "display_name": "Command emits event",
+            "from_domain": "commands",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "commands[].emits",
+            },
+        },
         REL_PACKET_INCLUDES_TELEMETRY: {
             "relationship_type": REL_PACKET_INCLUDES_TELEMETRY,
             "display_name": "Packet includes telemetry",

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 10" in result.output
+    assert "Relationships emitted: 14" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,15 +40,16 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 10
+    assert manifest["counts"]["total_relationships"] == 14
     assert manifest["counts"]["relationship_types"] == {
+        "command_emits_event": 4,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 4
-    assert len(manifest["relationships"]) == 10
+    assert len(manifest["relationship_types"]) == 5
+    assert len(manifest["relationships"]) == 14
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,8 +55,9 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 10,
+        "total_relationships": 14,
         "relationship_types": {
+            "command_emits_event": 4,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
             "payload_generates_event": 2,
@@ -64,6 +65,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         },
     }
     assert manifest["relationship_types"] == [
+        {
+            "relationship_type": "command_emits_event",
+            "display_name": "Command emits event",
+            "from_domain": "commands",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "commands[].emits",
+            },
+            "relationship_count": 4,
+        },
         {
             "relationship_type": "packet_includes_telemetry",
             "display_name": "Packet includes telemetry",
@@ -107,11 +118,15 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 10
+    assert len(relationships) == 14
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
     } >= {
+        "commands:eps.get_status->command_emits_event:events:eps.status_requested",
+        "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
+        "commands:payload.stop_acquisition->command_emits_event:events:payload.acquisition_stopped",
+        "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
     }
@@ -128,7 +143,15 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     event_ids = {event.id for event in model.events}
 
     for relationship in manifest["relationships"]:
-        if relationship["relationship_type"] == "packet_includes_telemetry":
+        if relationship["relationship_type"] == "command_emits_event":
+            assert relationship["from"]["domain"] == "commands"
+            assert relationship["from"]["id"] in command_ids
+            assert relationship["to"]["domain"] == "events"
+            assert relationship["to"]["id"] in event_ids
+            assert relationship["derived_from"] == {
+                "model_field": "commands[].emits",
+            }
+        elif relationship["relationship_type"] == "packet_includes_telemetry":
             assert relationship["from"]["domain"] == "packets"
             assert relationship["from"]["id"] in packet_ids
             assert relationship["to"]["domain"] == "telemetry"


### PR DESCRIPTION
## Summary

This PR admits the fifth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
command_emits_event
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
commands[].emits
```

For the demo mission, this adds 4 command-to-event relationship records.

The demo manifest now emits 14 relationships total:

- 4 `command_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
command_emits_event
```

It does not add command target relationships or expected-effect relationships.

It does not use command ID prefixes, event ID prefixes, command targets, expected effects, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 14,
    "relationship_types": {
      "command_emits_event": 4,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Command event relationship records use:

```text
from.domain = commands
from.id = <command id>
to.domain = events
to.id = <event id>
derived_from.model_field = commands[].emits
```

## Non-goals

This PR intentionally does not introduce:

- command target relationships;
- command expected-effect relationships;
- fault relationships;
- payload fault relationships;
- payload subsystem relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
