### PR TITLE
feat: add fault event relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,10 +18,11 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits five deliberately narrow relationship families:
+At the current baseline, this surface emits six deliberately narrow relationship families:
 
 ```text
 command_emits_event
+fault_emits_event
 packet_includes_telemetry
 payload_accepts_command
 payload_generates_event
@@ -32,6 +33,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 
 ```text
 commands[].emits
+faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].events.generated
@@ -70,7 +72,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -138,9 +140,10 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 14,
+    "total_relationships": 16,
     "relationship_types": {
       "command_emits_event": 4,
+      "fault_emits_event": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
       "payload_generates_event": 2,
@@ -157,6 +160,16 @@ The current candidate manifest contains:
         "model_field": "commands[].emits"
       },
       "relationship_count": 4
+    },
+    {
+      "relationship_type": "fault_emits_event",
+      "display_name": "Fault emits event",
+      "from_domain": "faults",
+      "to_domain": "events",
+      "derived_from": {
+        "model_field": "faults[].emits"
+      },
+      "relationship_count": 2
     },
     {
       "relationship_type": "packet_includes_telemetry",
@@ -281,6 +294,47 @@ Conceptual record shape:
 This is a direct command contract reference.
 
 It is not derived from command ID prefixes, event ID prefixes, command targets or expected effects.
+
+### fault_emits_event
+
+This relationship states that a fault emits an event.
+
+It is derived from:
+
+```text
+faults[].emits
+```
+
+Relationship endpoints are:
+
+```text
+from: faults.<id>
+to: events.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
+  "relationship_type": "fault_emits_event",
+  "from": {
+    "domain": "faults",
+    "id": "eps.battery_low_fault"
+  },
+  "to": {
+    "domain": "events",
+    "id": "eps.battery_low"
+  },
+  "derived_from": {
+    "model_field": "faults[].emits"
+  }
+}
+```
+
+This is a direct fault contract reference.
+
+It is not derived from fault ID prefixes, event ID prefixes, fault conditions, source fields or recovery actions.
 
 ### packet_includes_telemetry
 
@@ -456,6 +510,7 @@ Currently admitted derivation sources:
 
 ```text
 commands[].emits
+faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].events.generated
@@ -470,7 +525,6 @@ command.target
 command.expected_effects
 event.source
 fault.source
-fault.emits
 fault.recovery.auto_commands
 payload.subsystem
 payload.faults.possible
@@ -622,7 +676,6 @@ Candidate families include:
 
 ```text
 command targets subsystem or payload
-fault emits event
 payload may raise fault
 data product produced by payload or subsystem
 downlink flow includes data product
@@ -681,6 +734,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -6,9 +6,10 @@ from typing import Any
 
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
-from orbitfabric.model.mission import Command, MissionModel, Packet, PayloadContract
+from orbitfabric.model.mission import Command, Fault, MissionModel, Packet, PayloadContract
 
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
+REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
@@ -108,6 +109,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     ]
     records.extend(
         record
+        for fault in sorted(model.faults, key=lambda item: item.id)
+        for record in _fault_event_relationship_records(fault)
+    )
+    records.extend(
+        record
         for packet in sorted(model.packets, key=lambda item: item.id)
         for record in _packet_telemetry_relationship_records(packet)
     )
@@ -149,6 +155,27 @@ def _command_event_relationship_records(command: Command) -> list[dict[str, Any]
             },
         }
         for event_id in sorted(command.emits)
+    ]
+
+
+def _fault_event_relationship_records(fault: Fault) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": f"faults:{fault.id}->{REL_FAULT_EMITS_EVENT}:events:{event_id}",
+            "relationship_type": REL_FAULT_EMITS_EVENT,
+            "from": {
+                "domain": "faults",
+                "id": fault.id,
+            },
+            "to": {
+                "domain": "events",
+                "id": event_id,
+            },
+            "derived_from": {
+                "model_field": "faults[].emits",
+            },
+        }
+        for event_id in sorted(fault.emits)
     ]
 
 
@@ -271,6 +298,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "commands[].emits",
+            },
+        },
+        REL_FAULT_EMITS_EVENT: {
+            "relationship_type": REL_FAULT_EMITS_EVENT,
+            "display_name": "Fault emits event",
+            "from_domain": "faults",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "faults[].emits",
             },
         },
         REL_PACKET_INCLUDES_TELEMETRY: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 14" in result.output
+    assert "Relationships emitted: 16" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,16 +40,17 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 14
+    assert manifest["counts"]["total_relationships"] == 16
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
+        "fault_emits_event": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 5
-    assert len(manifest["relationships"]) == 14
+    assert len(manifest["relationship_types"]) == 6
+    assert len(manifest["relationships"]) == 16
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,9 +55,10 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 14,
+        "total_relationships": 16,
         "relationship_types": {
             "command_emits_event": 4,
+            "fault_emits_event": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
             "payload_generates_event": 2,
@@ -74,6 +75,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
                 "model_field": "commands[].emits",
             },
             "relationship_count": 4,
+        },
+        {
+            "relationship_type": "fault_emits_event",
+            "display_name": "Fault emits event",
+            "from_domain": "faults",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "faults[].emits",
+            },
+            "relationship_count": 2,
         },
         {
             "relationship_type": "packet_includes_telemetry",
@@ -118,7 +129,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 14
+    assert len(relationships) == 16
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -127,6 +138,8 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
         "commands:payload.stop_acquisition->command_emits_event:events:payload.acquisition_stopped",
         "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
+        "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
+        "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
     }
@@ -141,6 +154,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     telemetry_ids = {telemetry.id for telemetry in model.telemetry}
     command_ids = {command.id for command in model.commands}
     event_ids = {event.id for event in model.events}
+    fault_ids = {fault.id for fault in model.faults}
 
     for relationship in manifest["relationships"]:
         if relationship["relationship_type"] == "command_emits_event":
@@ -150,6 +164,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in event_ids
             assert relationship["derived_from"] == {
                 "model_field": "commands[].emits",
+            }
+        elif relationship["relationship_type"] == "fault_emits_event":
+            assert relationship["from"]["domain"] == "faults"
+            assert relationship["from"]["id"] in fault_ids
+            assert relationship["to"]["domain"] == "events"
+            assert relationship["to"]["id"] in event_ids
+            assert relationship["derived_from"] == {
+                "model_field": "faults[].emits",
             }
         elif relationship["relationship_type"] == "packet_includes_telemetry":
             assert relationship["from"]["domain"] == "packets"


### PR DESCRIPTION
## Summary

This PR admits the sixth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
fault_emits_event
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
faults[].emits
```

For the demo mission, this adds 2 fault-to-event relationship records.

The demo manifest now emits 16 relationships total:

- 4 `command_emits_event`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
fault_emits_event
```

It does not add fault recovery relationships, auto-command relationships, fault source relationships or fault condition relationships.

It does not use fault ID prefixes, event ID prefixes, fault conditions, source fields, recovery actions, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 16,
    "relationship_types": {
      "command_emits_event": 4,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Fault event relationship records use:

```text
from.domain = faults
from.id = <fault id>
to.domain = events
to.id = <event id>
derived_from.model_field = faults[].emits
```

## Non-goals

This PR intentionally does not introduce:

- fault recovery relationships;
- fault auto-command relationships;
- fault source relationships;
- fault condition relationships;
- command target relationships;
- command expected-effect relationships;
- payload fault relationships;
- payload subsystem relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
