### PR TITLE
feat: add command subsystem relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,10 +18,11 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits six deliberately narrow relationship families:
+At the current baseline, this surface emits seven deliberately narrow relationship families:
 
 ```text
 command_emits_event
+command_targets_subsystem
 fault_emits_event
 packet_includes_telemetry
 payload_accepts_command
@@ -33,6 +34,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 
 ```text
 commands[].emits
+commands[].target
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -72,7 +74,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, command-to-subsystem target records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -140,9 +142,10 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 16,
+    "total_relationships": 20,
     "relationship_types": {
       "command_emits_event": 4,
+      "command_targets_subsystem": 4,
       "fault_emits_event": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
@@ -158,6 +161,16 @@ The current candidate manifest contains:
       "to_domain": "events",
       "derived_from": {
         "model_field": "commands[].emits"
+      },
+      "relationship_count": 4
+    },
+    {
+      "relationship_type": "command_targets_subsystem",
+      "display_name": "Command targets subsystem",
+      "from_domain": "commands",
+      "to_domain": "subsystems",
+      "derived_from": {
+        "model_field": "commands[].target"
       },
       "relationship_count": 4
     },
@@ -294,6 +307,49 @@ Conceptual record shape:
 This is a direct command contract reference.
 
 It is not derived from command ID prefixes, event ID prefixes, command targets or expected effects.
+
+### command_targets_subsystem
+
+This relationship states that a command targets an indexed subsystem.
+
+It is derived from:
+
+```text
+commands[].target
+```
+
+Relationship endpoints are:
+
+```text
+from: commands.<id>
+to: subsystems.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "commands:eps.get_status->command_targets_subsystem:subsystems:eps",
+  "relationship_type": "command_targets_subsystem",
+  "from": {
+    "domain": "commands",
+    "id": "eps.get_status"
+  },
+  "to": {
+    "domain": "subsystems",
+    "id": "eps"
+  },
+  "derived_from": {
+    "model_field": "commands[].target"
+  }
+}
+```
+
+This is a direct command contract reference.
+
+It is emitted only when `commands[].target` resolves to an indexed subsystem.
+
+It is not derived from command ID prefixes, subsystem naming conventions or payload contract references.
 
 ### fault_emits_event
 
@@ -510,6 +566,7 @@ Currently admitted derivation sources:
 
 ```text
 commands[].emits
+commands[].target
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -521,7 +578,6 @@ Candidate future derivation sources may include explicit fields such as:
 
 ```text
 telemetry.source
-command.target
 command.expected_effects
 event.source
 fault.source
@@ -675,7 +731,6 @@ A future implementation may consider additional explicit relationship families.
 Candidate families include:
 
 ```text
-command targets subsystem or payload
 payload may raise fault
 data product produced by payload or subsystem
 downlink flow includes data product
@@ -734,6 +789,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -9,6 +9,7 @@ from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import Command, Fault, MissionModel, Packet, PayloadContract
 
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
+REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
@@ -109,6 +110,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     ]
     records.extend(
         record
+        for command in sorted(model.commands, key=lambda item: item.id)
+        for record in _command_subsystem_relationship_records(command, model.subsystem_ids)
+    )
+    records.extend(
+        record
         for fault in sorted(model.faults, key=lambda item: item.id)
         for record in _fault_event_relationship_records(fault)
     )
@@ -155,6 +161,35 @@ def _command_event_relationship_records(command: Command) -> list[dict[str, Any]
             },
         }
         for event_id in sorted(command.emits)
+    ]
+
+
+def _command_subsystem_relationship_records(
+    command: Command,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if command.target not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"commands:{command.id}->{REL_COMMAND_TARGETS_SUBSYSTEM}:"
+                f"subsystems:{command.target}"
+            ),
+            "relationship_type": REL_COMMAND_TARGETS_SUBSYSTEM,
+            "from": {
+                "domain": "commands",
+                "id": command.id,
+            },
+            "to": {
+                "domain": "subsystems",
+                "id": command.target,
+            },
+            "derived_from": {
+                "model_field": "commands[].target",
+            },
+        }
     ]
 
 
@@ -298,6 +333,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "commands[].emits",
+            },
+        },
+        REL_COMMAND_TARGETS_SUBSYSTEM: {
+            "relationship_type": REL_COMMAND_TARGETS_SUBSYSTEM,
+            "display_name": "Command targets subsystem",
+            "from_domain": "commands",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "commands[].target",
             },
         },
         REL_FAULT_EMITS_EVENT: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 16" in result.output
+    assert "Relationships emitted: 20" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,17 +40,18 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 16
+    assert manifest["counts"]["total_relationships"] == 20
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
+        "command_targets_subsystem": 4,
         "fault_emits_event": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 6
-    assert len(manifest["relationships"]) == 16
+    assert len(manifest["relationship_types"]) == 7
+    assert len(manifest["relationships"]) == 20
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,9 +55,10 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 16,
+        "total_relationships": 20,
         "relationship_types": {
             "command_emits_event": 4,
+            "command_targets_subsystem": 4,
             "fault_emits_event": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
@@ -73,6 +74,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "commands[].emits",
+            },
+            "relationship_count": 4,
+        },
+        {
+            "relationship_type": "command_targets_subsystem",
+            "display_name": "Command targets subsystem",
+            "from_domain": "commands",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "commands[].target",
             },
             "relationship_count": 4,
         },
@@ -129,15 +140,19 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 16
+    assert len(relationships) == 20
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
     } >= {
         "commands:eps.get_status->command_emits_event:events:eps.status_requested",
+        "commands:eps.get_status->command_targets_subsystem:subsystems:eps",
         "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
+        "commands:payload.start_acquisition->command_targets_subsystem:subsystems:payload",
         "commands:payload.stop_acquisition->command_emits_event:events:payload.acquisition_stopped",
+        "commands:payload.stop_acquisition->command_targets_subsystem:subsystems:payload",
         "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
+        "commands:radio.downlink_housekeeping->command_targets_subsystem:subsystems:radio",
         "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
@@ -155,6 +170,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     command_ids = {command.id for command in model.commands}
     event_ids = {event.id for event in model.events}
     fault_ids = {fault.id for fault in model.faults}
+    subsystem_ids = {subsystem.id for subsystem in model.subsystems}
 
     for relationship in manifest["relationships"]:
         if relationship["relationship_type"] == "command_emits_event":
@@ -164,6 +180,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in event_ids
             assert relationship["derived_from"] == {
                 "model_field": "commands[].emits",
+            }
+        elif relationship["relationship_type"] == "command_targets_subsystem":
+            assert relationship["from"]["domain"] == "commands"
+            assert relationship["from"]["id"] in command_ids
+            assert relationship["to"]["domain"] == "subsystems"
+            assert relationship["to"]["id"] in subsystem_ids
+            assert relationship["derived_from"] == {
+                "model_field": "commands[].target",
             }
         elif relationship["relationship_type"] == "fault_emits_event":
             assert relationship["from"]["domain"] == "faults"


### PR DESCRIPTION
## Summary

This PR admits the seventh deterministic relationship family into the candidate Relationship Manifest Surface:

```text
command_targets_subsystem
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
commands[].target
```

Records are emitted only when `commands[].target` resolves to an indexed subsystem.

For the demo mission, this adds 4 command-to-subsystem relationship records.

The demo manifest now emits 20 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
command_targets_subsystem
```

It does not add command target payload relationships, command expected-effect relationships or payload subsystem relationships.

It does not use command ID prefixes, subsystem naming conventions, payload contract references, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 20,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Command subsystem relationship records use:

```text
from.domain = commands
from.id = <command id>
to.domain = subsystems
to.id = <subsystem id>
derived_from.model_field = commands[].target
```

## Non-goals

This PR intentionally does not introduce:

- command target payload relationships;
- command expected-effect relationships;
- payload subsystem relationships;
- payload fault relationships;
- data product relationships;
- contact or downlink relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
