### PR TITLE
feat: add payload data product relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,11 +18,12 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits seven deliberately narrow relationship families:
+At the current baseline, this surface emits eight deliberately narrow relationship families:
 
 ```text
 command_emits_event
 command_targets_subsystem
+data_product_produced_by_payload
 fault_emits_event
 packet_includes_telemetry
 payload_accepts_command
@@ -35,6 +36,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 ```text
 commands[].emits
 commands[].target
+data_products[].producer
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -74,7 +76,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, command-to-subsystem target records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -142,10 +144,11 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 20,
+    "total_relationships": 21,
     "relationship_types": {
       "command_emits_event": 4,
       "command_targets_subsystem": 4,
+      "data_product_produced_by_payload": 1,
       "fault_emits_event": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
@@ -173,6 +176,16 @@ The current candidate manifest contains:
         "model_field": "commands[].target"
       },
       "relationship_count": 4
+    },
+    {
+      "relationship_type": "data_product_produced_by_payload",
+      "display_name": "Data product produced by payload",
+      "from_domain": "data_products",
+      "to_domain": "payloads",
+      "derived_from": {
+        "model_field": "data_products[].producer"
+      },
+      "relationship_count": 1
     },
     {
       "relationship_type": "fault_emits_event",
@@ -350,6 +363,49 @@ This is a direct command contract reference.
 It is emitted only when `commands[].target` resolves to an indexed subsystem.
 
 It is not derived from command ID prefixes, subsystem naming conventions or payload contract references.
+
+### data_product_produced_by_payload
+
+This relationship states that a data product is produced by an indexed payload.
+
+It is derived from:
+
+```text
+data_products[].producer
+```
+
+Relationship endpoints are:
+
+```text
+from: data_products.<id>
+to: payloads.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
+  "relationship_type": "data_product_produced_by_payload",
+  "from": {
+    "domain": "data_products",
+    "id": "payload.radiation_histogram"
+  },
+  "to": {
+    "domain": "payloads",
+    "id": "demo_iod_payload"
+  },
+  "derived_from": {
+    "model_field": "data_products[].producer"
+  }
+}
+```
+
+This is a direct data product contract reference.
+
+It is emitted only when `data_products[].producer_type` is `payload` and `data_products[].producer` resolves to an indexed payload.
+
+It is not derived from data product ID prefixes, payload naming conventions, storage policy or downlink policy.
 
 ### fault_emits_event
 
@@ -567,6 +623,7 @@ Currently admitted derivation sources:
 ```text
 commands[].emits
 commands[].target
+data_products[].producer
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -584,7 +641,6 @@ fault.source
 fault.recovery.auto_commands
 payload.subsystem
 payload.faults.possible
-data_product.producer
 data_product.payload
 contact_window.contact_profile
 contact_window.link_profile
@@ -732,7 +788,7 @@ Candidate families include:
 
 ```text
 payload may raise fault
-data product produced by payload or subsystem
+data product produced by subsystem
 downlink flow includes data product
 commandability rule constrains command
 autonomous action dispatches command
@@ -789,6 +845,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `command_targets_subsystem`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -6,10 +6,18 @@ from typing import Any
 
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
-from orbitfabric.model.mission import Command, Fault, MissionModel, Packet, PayloadContract
+from orbitfabric.model.mission import (
+    Command,
+    DataProductContract,
+    Fault,
+    MissionModel,
+    Packet,
+    PayloadContract,
+)
 
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
+REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
@@ -115,6 +123,14 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     )
     records.extend(
         record
+        for data_product in sorted(model.data_products, key=lambda item: item.id)
+        for record in _data_product_payload_relationship_records(
+            data_product,
+            model.payload_ids,
+        )
+    )
+    records.extend(
+        record
         for fault in sorted(model.faults, key=lambda item: item.id)
         for record in _fault_event_relationship_records(fault)
     )
@@ -188,6 +204,38 @@ def _command_subsystem_relationship_records(
             },
             "derived_from": {
                 "model_field": "commands[].target",
+            },
+        }
+    ]
+
+
+def _data_product_payload_relationship_records(
+    data_product: DataProductContract,
+    payload_ids: set[str],
+) -> list[dict[str, Any]]:
+    if data_product.producer_type != "payload":
+        return []
+    if data_product.producer not in payload_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"data_products:{data_product.id}->"
+                f"{REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD}:"
+                f"payloads:{data_product.producer}"
+            ),
+            "relationship_type": REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD,
+            "from": {
+                "domain": "data_products",
+                "id": data_product.id,
+            },
+            "to": {
+                "domain": "payloads",
+                "id": data_product.producer,
+            },
+            "derived_from": {
+                "model_field": "data_products[].producer",
             },
         }
     ]
@@ -342,6 +390,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "subsystems",
             "derived_from": {
                 "model_field": "commands[].target",
+            },
+        },
+        REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD: {
+            "relationship_type": REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD,
+            "display_name": "Data product produced by payload",
+            "from_domain": "data_products",
+            "to_domain": "payloads",
+            "derived_from": {
+                "model_field": "data_products[].producer",
             },
         },
         REL_FAULT_EMITS_EVENT: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 20" in result.output
+    assert "Relationships emitted: 21" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,18 +40,19 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 20
+    assert manifest["counts"]["total_relationships"] == 21
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
+        "data_product_produced_by_payload": 1,
         "fault_emits_event": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 7
-    assert len(manifest["relationships"]) == 20
+    assert len(manifest["relationship_types"]) == 8
+    assert len(manifest["relationships"]) == 21
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,10 +55,11 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 20,
+        "total_relationships": 21,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
+            "data_product_produced_by_payload": 1,
             "fault_emits_event": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
@@ -86,6 +87,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
                 "model_field": "commands[].target",
             },
             "relationship_count": 4,
+        },
+        {
+            "relationship_type": "data_product_produced_by_payload",
+            "display_name": "Data product produced by payload",
+            "from_domain": "data_products",
+            "to_domain": "payloads",
+            "derived_from": {
+                "model_field": "data_products[].producer",
+            },
+            "relationship_count": 1,
         },
         {
             "relationship_type": "fault_emits_event",
@@ -140,7 +151,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 20
+    assert len(relationships) == 21
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -153,6 +164,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "commands:payload.stop_acquisition->command_targets_subsystem:subsystems:payload",
         "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
         "commands:radio.downlink_housekeeping->command_targets_subsystem:subsystems:radio",
+        "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
         "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
@@ -171,6 +183,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     event_ids = {event.id for event in model.events}
     fault_ids = {fault.id for fault in model.faults}
     subsystem_ids = {subsystem.id for subsystem in model.subsystems}
+    data_product_ids = {data_product.id for data_product in model.data_products}
 
     for relationship in manifest["relationships"]:
         if relationship["relationship_type"] == "command_emits_event":
@@ -188,6 +201,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in subsystem_ids
             assert relationship["derived_from"] == {
                 "model_field": "commands[].target",
+            }
+        elif relationship["relationship_type"] == "data_product_produced_by_payload":
+            assert relationship["from"]["domain"] == "data_products"
+            assert relationship["from"]["id"] in data_product_ids
+            assert relationship["to"]["domain"] == "payloads"
+            assert relationship["to"]["id"] in payload_ids
+            assert relationship["derived_from"] == {
+                "model_field": "data_products[].producer",
             }
         elif relationship["relationship_type"] == "fault_emits_event":
             assert relationship["from"]["domain"] == "faults"


### PR DESCRIPTION
## Summary

This PR admits the eighth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
data_product_produced_by_payload
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
data_products[].producer
```

Records are emitted only when:

```text
data_products[].producer_type == payload
```

and `data_products[].producer` resolves to an indexed payload.

For the demo mission, this adds 1 data-product-to-payload relationship record.

The demo manifest now emits 21 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 1 `data_product_produced_by_payload`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
data_product_produced_by_payload
```

It does not add data-product-to-subsystem relationships, storage relationships, downlink relationships or data product lifecycle relationships.

It does not use data product ID prefixes, payload naming conventions, storage policy, downlink policy, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 21,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "data_product_produced_by_payload": 1,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Payload data product relationship records use:

```text
from.domain = data_products
from.id = <data product id>
to.domain = payloads
to.id = <payload id>
derived_from.model_field = data_products[].producer
```

## Non-goals

This PR intentionally does not introduce:

- data-product-to-subsystem relationships;
- storage relationships;
- downlink relationships;
- data product lifecycle relationships;
- command expected-effect relationships;
- payload fault relationships;
- payload subsystem relationships;
- contact or downlink flow relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
