### PR TITLE
feat: add payload subsystem relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,7 +18,7 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits eight deliberately narrow relationship families:
+At the current baseline, this surface emits nine deliberately narrow relationship families:
 
 ```text
 command_emits_event
@@ -27,6 +27,7 @@ data_product_produced_by_payload
 fault_emits_event
 packet_includes_telemetry
 payload_accepts_command
+payload_belongs_to_subsystem
 payload_generates_event
 payload_produces_telemetry
 ```
@@ -40,6 +41,7 @@ data_products[].producer
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
+payloads[].subsystem
 payloads[].events.generated
 payloads[].telemetry.produced
 ```
@@ -76,7 +78,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records and payload-to-telemetry production records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -144,7 +146,7 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 21,
+    "total_relationships": 22,
     "relationship_types": {
       "command_emits_event": 4,
       "command_targets_subsystem": 4,
@@ -152,6 +154,7 @@ The current candidate manifest contains:
       "fault_emits_event": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
+      "payload_belongs_to_subsystem": 1,
       "payload_generates_event": 2,
       "payload_produces_telemetry": 1
     }
@@ -216,6 +219,16 @@ The current candidate manifest contains:
         "model_field": "payloads[].commands.accepted"
       },
       "relationship_count": 2
+    },
+    {
+      "relationship_type": "payload_belongs_to_subsystem",
+      "display_name": "Payload belongs to subsystem",
+      "from_domain": "payloads",
+      "to_domain": "subsystems",
+      "derived_from": {
+        "model_field": "payloads[].subsystem"
+      },
+      "relationship_count": 1
     },
     {
       "relationship_type": "payload_generates_event",
@@ -530,6 +543,49 @@ This is a direct payload contract reference.
 
 It is not derived from command ID prefixes, payload naming conventions or command targets.
 
+### payload_belongs_to_subsystem
+
+This relationship states that a payload belongs to an indexed subsystem.
+
+It is derived from:
+
+```text
+payloads[].subsystem
+```
+
+Relationship endpoints are:
+
+```text
+from: payloads.<id>
+to: subsystems.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
+  "relationship_type": "payload_belongs_to_subsystem",
+  "from": {
+    "domain": "payloads",
+    "id": "demo_iod_payload"
+  },
+  "to": {
+    "domain": "subsystems",
+    "id": "payload"
+  },
+  "derived_from": {
+    "model_field": "payloads[].subsystem"
+  }
+}
+```
+
+This is a direct payload contract reference.
+
+It is emitted only when `payloads[].subsystem` resolves to an indexed subsystem.
+
+It is not derived from payload ID prefixes, subsystem naming conventions or command targets.
+
 ### payload_generates_event
 
 This relationship states that a payload generates an event.
@@ -627,6 +683,7 @@ data_products[].producer
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
+payloads[].subsystem
 payloads[].events.generated
 payloads[].telemetry.produced
 ```
@@ -639,7 +696,6 @@ command.expected_effects
 event.source
 fault.source
 fault.recovery.auto_commands
-payload.subsystem
 payload.faults.possible
 data_product.payload
 contact_window.contact_profile
@@ -845,6 +901,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event` and `payload_produces_telemetry` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -21,6 +21,7 @@ REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
+REL_PAYLOAD_BELONGS_TO_SUBSYSTEM = "payload_belongs_to_subsystem"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
 
@@ -138,6 +139,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         record
         for packet in sorted(model.packets, key=lambda item: item.id)
         for record in _packet_telemetry_relationship_records(packet)
+    )
+    records.extend(
+        record
+        for payload in sorted(model.payloads, key=lambda item: item.id)
+        for record in _payload_subsystem_relationship_records(payload, model.subsystem_ids)
     )
     records.extend(
         record
@@ -286,6 +292,35 @@ def _packet_telemetry_relationship_records(packet: Packet) -> list[dict[str, Any
     ]
 
 
+def _payload_subsystem_relationship_records(
+    payload: PayloadContract,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if payload.subsystem not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"payloads:{payload.id}->{REL_PAYLOAD_BELONGS_TO_SUBSYSTEM}:"
+                f"subsystems:{payload.subsystem}"
+            ),
+            "relationship_type": REL_PAYLOAD_BELONGS_TO_SUBSYSTEM,
+            "from": {
+                "domain": "payloads",
+                "id": payload.id,
+            },
+            "to": {
+                "domain": "subsystems",
+                "id": payload.subsystem,
+            },
+            "derived_from": {
+                "model_field": "payloads[].subsystem",
+            },
+        }
+    ]
+
+
 def _payload_telemetry_relationship_records(
     payload: PayloadContract,
 ) -> list[dict[str, Any]]:
@@ -426,6 +461,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "commands",
             "derived_from": {
                 "model_field": "payloads[].commands.accepted",
+            },
+        },
+        REL_PAYLOAD_BELONGS_TO_SUBSYSTEM: {
+            "relationship_type": REL_PAYLOAD_BELONGS_TO_SUBSYSTEM,
+            "display_name": "Payload belongs to subsystem",
+            "from_domain": "payloads",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "payloads[].subsystem",
             },
         },
         REL_PAYLOAD_GENERATES_EVENT: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 21" in result.output
+    assert "Relationships emitted: 22" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,7 +40,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 21
+    assert manifest["counts"]["total_relationships"] == 22
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
@@ -48,11 +48,12 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "fault_emits_event": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
+        "payload_belongs_to_subsystem": 1,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
     }
-    assert len(manifest["relationship_types"]) == 8
-    assert len(manifest["relationships"]) == 21
+    assert len(manifest["relationship_types"]) == 9
+    assert len(manifest["relationships"]) == 22
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,7 +55,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 21,
+        "total_relationships": 22,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
@@ -63,6 +63,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "fault_emits_event": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
+            "payload_belongs_to_subsystem": 1,
             "payload_generates_event": 2,
             "payload_produces_telemetry": 1,
         },
@@ -129,6 +130,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "relationship_count": 2,
         },
         {
+            "relationship_type": "payload_belongs_to_subsystem",
+            "display_name": "Payload belongs to subsystem",
+            "from_domain": "payloads",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "payloads[].subsystem",
+            },
+            "relationship_count": 1,
+        },
+        {
             "relationship_type": "payload_generates_event",
             "display_name": "Payload generates event",
             "from_domain": "payloads",
@@ -151,7 +162,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 21
+    assert len(relationships) == 22
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -167,6 +178,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
         "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
+        "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
     }
@@ -233,6 +245,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in command_ids
             assert relationship["derived_from"] == {
                 "model_field": "payloads[].commands.accepted",
+            }
+        elif relationship["relationship_type"] == "payload_belongs_to_subsystem":
+            assert relationship["from"]["domain"] == "payloads"
+            assert relationship["from"]["id"] in payload_ids
+            assert relationship["to"]["domain"] == "subsystems"
+            assert relationship["to"]["id"] in subsystem_ids
+            assert relationship["derived_from"] == {
+                "model_field": "payloads[].subsystem",
             }
         elif relationship["relationship_type"] == "payload_generates_event":
             assert relationship["from"]["domain"] == "payloads"


### PR DESCRIPTION
## Summary

This PR admits the ninth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
payload_belongs_to_subsystem
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
payloads[].subsystem
```

Records are emitted only when `payloads[].subsystem` resolves to an indexed subsystem.

For the demo mission, this adds 1 payload-to-subsystem relationship record.

The demo manifest now emits 22 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 1 `data_product_produced_by_payload`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 1 `payload_belongs_to_subsystem`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
payload_belongs_to_subsystem
```

It does not add payload fault relationships, subsystem ownership semantics beyond the explicit payload contract field, command target payload relationships or subsystem behavior relationships.

It does not use payload ID prefixes, subsystem naming conventions, command targets, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 22,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "data_product_produced_by_payload": 1,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_belongs_to_subsystem": 1,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1
    }
  }
}
```

for the demo mission.

Payload subsystem relationship records use:

```text
from.domain = payloads
from.id = <payload id>
to.domain = subsystems
to.id = <subsystem id>
derived_from.model_field = payloads[].subsystem
```

## Non-goals

This PR intentionally does not introduce:

- payload fault relationships;
- subsystem ownership semantics beyond the explicit payload contract field;
- command target payload relationships;
- subsystem behavior relationships;
- data-product-to-subsystem relationships;
- storage relationships;
- downlink relationships;
- command expected-effect relationships;
- contact or downlink flow relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Deferred demo coverage note

The current `examples/demo-3u/mission/payloads.yaml` keeps:

```text
payloads[].faults.possible = []
```

A later demo-enrichment PR should add minimal but useful payload fault references so that future `payload_may_raise_fault` style relationships can be exercised without artificial inflation.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
