### PR TITLE
feat: add telemetry subsystem relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,7 +18,7 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits nine deliberately narrow relationship families:
+At the current baseline, this surface emits ten deliberately narrow relationship families:
 
 ```text
 command_emits_event
@@ -30,6 +30,7 @@ payload_accepts_command
 payload_belongs_to_subsystem
 payload_generates_event
 payload_produces_telemetry
+telemetry_sourced_from_subsystem
 ```
 
 These relationships are derived only from explicit loaded Mission Model fields:
@@ -44,6 +45,7 @@ payloads[].commands.accepted
 payloads[].subsystem
 payloads[].events.generated
 payloads[].telemetry.produced
+telemetry[].source
 ```
 
 No other relationship type is admitted yet.
@@ -78,7 +80,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records and payload-to-telemetry production records.
+It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records, payload-to-telemetry production records and telemetry-to-subsystem source records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -146,7 +148,7 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 22,
+    "total_relationships": 27,
     "relationship_types": {
       "command_emits_event": 4,
       "command_targets_subsystem": 4,
@@ -156,7 +158,8 @@ The current candidate manifest contains:
       "payload_accepts_command": 2,
       "payload_belongs_to_subsystem": 1,
       "payload_generates_event": 2,
-      "payload_produces_telemetry": 1
+      "payload_produces_telemetry": 1,
+      "telemetry_sourced_from_subsystem": 5
     }
   },
   "relationship_types": [
@@ -249,6 +252,16 @@ The current candidate manifest contains:
         "model_field": "payloads[].telemetry.produced"
       },
       "relationship_count": 1
+    },
+    {
+      "relationship_type": "telemetry_sourced_from_subsystem",
+      "display_name": "Telemetry sourced from subsystem",
+      "from_domain": "telemetry",
+      "to_domain": "subsystems",
+      "derived_from": {
+        "model_field": "telemetry[].source"
+      },
+      "relationship_count": 5
     }
   ],
   "relationships": []
@@ -668,6 +681,49 @@ This is a direct payload contract reference.
 
 It is not derived from telemetry ID prefixes or payload naming conventions.
 
+### telemetry_sourced_from_subsystem
+
+This relationship states that a telemetry item is sourced from an indexed subsystem.
+
+It is derived from:
+
+```text
+telemetry[].source
+```
+
+Relationship endpoints are:
+
+```text
+from: telemetry.<id>
+to: subsystems.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "telemetry:eps.battery.voltage->telemetry_sourced_from_subsystem:subsystems:eps",
+  "relationship_type": "telemetry_sourced_from_subsystem",
+  "from": {
+    "domain": "telemetry",
+    "id": "eps.battery.voltage"
+  },
+  "to": {
+    "domain": "subsystems",
+    "id": "eps"
+  },
+  "derived_from": {
+    "model_field": "telemetry[].source"
+  }
+}
+```
+
+This is a direct telemetry contract reference.
+
+It is emitted only when `telemetry[].source` resolves to an indexed subsystem.
+
+It is not derived from telemetry ID prefixes, subsystem naming conventions, packets or payload telemetry declarations.
+
 ---
 
 ## Deterministic derivation rule
@@ -686,12 +742,12 @@ payloads[].commands.accepted
 payloads[].subsystem
 payloads[].events.generated
 payloads[].telemetry.produced
+telemetry[].source
 ```
 
 Candidate future derivation sources may include explicit fields such as:
 
 ```text
-telemetry.source
 command.expected_effects
 event.source
 fault.source
@@ -901,6 +957,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event` and `payload_produces_telemetry` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event`, `payload_produces_telemetry` and `telemetry_sourced_from_subsystem` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -13,6 +13,7 @@ from orbitfabric.model.mission import (
     MissionModel,
     Packet,
     PayloadContract,
+    TelemetryItem,
 )
 
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
@@ -24,6 +25,7 @@ REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_BELONGS_TO_SUBSYSTEM = "payload_belongs_to_subsystem"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
+REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM = "telemetry_sourced_from_subsystem"
 
 
 def relationship_manifest_to_dict(
@@ -159,6 +161,14 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         record
         for payload in sorted(model.payloads, key=lambda item: item.id)
         for record in _payload_event_relationship_records(payload)
+    )
+    records.extend(
+        record
+        for telemetry in sorted(model.telemetry, key=lambda item: item.id)
+        for record in _telemetry_subsystem_relationship_records(
+            telemetry,
+            model.subsystem_ids,
+        )
     )
     return sorted(records, key=lambda item: item["relationship_id"])
 
@@ -399,6 +409,35 @@ def _payload_event_relationship_records(
     ]
 
 
+def _telemetry_subsystem_relationship_records(
+    telemetry: TelemetryItem,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if telemetry.source not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"telemetry:{telemetry.id}->{REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM}:"
+                f"subsystems:{telemetry.source}"
+            ),
+            "relationship_type": REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM,
+            "from": {
+                "domain": "telemetry",
+                "id": telemetry.id,
+            },
+            "to": {
+                "domain": "subsystems",
+                "id": telemetry.source,
+            },
+            "derived_from": {
+                "model_field": "telemetry[].source",
+            },
+        }
+    ]
+
+
 def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for relationship in relationships:
@@ -488,6 +527,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "telemetry",
             "derived_from": {
                 "model_field": "payloads[].telemetry.produced",
+            },
+        },
+        REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM: {
+            "relationship_type": REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM,
+            "display_name": "Telemetry sourced from subsystem",
+            "from_domain": "telemetry",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "telemetry[].source",
             },
         },
     }

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 22" in result.output
+    assert "Relationships emitted: 27" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,7 +40,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 22
+    assert manifest["counts"]["total_relationships"] == 27
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
@@ -51,9 +51,10 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_belongs_to_subsystem": 1,
         "payload_generates_event": 2,
         "payload_produces_telemetry": 1,
+        "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 9
-    assert len(manifest["relationships"]) == 22
+    assert len(manifest["relationship_types"]) == 10
+    assert len(manifest["relationships"]) == 27
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,7 +55,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 22,
+        "total_relationships": 27,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
@@ -66,6 +66,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "payload_belongs_to_subsystem": 1,
             "payload_generates_event": 2,
             "payload_produces_telemetry": 1,
+            "telemetry_sourced_from_subsystem": 5,
         },
     }
     assert manifest["relationship_types"] == [
@@ -159,10 +160,20 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             },
             "relationship_count": 1,
         },
+        {
+            "relationship_type": "telemetry_sourced_from_subsystem",
+            "display_name": "Telemetry sourced from subsystem",
+            "from_domain": "telemetry",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "telemetry[].source",
+            },
+            "relationship_count": 5,
+        },
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 22
+    assert len(relationships) == 27
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -181,6 +192,11 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
+        "telemetry:eps.battery.current->telemetry_sourced_from_subsystem:subsystems:eps",
+        "telemetry:eps.battery.voltage->telemetry_sourced_from_subsystem:subsystems:eps",
+        "telemetry:obc.mode->telemetry_sourced_from_subsystem:subsystems:obc",
+        "telemetry:payload.acquisition.active->telemetry_sourced_from_subsystem:subsystems:payload",
+        "telemetry:radio.downlink.available->telemetry_sourced_from_subsystem:subsystems:radio",
     }
 
 
@@ -269,6 +285,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in telemetry_ids
             assert relationship["derived_from"] == {
                 "model_field": "payloads[].telemetry.produced",
+            }
+        elif relationship["relationship_type"] == "telemetry_sourced_from_subsystem":
+            assert relationship["from"]["domain"] == "telemetry"
+            assert relationship["from"]["id"] in telemetry_ids
+            assert relationship["to"]["domain"] == "subsystems"
+            assert relationship["to"]["id"] in subsystem_ids
+            assert relationship["derived_from"] == {
+                "model_field": "telemetry[].source",
             }
         else:
             raise AssertionError("unexpected relationship type")


### PR DESCRIPTION
## Summary

This PR admits the tenth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
telemetry_sourced_from_subsystem
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
telemetry[].source
```

Records are emitted only when `telemetry[].source` resolves to an indexed subsystem.

For the demo mission, this adds 5 telemetry-to-subsystem relationship records.

The demo manifest now emits 27 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 1 `data_product_produced_by_payload`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 1 `payload_belongs_to_subsystem`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`
- 5 `telemetry_sourced_from_subsystem`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
telemetry_sourced_from_subsystem
```

It does not add telemetry-to-payload relationships, telemetry-to-packet relationships, event source relationships or fault source relationships.

It does not use telemetry ID prefixes, subsystem naming conventions, packet membership, payload telemetry declarations, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 27,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "data_product_produced_by_payload": 1,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_belongs_to_subsystem": 1,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1,
      "telemetry_sourced_from_subsystem": 5
    }
  }
}
```

for the demo mission.

Telemetry subsystem relationship records use:

```text
from.domain = telemetry
from.id = <telemetry id>
to.domain = subsystems
to.id = <subsystem id>
derived_from.model_field = telemetry[].source
```

## Non-goals

This PR intentionally does not introduce:

- telemetry-to-payload relationships;
- telemetry-to-packet relationships;
- event source relationships;
- fault source relationships;
- payload fault relationships;
- data-product-to-subsystem relationships;
- storage relationships;
- downlink relationships;
- command expected-effect relationships;
- contact or downlink flow relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
