### PR TITLE
feat: add event subsystem relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,12 +18,13 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits ten deliberately narrow relationship families:
+At the current baseline, this surface emits eleven deliberately narrow relationship families:
 
 ```text
 command_emits_event
 command_targets_subsystem
 data_product_produced_by_payload
+event_sourced_from_subsystem
 fault_emits_event
 packet_includes_telemetry
 payload_accepts_command
@@ -39,6 +40,7 @@ These relationships are derived only from explicit loaded Mission Model fields:
 commands[].emits
 commands[].target
 data_products[].producer
+events[].source
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -80,7 +82,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records, payload-to-telemetry production records and telemetry-to-subsystem source records.
+It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, event-to-subsystem source records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records, payload-to-telemetry production records and telemetry-to-subsystem source records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -148,11 +150,12 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 27,
+    "total_relationships": 35,
     "relationship_types": {
       "command_emits_event": 4,
       "command_targets_subsystem": 4,
       "data_product_produced_by_payload": 1,
+      "event_sourced_from_subsystem": 8,
       "fault_emits_event": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
@@ -192,6 +195,16 @@ The current candidate manifest contains:
         "model_field": "data_products[].producer"
       },
       "relationship_count": 1
+    },
+    {
+      "relationship_type": "event_sourced_from_subsystem",
+      "display_name": "Event sourced from subsystem",
+      "from_domain": "events",
+      "to_domain": "subsystems",
+      "derived_from": {
+        "model_field": "events[].source"
+      },
+      "relationship_count": 8
     },
     {
       "relationship_type": "fault_emits_event",
@@ -432,6 +445,49 @@ This is a direct data product contract reference.
 It is emitted only when `data_products[].producer_type` is `payload` and `data_products[].producer` resolves to an indexed payload.
 
 It is not derived from data product ID prefixes, payload naming conventions, storage policy or downlink policy.
+
+### event_sourced_from_subsystem
+
+This relationship states that an event is sourced from an indexed subsystem.
+
+It is derived from:
+
+```text
+events[].source
+```
+
+Relationship endpoints are:
+
+```text
+from: events.<id>
+to: subsystems.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "events:eps.battery_low->event_sourced_from_subsystem:subsystems:eps",
+  "relationship_type": "event_sourced_from_subsystem",
+  "from": {
+    "domain": "events",
+    "id": "eps.battery_low"
+  },
+  "to": {
+    "domain": "subsystems",
+    "id": "eps"
+  },
+  "derived_from": {
+    "model_field": "events[].source"
+  }
+}
+```
+
+This is a direct event contract reference.
+
+It is emitted only when `events[].source` resolves to an indexed subsystem.
+
+It is not derived from event ID prefixes, subsystem naming conventions, command emissions, fault emissions or payload event declarations.
 
 ### fault_emits_event
 
@@ -736,6 +792,7 @@ Currently admitted derivation sources:
 commands[].emits
 commands[].target
 data_products[].producer
+events[].source
 faults[].emits
 packets[].telemetry
 payloads[].commands.accepted
@@ -749,7 +806,6 @@ Candidate future derivation sources may include explicit fields such as:
 
 ```text
 command.expected_effects
-event.source
 fault.source
 fault.recovery.auto_commands
 payload.faults.possible
@@ -957,6 +1013,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event`, `payload_produces_telemetry` and `telemetry_sourced_from_subsystem` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `event_sourced_from_subsystem`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event`, `payload_produces_telemetry` and `telemetry_sourced_from_subsystem` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -9,6 +9,7 @@ from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import (
     Command,
     DataProductContract,
+    Event,
     Fault,
     MissionModel,
     Packet,
@@ -19,6 +20,7 @@ from orbitfabric.model.mission import (
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
+REL_EVENT_SOURCED_FROM_SUBSYSTEM = "event_sourced_from_subsystem"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
@@ -131,6 +133,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
             data_product,
             model.payload_ids,
         )
+    )
+    records.extend(
+        record
+        for event in sorted(model.events, key=lambda item: item.id)
+        for record in _event_subsystem_relationship_records(event, model.subsystem_ids)
     )
     records.extend(
         record
@@ -252,6 +259,35 @@ def _data_product_payload_relationship_records(
             },
             "derived_from": {
                 "model_field": "data_products[].producer",
+            },
+        }
+    ]
+
+
+def _event_subsystem_relationship_records(
+    event: Event,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if event.source not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"events:{event.id}->{REL_EVENT_SOURCED_FROM_SUBSYSTEM}:"
+                f"subsystems:{event.source}"
+            ),
+            "relationship_type": REL_EVENT_SOURCED_FROM_SUBSYSTEM,
+            "from": {
+                "domain": "events",
+                "id": event.id,
+            },
+            "to": {
+                "domain": "subsystems",
+                "id": event.source,
+            },
+            "derived_from": {
+                "model_field": "events[].source",
             },
         }
     ]
@@ -473,6 +509,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "payloads",
             "derived_from": {
                 "model_field": "data_products[].producer",
+            },
+        },
+        REL_EVENT_SOURCED_FROM_SUBSYSTEM: {
+            "relationship_type": REL_EVENT_SOURCED_FROM_SUBSYSTEM,
+            "display_name": "Event sourced from subsystem",
+            "from_domain": "events",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "events[].source",
             },
         },
         REL_FAULT_EMITS_EVENT: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 27" in result.output
+    assert "Relationships emitted: 35" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,11 +40,12 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 27
+    assert manifest["counts"]["total_relationships"] == 35
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
         "data_product_produced_by_payload": 1,
+        "event_sourced_from_subsystem": 8,
         "fault_emits_event": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
@@ -53,8 +54,8 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 10
-    assert len(manifest["relationships"]) == 27
+    assert len(manifest["relationship_types"]) == 11
+    assert len(manifest["relationships"]) == 35
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,11 +55,12 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 27,
+        "total_relationships": 35,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
             "data_product_produced_by_payload": 1,
+            "event_sourced_from_subsystem": 8,
             "fault_emits_event": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
@@ -99,6 +100,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
                 "model_field": "data_products[].producer",
             },
             "relationship_count": 1,
+        },
+        {
+            "relationship_type": "event_sourced_from_subsystem",
+            "display_name": "Event sourced from subsystem",
+            "from_domain": "events",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "events[].source",
+            },
+            "relationship_count": 8,
         },
         {
             "relationship_type": "fault_emits_event",
@@ -173,7 +184,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 27
+    assert len(relationships) == 35
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -187,6 +198,14 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
         "commands:radio.downlink_housekeeping->command_targets_subsystem:subsystems:radio",
         "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
+        "events:eps.battery_critical->event_sourced_from_subsystem:subsystems:eps",
+        "events:eps.battery_low->event_sourced_from_subsystem:subsystems:eps",
+        "events:eps.status_requested->event_sourced_from_subsystem:subsystems:eps",
+        "events:obc.mode_changed->event_sourced_from_subsystem:subsystems:obc",
+        "events:payload.acquisition_started->event_sourced_from_subsystem:subsystems:payload",
+        "events:payload.acquisition_stopped->event_sourced_from_subsystem:subsystems:payload",
+        "events:payload.command_timeout->event_sourced_from_subsystem:subsystems:payload",
+        "events:radio.housekeeping_downlink_requested->event_sourced_from_subsystem:subsystems:radio",
         "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
         "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
@@ -237,6 +256,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in payload_ids
             assert relationship["derived_from"] == {
                 "model_field": "data_products[].producer",
+            }
+        elif relationship["relationship_type"] == "event_sourced_from_subsystem":
+            assert relationship["from"]["domain"] == "events"
+            assert relationship["from"]["id"] in event_ids
+            assert relationship["to"]["domain"] == "subsystems"
+            assert relationship["to"]["id"] in subsystem_ids
+            assert relationship["derived_from"] == {
+                "model_field": "events[].source",
             }
         elif relationship["relationship_type"] == "fault_emits_event":
             assert relationship["from"]["domain"] == "faults"


### PR DESCRIPTION
## Summary

This PR admits the eleventh deterministic relationship family into the candidate Relationship Manifest Surface:

```text
event_sourced_from_subsystem
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
events[].source
```

Records are emitted only when `events[].source` resolves to an indexed subsystem.

For the demo mission, this adds 8 event-to-subsystem relationship records.

The demo manifest now emits 35 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 1 `data_product_produced_by_payload`
- 8 `event_sourced_from_subsystem`
- 2 `fault_emits_event`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 1 `payload_belongs_to_subsystem`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`
- 5 `telemetry_sourced_from_subsystem`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
event_sourced_from_subsystem
```

It does not add event-to-payload relationships, fault source relationships, telemetry source relationships beyond the already admitted telemetry family or command expected-effect relationships.

It does not use event ID prefixes, subsystem naming conventions, command emissions, fault emissions, payload event declarations, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 35,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "data_product_produced_by_payload": 1,
      "event_sourced_from_subsystem": 8,
      "fault_emits_event": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_belongs_to_subsystem": 1,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1,
      "telemetry_sourced_from_subsystem": 5
    }
  }
}
```

for the demo mission.

Event subsystem relationship records use:

```text
from.domain = events
from.id = <event id>
to.domain = subsystems
to.id = <subsystem id>
derived_from.model_field = events[].source
```

## Non-goals

This PR intentionally does not introduce:

- event-to-payload relationships;
- fault source relationships;
- telemetry source semantics beyond the existing telemetry_sourced_from_subsystem family;
- command expected-effect relationships;
- payload fault relationships;
- data-product-to-subsystem relationships;
- storage relationships;
- downlink relationships;
- contact or downlink flow relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
