### PR TITLE
feat: add fault subsystem relationship records

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -18,7 +18,7 @@ It is intended to answer:
 How are indexed mission contract entities related?
 ```
 
-At the current baseline, this surface emits eleven deliberately narrow relationship families:
+At the current baseline, this surface emits twelve deliberately narrow relationship families:
 
 ```text
 command_emits_event
@@ -26,6 +26,7 @@ command_targets_subsystem
 data_product_produced_by_payload
 event_sourced_from_subsystem
 fault_emits_event
+fault_sourced_from_subsystem
 packet_includes_telemetry
 payload_accepts_command
 payload_belongs_to_subsystem
@@ -42,6 +43,7 @@ commands[].target
 data_products[].producer
 events[].source
 faults[].emits
+faults[].source
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].subsystem
@@ -82,7 +84,7 @@ What contract entities are defined in this mission?
 
 `relationship_manifest.json` is currently a candidate relationship surface.
 
-It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, event-to-subsystem source records, fault-to-event emission records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records, payload-to-telemetry production records and telemetry-to-subsystem source records.
+It emits command-to-event emission records, command-to-subsystem target records, data-product-to-payload producer records, event-to-subsystem source records, fault-to-event emission records, fault-to-subsystem source records, packet-to-telemetry inclusion records, payload-to-command acceptance records, payload-to-subsystem membership records, payload-to-event generation records, payload-to-telemetry production records and telemetry-to-subsystem source records.
 
 `entity_index.json` contains nodes, not edges.
 
@@ -150,13 +152,14 @@ The current candidate manifest contains:
   "kind": "orbitfabric.relationship_manifest",
   "status": "candidate",
   "counts": {
-    "total_relationships": 35,
+    "total_relationships": 37,
     "relationship_types": {
       "command_emits_event": 4,
       "command_targets_subsystem": 4,
       "data_product_produced_by_payload": 1,
       "event_sourced_from_subsystem": 8,
       "fault_emits_event": 2,
+      "fault_sourced_from_subsystem": 2,
       "packet_includes_telemetry": 5,
       "payload_accepts_command": 2,
       "payload_belongs_to_subsystem": 1,
@@ -213,6 +216,16 @@ The current candidate manifest contains:
       "to_domain": "events",
       "derived_from": {
         "model_field": "faults[].emits"
+      },
+      "relationship_count": 2
+    },
+    {
+      "relationship_type": "fault_sourced_from_subsystem",
+      "display_name": "Fault sourced from subsystem",
+      "from_domain": "faults",
+      "to_domain": "subsystems",
+      "derived_from": {
+        "model_field": "faults[].source"
       },
       "relationship_count": 2
     },
@@ -530,6 +543,49 @@ This is a direct fault contract reference.
 
 It is not derived from fault ID prefixes, event ID prefixes, fault conditions, source fields or recovery actions.
 
+### fault_sourced_from_subsystem
+
+This relationship states that a fault is sourced from an indexed subsystem.
+
+It is derived from:
+
+```text
+faults[].source
+```
+
+Relationship endpoints are:
+
+```text
+from: faults.<id>
+to: subsystems.<id>
+```
+
+Conceptual record shape:
+
+```json
+{
+  "relationship_id": "faults:eps.battery_low_fault->fault_sourced_from_subsystem:subsystems:eps",
+  "relationship_type": "fault_sourced_from_subsystem",
+  "from": {
+    "domain": "faults",
+    "id": "eps.battery_low_fault"
+  },
+  "to": {
+    "domain": "subsystems",
+    "id": "eps"
+  },
+  "derived_from": {
+    "model_field": "faults[].source"
+  }
+}
+```
+
+This is a direct fault contract reference.
+
+It is emitted only when `faults[].source` resolves to an indexed subsystem.
+
+It is not derived from fault ID prefixes, subsystem naming conventions, fault emissions, fault conditions or recovery actions.
+
 ### packet_includes_telemetry
 
 This relationship states that a packet includes a telemetry item.
@@ -794,6 +850,7 @@ commands[].target
 data_products[].producer
 events[].source
 faults[].emits
+faults[].source
 packets[].telemetry
 payloads[].commands.accepted
 payloads[].subsystem
@@ -806,7 +863,6 @@ Candidate future derivation sources may include explicit fields such as:
 
 ```text
 command.expected_effects
-fault.source
 fault.recovery.auto_commands
 payload.faults.possible
 data_product.payload
@@ -1013,6 +1069,6 @@ keep Studio-specific behavior out of Core
 
 The Relationship Manifest Surface is a candidate Core-owned read-only inspection surface.
 
-It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `event_sourced_from_subsystem`, `fault_emits_event`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event`, `payload_produces_telemetry` and `telemetry_sourced_from_subsystem` relationships.
+It currently emits `command_emits_event`, `command_targets_subsystem`, `data_product_produced_by_payload`, `event_sourced_from_subsystem`, `fault_emits_event`, `fault_sourced_from_subsystem`, `packet_includes_telemetry`, `payload_accepts_command`, `payload_belongs_to_subsystem`, `payload_generates_event`, `payload_produces_telemetry` and `telemetry_sourced_from_subsystem` relationships.
 
 Additional relationship families may be added only if Core can derive them deterministically from explicit Mission Model semantics.

--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -22,6 +22,7 @@ REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
 REL_EVENT_SOURCED_FROM_SUBSYSTEM = "event_sourced_from_subsystem"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
+REL_FAULT_SOURCED_FROM_SUBSYSTEM = "fault_sourced_from_subsystem"
 REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_BELONGS_TO_SUBSYSTEM = "payload_belongs_to_subsystem"
@@ -143,6 +144,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         record
         for fault in sorted(model.faults, key=lambda item: item.id)
         for record in _fault_event_relationship_records(fault)
+    )
+    records.extend(
+        record
+        for fault in sorted(model.faults, key=lambda item: item.id)
+        for record in _fault_subsystem_relationship_records(fault, model.subsystem_ids)
     )
     records.extend(
         record
@@ -311,6 +317,35 @@ def _fault_event_relationship_records(fault: Fault) -> list[dict[str, Any]]:
             },
         }
         for event_id in sorted(fault.emits)
+    ]
+
+
+def _fault_subsystem_relationship_records(
+    fault: Fault,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if fault.source not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"faults:{fault.id}->{REL_FAULT_SOURCED_FROM_SUBSYSTEM}:"
+                f"subsystems:{fault.source}"
+            ),
+            "relationship_type": REL_FAULT_SOURCED_FROM_SUBSYSTEM,
+            "from": {
+                "domain": "faults",
+                "id": fault.id,
+            },
+            "to": {
+                "domain": "subsystems",
+                "id": fault.source,
+            },
+            "derived_from": {
+                "model_field": "faults[].source",
+            },
+        }
     ]
 
 
@@ -527,6 +562,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "faults[].emits",
+            },
+        },
+        REL_FAULT_SOURCED_FROM_SUBSYSTEM: {
+            "relationship_type": REL_FAULT_SOURCED_FROM_SUBSYSTEM,
+            "display_name": "Fault sourced from subsystem",
+            "from_domain": "faults",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "faults[].source",
             },
         },
         REL_PACKET_INCLUDES_TELEMETRY: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 35" in result.output
+    assert "Relationships emitted: 37" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,13 +40,14 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 35
+    assert manifest["counts"]["total_relationships"] == 37
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
         "data_product_produced_by_payload": 1,
         "event_sourced_from_subsystem": 8,
         "fault_emits_event": 2,
+        "fault_sourced_from_subsystem": 2,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_belongs_to_subsystem": 1,
@@ -54,8 +55,8 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 11
-    assert len(manifest["relationships"]) == 35
+    assert len(manifest["relationship_types"]) == 12
+    assert len(manifest["relationships"]) == 37
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,13 +55,14 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 35,
+        "total_relationships": 37,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
             "data_product_produced_by_payload": 1,
             "event_sourced_from_subsystem": 8,
             "fault_emits_event": 2,
+            "fault_sourced_from_subsystem": 2,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
             "payload_belongs_to_subsystem": 1,
@@ -118,6 +119,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "faults[].emits",
+            },
+            "relationship_count": 2,
+        },
+        {
+            "relationship_type": "fault_sourced_from_subsystem",
+            "display_name": "Fault sourced from subsystem",
+            "from_domain": "faults",
+            "to_domain": "subsystems",
+            "derived_from": {
+                "model_field": "faults[].source",
             },
             "relationship_count": 2,
         },
@@ -184,7 +195,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 35
+    assert len(relationships) == 37
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -207,7 +218,9 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "events:payload.command_timeout->event_sourced_from_subsystem:subsystems:payload",
         "events:radio.housekeeping_downlink_requested->event_sourced_from_subsystem:subsystems:radio",
         "faults:eps.battery_critical_fault->fault_emits_event:events:eps.battery_critical",
+        "faults:eps.battery_critical_fault->fault_sourced_from_subsystem:subsystems:eps",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
+        "faults:eps.battery_low_fault->fault_sourced_from_subsystem:subsystems:eps",
         "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
@@ -272,6 +285,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in event_ids
             assert relationship["derived_from"] == {
                 "model_field": "faults[].emits",
+            }
+        elif relationship["relationship_type"] == "fault_sourced_from_subsystem":
+            assert relationship["from"]["domain"] == "faults"
+            assert relationship["from"]["id"] in fault_ids
+            assert relationship["to"]["domain"] == "subsystems"
+            assert relationship["to"]["id"] in subsystem_ids
+            assert relationship["derived_from"] == {
+                "model_field": "faults[].source",
             }
         elif relationship["relationship_type"] == "packet_includes_telemetry":
             assert relationship["from"]["domain"] == "packets"


### PR DESCRIPTION
## Summary

This PR admits the twelfth deterministic relationship family into the candidate Relationship Manifest Surface:

```text
fault_sourced_from_subsystem
```

The relationship records are derived only from the explicit loaded Mission Model field:

```text
faults[].source
```

Records are emitted only when `faults[].source` resolves to an indexed subsystem.

For the demo mission, this adds 2 fault-to-subsystem relationship records.

The demo manifest now emits 37 relationships total:

- 4 `command_emits_event`
- 4 `command_targets_subsystem`
- 1 `data_product_produced_by_payload`
- 8 `event_sourced_from_subsystem`
- 2 `fault_emits_event`
- 2 `fault_sourced_from_subsystem`
- 5 `packet_includes_telemetry`
- 2 `payload_accepts_command`
- 1 `payload_belongs_to_subsystem`
- 2 `payload_generates_event`
- 1 `payload_produces_telemetry`
- 5 `telemetry_sourced_from_subsystem`

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR introduces exactly one new admitted relationship type:

```text
fault_sourced_from_subsystem
```

It does not add fault condition relationships, fault recovery relationships, fault auto-command relationships, payload fault relationships or command expected-effect relationships.

It does not use fault ID prefixes, subsystem naming conventions, fault emissions, fault conditions, recovery actions, raw YAML scanning or downstream assumptions.

## Output shape

The manifest now contains:

```json
{
  "counts": {
    "total_relationships": 37,
    "relationship_types": {
      "command_emits_event": 4,
      "command_targets_subsystem": 4,
      "data_product_produced_by_payload": 1,
      "event_sourced_from_subsystem": 8,
      "fault_emits_event": 2,
      "fault_sourced_from_subsystem": 2,
      "packet_includes_telemetry": 5,
      "payload_accepts_command": 2,
      "payload_belongs_to_subsystem": 1,
      "payload_generates_event": 2,
      "payload_produces_telemetry": 1,
      "telemetry_sourced_from_subsystem": 5
    }
  }
}
```

for the demo mission.

Fault subsystem relationship records use:

```text
from.domain = faults
from.id = <fault id>
to.domain = subsystems
to.id = <subsystem id>
derived_from.model_field = faults[].source
```

## Non-goals

This PR intentionally does not introduce:

- fault condition relationships;
- fault recovery relationships;
- fault auto-command relationships;
- payload fault relationships;
- command expected-effect relationships;
- data-product-to-subsystem relationships;
- storage relationships;
- downlink relationships;
- contact or downlink flow relationships;
- commandability relationships;
- autonomous action relationships;
- recovery intent relationships;
- relationship inference;
- graph semantics;
- dependency graph;
- source locations;
- YAML AST export;
- plugin API;
- plugin loader;
- Studio API;
- runtime behavior;
- ground behavior.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
