### PR TITLE
feat: add downlink flow data product relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -9,6 +9,7 @@ from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import (
     Command,
     DataProductContract,
+    DownlinkFlowContract,
     Event,
     Fault,
     MissionModel,
@@ -20,6 +21,7 @@ from orbitfabric.model.mission import (
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
+REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT = "downlink_flow_includes_data_product"
 REL_EVENT_SOURCED_FROM_SUBSYSTEM = "event_sourced_from_subsystem"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
 REL_FAULT_SOURCED_FROM_SUBSYSTEM = "fault_sourced_from_subsystem"
@@ -133,6 +135,17 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         for record in _data_product_payload_relationship_records(
             data_product,
             model.payload_ids,
+        )
+    )
+    records.extend(
+        record
+        for downlink_flow in sorted(
+            model.contacts.downlink_flows,
+            key=lambda item: item.id,
+        )
+        for record in _downlink_flow_data_product_relationship_records(
+            downlink_flow,
+            model.data_product_ids,
         )
     )
     records.extend(
@@ -267,6 +280,35 @@ def _data_product_payload_relationship_records(
                 "model_field": "data_products[].producer",
             },
         }
+    ]
+
+
+def _downlink_flow_data_product_relationship_records(
+    downlink_flow: DownlinkFlowContract,
+    data_product_ids: set[str],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"downlink_flows:{downlink_flow.id}->"
+                f"{REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT}:"
+                f"data_products:{data_product_id}"
+            ),
+            "relationship_type": REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT,
+            "from": {
+                "domain": "downlink_flows",
+                "id": downlink_flow.id,
+            },
+            "to": {
+                "domain": "data_products",
+                "id": data_product_id,
+            },
+            "derived_from": {
+                "model_field": "downlink_flows[].eligible_data_products",
+            },
+        }
+        for data_product_id in sorted(downlink_flow.eligible_data_products)
+        if data_product_id in data_product_ids
     ]
 
 
@@ -544,6 +586,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "payloads",
             "derived_from": {
                 "model_field": "data_products[].producer",
+            },
+        },
+        REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT: {
+            "relationship_type": REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT,
+            "display_name": "Downlink flow includes data product",
+            "from_domain": "downlink_flows",
+            "to_domain": "data_products",
+            "derived_from": {
+                "model_field": "downlink_flows[].eligible_data_products",
             },
         },
         REL_EVENT_SOURCED_FROM_SUBSYSTEM: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 37" in result.output
+    assert "Relationships emitted: 38" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,11 +40,12 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 37
+    assert manifest["counts"]["total_relationships"] == 38
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
         "data_product_produced_by_payload": 1,
+        "downlink_flow_includes_data_product": 1,
         "event_sourced_from_subsystem": 8,
         "fault_emits_event": 2,
         "fault_sourced_from_subsystem": 2,
@@ -55,8 +56,8 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 12
-    assert len(manifest["relationships"]) == 37
+    assert len(manifest["relationship_types"]) == 13
+    assert len(manifest["relationships"]) == 38
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,11 +55,12 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 37,
+        "total_relationships": 38,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
             "data_product_produced_by_payload": 1,
+            "downlink_flow_includes_data_product": 1,
             "event_sourced_from_subsystem": 8,
             "fault_emits_event": 2,
             "fault_sourced_from_subsystem": 2,
@@ -99,6 +100,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "to_domain": "payloads",
             "derived_from": {
                 "model_field": "data_products[].producer",
+            },
+            "relationship_count": 1,
+        },
+        {
+            "relationship_type": "downlink_flow_includes_data_product",
+            "display_name": "Downlink flow includes data product",
+            "from_domain": "downlink_flows",
+            "to_domain": "data_products",
+            "derived_from": {
+                "model_field": "downlink_flows[].eligible_data_products",
             },
             "relationship_count": 1,
         },
@@ -195,7 +206,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 37
+    assert len(relationships) == 38
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -209,6 +220,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "commands:radio.downlink_housekeeping->command_emits_event:events:radio.housekeeping_downlink_requested",
         "commands:radio.downlink_housekeeping->command_targets_subsystem:subsystems:radio",
         "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
+        "downlink_flows:science_next_available_contact->downlink_flow_includes_data_product:data_products:payload.radiation_histogram",
         "events:eps.battery_critical->event_sourced_from_subsystem:subsystems:eps",
         "events:eps.battery_low->event_sourced_from_subsystem:subsystems:eps",
         "events:eps.status_requested->event_sourced_from_subsystem:subsystems:eps",
@@ -244,6 +256,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     fault_ids = {fault.id for fault in model.faults}
     subsystem_ids = {subsystem.id for subsystem in model.subsystems}
     data_product_ids = {data_product.id for data_product in model.data_products}
+    downlink_flow_ids = {flow.id for flow in model.contacts.downlink_flows}
 
     for relationship in manifest["relationships"]:
         if relationship["relationship_type"] == "command_emits_event":
@@ -269,6 +282,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in payload_ids
             assert relationship["derived_from"] == {
                 "model_field": "data_products[].producer",
+            }
+        elif relationship["relationship_type"] == "downlink_flow_includes_data_product":
+            assert relationship["from"]["domain"] == "downlink_flows"
+            assert relationship["from"]["id"] in downlink_flow_ids
+            assert relationship["to"]["domain"] == "data_products"
+            assert relationship["to"]["id"] in data_product_ids
+            assert relationship["derived_from"] == {
+                "model_field": "downlink_flows[].eligible_data_products",
             }
         elif relationship["relationship_type"] == "event_sourced_from_subsystem":
             assert relationship["from"]["domain"] == "events"


### PR DESCRIPTION
## Summary

Adds one deterministic relationship family to the candidate Relationship Manifest Surface:

```text
downlink_flow_includes_data_product
```

Derived only from:

```text
downlink_flows[].eligible_data_products
```

A record is emitted only when the referenced data product resolves to an indexed data product.

For `examples/demo-3u/mission`, this adds 1 record and brings the demo manifest to 38 total relationships.

## Scope

Modified:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_export.py`
- `tests/test_relationship_manifest_cli.py`

## Documentation note

The reference page is intentionally left out of this PR to avoid rewriting a large document non-conservatively. A dedicated docs-only follow-up should update `docs/reference/relationship-manifest-surface.md` after this technical PR passes.

## Boundary

This PR adds no contact profile relationships, link profile relationships, contact window relationships, storage relationships, commandability relationships, plugin API, Studio API, runtime behavior or ground behavior.

It uses no ID-prefix inference, naming-convention inference, raw YAML scanning or downstream assumptions.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
