### PR TITLE
feat: add data product subsystem relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -21,6 +21,7 @@ from orbitfabric.model.mission import (
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
+REL_DATA_PRODUCT_PRODUCED_BY_SUBSYSTEM = "data_product_produced_by_subsystem"
 REL_DOWNLINK_FLOW_INCLUDES_DATA_PRODUCT = "downlink_flow_includes_data_product"
 REL_EVENT_SOURCED_FROM_SUBSYSTEM = "event_sourced_from_subsystem"
 REL_FAULT_EMITS_EVENT = "fault_emits_event"
@@ -135,6 +136,14 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         for record in _data_product_payload_relationship_records(
             data_product,
             model.payload_ids,
+        )
+    )
+    records.extend(
+        record
+        for data_product in sorted(model.data_products, key=lambda item: item.id)
+        for record in _data_product_subsystem_relationship_records(
+            data_product,
+            model.subsystem_ids,
         )
     )
     records.extend(
@@ -274,6 +283,38 @@ def _data_product_payload_relationship_records(
             },
             "to": {
                 "domain": "payloads",
+                "id": data_product.producer,
+            },
+            "derived_from": {
+                "model_field": "data_products[].producer",
+            },
+        }
+    ]
+
+
+def _data_product_subsystem_relationship_records(
+    data_product: DataProductContract,
+    subsystem_ids: set[str],
+) -> list[dict[str, Any]]:
+    if data_product.producer_type != "subsystem":
+        return []
+    if data_product.producer not in subsystem_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"data_products:{data_product.id}->"
+                f"{REL_DATA_PRODUCT_PRODUCED_BY_SUBSYSTEM}:"
+                f"subsystems:{data_product.producer}"
+            ),
+            "relationship_type": REL_DATA_PRODUCT_PRODUCED_BY_SUBSYSTEM,
+            "from": {
+                "domain": "data_products",
+                "id": data_product.id,
+            },
+            "to": {
+                "domain": "subsystems",
                 "id": data_product.producer,
             },
             "derived_from": {
@@ -584,6 +625,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "display_name": "Data product produced by payload",
             "from_domain": "data_products",
             "to_domain": "payloads",
+            "derived_from": {
+                "model_field": "data_products[].producer",
+            },
+        },
+        REL_DATA_PRODUCT_PRODUCED_BY_SUBSYSTEM: {
+            "relationship_type": REL_DATA_PRODUCT_PRODUCED_BY_SUBSYSTEM,
+            "display_name": "Data product produced by subsystem",
+            "from_domain": "data_products",
+            "to_domain": "subsystems",
             "derived_from": {
                 "model_field": "data_products[].producer",
             },

--- a/tests/test_relationship_manifest_examples.py
+++ b/tests/test_relationship_manifest_examples.py
@@ -8,6 +8,34 @@ from orbitfabric.model.loader import MissionModelLoader
 SPACELAB_MINISLICE = Path("examples/spacelab-inspired-communications-minislice/mission")
 
 
+def test_relationship_manifest_emits_data_product_subsystem_records_for_spacelab_minislice() -> None:
+    model = MissionModelLoader().load(SPACELAB_MINISLICE)
+
+    manifest = relationship_manifest_to_dict(model, SPACELAB_MINISLICE)
+    relationships = manifest["relationships"]
+    data_product_relationships = [
+        relationship
+        for relationship in relationships
+        if relationship["relationship_type"] == "data_product_produced_by_subsystem"
+    ]
+
+    assert len(data_product_relationships) == 7
+    assert {
+        relationship["relationship_id"] for relationship in data_product_relationships
+    } == {
+        "data_products:critical_housekeeping_packet->data_product_produced_by_subsystem:subsystems:obdh",
+        "data_products:decoder_reception_log->data_product_produced_by_subsystem:subsystems:decoder_context",
+        "data_products:downlink_summary_report->data_product_produced_by_subsystem:subsystems:obdh",
+        "data_products:periodic_beacon_packet->data_product_produced_by_subsystem:subsystems:beacon_context",
+        "data_products:requested_data_frame_batch->data_product_produced_by_subsystem:subsystems:data_storage",
+        "data_products:requested_telemetry_frame_batch->data_product_produced_by_subsystem:subsystems:obdh",
+        "data_products:scenario_evidence_log->data_product_produced_by_subsystem:subsystems:obdh",
+    }
+    assert manifest["counts"]["relationship_types"][
+        "data_product_produced_by_subsystem"
+    ] == 7
+
+
 def test_relationship_manifest_emits_downlink_flow_records_for_spacelab_minislice() -> None:
     model = MissionModelLoader().load(SPACELAB_MINISLICE)
 

--- a/tests/test_relationship_manifest_examples.py
+++ b/tests/test_relationship_manifest_examples.py
@@ -8,7 +8,7 @@ from orbitfabric.model.loader import MissionModelLoader
 SPACELAB_MINISLICE = Path("examples/spacelab-inspired-communications-minislice/mission")
 
 
-def test_relationship_manifest_emits_data_product_subsystem_records_for_spacelab_minislice() -> None:
+def test_relationship_manifest_emits_data_product_subsystem_records() -> None:
     model = MissionModelLoader().load(SPACELAB_MINISLICE)
 
     manifest = relationship_manifest_to_dict(model, SPACELAB_MINISLICE)


### PR DESCRIPTION
## Summary

Adds one deterministic relationship family to the candidate Relationship Manifest Surface:

```text
data_product_produced_by_subsystem
```

Derived only from:

```text
data_products[].producer
```

A record is emitted only when:

- `data_products[].producer_type == subsystem`
- `data_products[].producer` resolves to an indexed subsystem

## Example coverage

The richer SpaceLab-inspired communications minislice now exercises this family with 7 records.

The demo mission remains unchanged for CLI counts because its data product producer is a payload, not a subsystem.

## Scope

Modified only:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_examples.py`

## Documentation note

The reference page is intentionally left out of this PR to avoid rewriting a large document non-conservatively. A dedicated docs-only follow-up should update `docs/reference/relationship-manifest-surface.md` after this technical PR passes.

## Boundary

This PR adds no storage relationships, downlink policy relationships, payload inference, subsystem behavior, runtime behavior, ground behavior, plugin API or Studio API.

It uses no ID-prefix inference, naming-convention inference, storage policy inference, downlink policy inference, raw YAML scanning or downstream assumptions.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
