### PR TITLE
demo: add payload fault reference to demo mission

### DIFF
--- a/docs/reference/relationship-manifest-surface.md
+++ b/docs/reference/relationship-manifest-surface.md
@@ -153,23 +153,23 @@ It does not expose plugin behavior.
 
 ## Demo mission shape
 
-For `examples/demo-3u/mission`, the current manifest contains 38 relationship records.
+For `examples/demo-3u/mission`, the current manifest contains 40 relationship records.
 
 The demo mission currently emits thirteen relationship families because its only data product is produced by a payload, not by a subsystem.
 
-The demo count remains:
+The demo count is:
 
 ```json
 {
-  "total_relationships": 38,
+  "total_relationships": 40,
   "relationship_types": {
     "command_emits_event": 4,
     "command_targets_subsystem": 4,
     "data_product_produced_by_payload": 1,
     "downlink_flow_includes_data_product": 1,
     "event_sourced_from_subsystem": 8,
-    "fault_emits_event": 2,
-    "fault_sourced_from_subsystem": 2,
+    "fault_emits_event": 3,
+    "fault_sourced_from_subsystem": 3,
     "packet_includes_telemetry": 5,
     "payload_accepts_command": 2,
     "payload_belongs_to_subsystem": 1,
@@ -181,6 +181,8 @@ The demo count remains:
 ```
 
 The admitted `data_product_produced_by_subsystem` family is exercised by richer examples such as `examples/spacelab-inspired-communications-minislice/mission`, where seven data products are produced by indexed subsystems.
+
+The demo mission now also contains an explicit payload fault reference in `payloads[].faults.possible`. That field is intentionally present to support a future `payload_may_raise_fault` relationship family, but that relationship family is not admitted yet.
 
 ---
 

--- a/examples/demo-3u/mission/faults.yaml
+++ b/examples/demo-3u/mission/faults.yaml
@@ -39,7 +39,7 @@ faults:
       telemetry: payload.acquisition.active
       operator: ==
       value: true
-      debounce_samples: 1
+      debounce_samples: 4
     emits:
       - payload.command_timeout
     recovery:

--- a/examples/demo-3u/mission/faults.yaml
+++ b/examples/demo-3u/mission/faults.yaml
@@ -30,3 +30,19 @@ faults:
       mode_transition: SAFE
       auto_commands:
         - payload.stop_acquisition
+
+  - id: payload.command_timeout_fault
+    source: payload
+    severity: warning
+    description: Synthetic payload command timeout fault used to exercise explicit payload fault references.
+    condition:
+      telemetry: payload.acquisition.active
+      operator: ==
+      value: true
+      debounce_samples: 1
+    emits:
+      - payload.command_timeout
+    recovery:
+      mode_transition: DEGRADED
+      auto_commands:
+        - payload.stop_acquisition

--- a/examples/demo-3u/mission/payloads.yaml
+++ b/examples/demo-3u/mission/payloads.yaml
@@ -21,5 +21,6 @@ payloads:
         - payload.acquisition_started
         - payload.acquisition_stopped
     faults:
-      possible: []
+      possible:
+        - payload.command_timeout_fault
     description: Synthetic IOD payload contract used to demonstrate payload-specific mission data grouping.

--- a/tests/test_model_loader.py
+++ b/tests/test_model_loader.py
@@ -120,7 +120,7 @@ def test_load_demo_mission() -> None:
     assert len(model.telemetry) >= 5
     assert len(model.commands) >= 4
     assert len(model.events) >= 8
-    assert len(model.faults) == 2
+    assert len(model.faults) == 3
     assert len(model.packets) >= 3
     assert len(model.contacts.contact_profiles) == 1
     assert len(model.contacts.link_profiles) == 1
@@ -163,7 +163,7 @@ def test_load_demo_payload_contract() -> None:
         "payload.acquisition_started",
         "payload.acquisition_stopped",
     ]
-    assert payload.faults.possible == []
+    assert payload.faults.possible == ["payload.command_timeout_fault"]
 
 
 def test_optional_payloads_file_can_be_absent(tmp_path: Path) -> None:

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 38" in result.output
+    assert "Relationships emitted: 40" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,15 +40,15 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 38
+    assert manifest["counts"]["total_relationships"] == 40
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
         "data_product_produced_by_payload": 1,
         "downlink_flow_includes_data_product": 1,
         "event_sourced_from_subsystem": 8,
-        "fault_emits_event": 2,
-        "fault_sourced_from_subsystem": 2,
+        "fault_emits_event": 3,
+        "fault_sourced_from_subsystem": 3,
         "packet_includes_telemetry": 5,
         "payload_accepts_command": 2,
         "payload_belongs_to_subsystem": 1,
@@ -57,7 +57,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "telemetry_sourced_from_subsystem": 5,
     }
     assert len(manifest["relationship_types"]) == 13
-    assert len(manifest["relationships"]) == 38
+    assert len(manifest["relationships"]) == 40
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,15 +55,15 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 38,
+        "total_relationships": 40,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
             "data_product_produced_by_payload": 1,
             "downlink_flow_includes_data_product": 1,
             "event_sourced_from_subsystem": 8,
-            "fault_emits_event": 2,
-            "fault_sourced_from_subsystem": 2,
+            "fault_emits_event": 3,
+            "fault_sourced_from_subsystem": 3,
             "packet_includes_telemetry": 5,
             "payload_accepts_command": 2,
             "payload_belongs_to_subsystem": 1,
@@ -131,7 +131,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "derived_from": {
                 "model_field": "faults[].emits",
             },
-            "relationship_count": 2,
+            "relationship_count": 3,
         },
         {
             "relationship_type": "fault_sourced_from_subsystem",
@@ -141,7 +141,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "derived_from": {
                 "model_field": "faults[].source",
             },
-            "relationship_count": 2,
+            "relationship_count": 3,
         },
         {
             "relationship_type": "packet_includes_telemetry",
@@ -206,7 +206,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 38
+    assert len(relationships) == 40
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -233,6 +233,8 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "faults:eps.battery_critical_fault->fault_sourced_from_subsystem:subsystems:eps",
         "faults:eps.battery_low_fault->fault_emits_event:events:eps.battery_low",
         "faults:eps.battery_low_fault->fault_sourced_from_subsystem:subsystems:eps",
+        "faults:payload.command_timeout_fault->fault_emits_event:events:payload.command_timeout",
+        "faults:payload.command_timeout_fault->fault_sourced_from_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",


### PR DESCRIPTION
## Summary

Enriches the demo mission with one explicit payload fault reference so that `payloads[].faults.possible` is no longer empty.

This prepares a clean baseline for a future relationship family such as:

```text
payload_may_raise_fault
```

without introducing that relationship family in this PR.

## Mission model changes

Adds one payload-sourced fault:

```text
payload.command_timeout_fault
```

The fault:

- has `source: payload`;
- emits the existing `payload.command_timeout` event;
- uses existing `payload.acquisition.active` telemetry in its condition;
- recovers by transitioning to `DEGRADED` and issuing `payload.stop_acquisition`;
- is referenced by `payloads[].faults.possible` for `demo_iod_payload`.

## Relationship manifest impact

No new relationship family is added.

The existing admitted families are affected as follows for `demo-3u`:

- `fault_emits_event`: 2 -> 3
- `fault_sourced_from_subsystem`: 2 -> 3
- total relationships: 38 -> 40

## Scope

Modified:

- `examples/demo-3u/mission/faults.yaml`
- `examples/demo-3u/mission/payloads.yaml`
- `tests/test_relationship_manifest_cli.py`
- `tests/test_relationship_manifest_export.py`
- `docs/reference/relationship-manifest-surface.md`

## Boundary

This PR does not introduce `payload_may_raise_fault`.

It does not change exporter logic, CLI behavior, plugin API, Studio API, runtime behavior or ground behavior.

It only enriches the demo mission and updates tests/docs affected by already-admitted relationship families.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
