### PR TITLE
feat: add payload fault relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -30,6 +30,7 @@ REL_PACKET_INCLUDES_TELEMETRY = "packet_includes_telemetry"
 REL_PAYLOAD_ACCEPTS_COMMAND = "payload_accepts_command"
 REL_PAYLOAD_BELONGS_TO_SUBSYSTEM = "payload_belongs_to_subsystem"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
+REL_PAYLOAD_MAY_RAISE_FAULT = "payload_may_raise_fault"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
 REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM = "telemetry_sourced_from_subsystem"
 
@@ -196,6 +197,11 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         record
         for payload in sorted(model.payloads, key=lambda item: item.id)
         for record in _payload_event_relationship_records(payload)
+    )
+    records.extend(
+        record
+        for payload in sorted(model.payloads, key=lambda item: item.id)
+        for record in _payload_fault_relationship_records(payload, model.fault_ids)
     )
     records.extend(
         record
@@ -563,6 +569,34 @@ def _payload_event_relationship_records(
     ]
 
 
+def _payload_fault_relationship_records(
+    payload: PayloadContract,
+    fault_ids: set[str],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "relationship_id": (
+                f"payloads:{payload.id}->{REL_PAYLOAD_MAY_RAISE_FAULT}:"
+                f"faults:{fault_id}"
+            ),
+            "relationship_type": REL_PAYLOAD_MAY_RAISE_FAULT,
+            "from": {
+                "domain": "payloads",
+                "id": payload.id,
+            },
+            "to": {
+                "domain": "faults",
+                "id": fault_id,
+            },
+            "derived_from": {
+                "model_field": "payloads[].faults.possible",
+            },
+        }
+        for fault_id in sorted(payload.faults.possible)
+        if fault_id in fault_ids
+    ]
+
+
 def _telemetry_subsystem_relationship_records(
     telemetry: TelemetryItem,
     subsystem_ids: set[str],
@@ -708,6 +742,15 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "events",
             "derived_from": {
                 "model_field": "payloads[].events.generated",
+            },
+        },
+        REL_PAYLOAD_MAY_RAISE_FAULT: {
+            "relationship_type": REL_PAYLOAD_MAY_RAISE_FAULT,
+            "display_name": "Payload may raise fault",
+            "from_domain": "payloads",
+            "to_domain": "faults",
+            "derived_from": {
+                "model_field": "payloads[].faults.possible",
             },
         },
         REL_PAYLOAD_PRODUCES_TELEMETRY: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 40" in result.output
+    assert "Relationships emitted: 41" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,7 +40,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 40
+    assert manifest["counts"]["total_relationships"] == 41
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
@@ -53,11 +53,12 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_accepts_command": 2,
         "payload_belongs_to_subsystem": 1,
         "payload_generates_event": 2,
+        "payload_may_raise_fault": 1,
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 13
-    assert len(manifest["relationships"]) == 40
+    assert len(manifest["relationship_types"]) == 14
+    assert len(manifest["relationships"]) == 41
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -55,7 +55,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 40,
+        "total_relationships": 41,
         "relationship_types": {
             "command_emits_event": 4,
             "command_targets_subsystem": 4,
@@ -68,6 +68,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "payload_accepts_command": 2,
             "payload_belongs_to_subsystem": 1,
             "payload_generates_event": 2,
+            "payload_may_raise_fault": 1,
             "payload_produces_telemetry": 1,
             "telemetry_sourced_from_subsystem": 5,
         },
@@ -184,6 +185,16 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
             "relationship_count": 2,
         },
         {
+            "relationship_type": "payload_may_raise_fault",
+            "display_name": "Payload may raise fault",
+            "from_domain": "payloads",
+            "to_domain": "faults",
+            "derived_from": {
+                "model_field": "payloads[].faults.possible",
+            },
+            "relationship_count": 1,
+        },
+        {
             "relationship_type": "payload_produces_telemetry",
             "display_name": "Payload produces telemetry",
             "from_domain": "payloads",
@@ -206,7 +217,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 40
+    assert len(relationships) == 41
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -238,6 +249,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
+        "payloads:demo_iod_payload->payload_may_raise_fault:faults:payload.command_timeout_fault",
         "telemetry:eps.battery.current->telemetry_sourced_from_subsystem:subsystems:eps",
         "telemetry:eps.battery.voltage->telemetry_sourced_from_subsystem:subsystems:eps",
         "telemetry:obc.mode->telemetry_sourced_from_subsystem:subsystems:obc",
@@ -348,6 +360,14 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
             assert relationship["to"]["id"] in event_ids
             assert relationship["derived_from"] == {
                 "model_field": "payloads[].events.generated",
+            }
+        elif relationship["relationship_type"] == "payload_may_raise_fault":
+            assert relationship["from"]["domain"] == "payloads"
+            assert relationship["from"]["id"] in payload_ids
+            assert relationship["to"]["domain"] == "faults"
+            assert relationship["to"]["id"] in fault_ids
+            assert relationship["derived_from"] == {
+                "model_field": "payloads[].faults.possible",
             }
         elif relationship["relationship_type"] == "payload_produces_telemetry":
             assert relationship["from"]["domain"] == "payloads"


### PR DESCRIPTION
## Summary

Adds the deterministic `payload_may_raise_fault` relationship family to the candidate Relationship Manifest Surface.

The new family is derived only from:

```text
payloads[].faults.possible
```

## Behavior

Records are emitted from:

```text
payloads -> faults
```

A record is emitted only when a referenced fault resolves to an indexed fault in the loaded Mission Model.

For `examples/demo-3u/mission`, this adds one record:

```text
payloads:demo_iod_payload->payload_may_raise_fault:faults:payload.command_timeout_fault
```

## Demo impact

For the demo mission:

- total relationships: 40 -> 41
- emitted relationship families: 13 -> 14
- `payload_may_raise_fault`: 1

## Scope

Modified only:

- `src/orbitfabric/export/relationship_manifest.py`
- `tests/test_relationship_manifest_cli.py`
- `tests/test_relationship_manifest_export.py`

## Boundary

This PR does not infer faults from payload IDs, fault IDs, event sources, fault sources, telemetry sources, command recovery actions or naming conventions.

It does not introduce runtime behavior, ground behavior, plugin API, Studio API, graph semantics, dependency analysis or fault-handling semantics.

Documentation is intentionally left to a dedicated docs-only follow-up PR after this technical PR passes.

## Validation

Expected checks:

```bash
ruff check .
pytest
mkdocs build --strict
```
