### PR TITLE
feat: add commandability rule command relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -8,6 +8,7 @@ from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import (
     Command,
+    CommandabilityRule,
     DataProductContract,
     DownlinkFlowContract,
     Event,
@@ -18,6 +19,7 @@ from orbitfabric.model.mission import (
     TelemetryItem,
 )
 
+REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND = "commandability_rule_constrains_command"
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
 REL_DATA_PRODUCT_PRODUCED_BY_PAYLOAD = "data_product_produced_by_payload"
@@ -133,6 +135,14 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     )
     records.extend(
         record
+        for rule in sorted(model.commandability.rules, key=lambda item: item.id)
+        for record in _commandability_rule_command_relationship_records(
+            rule,
+            model.command_ids,
+        )
+    )
+    records.extend(
+        record
         for data_product in sorted(model.data_products, key=lambda item: item.id)
         for record in _data_product_payload_relationship_records(
             data_product,
@@ -212,6 +222,36 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         )
     )
     return sorted(records, key=lambda item: item["relationship_id"])
+
+
+def _commandability_rule_command_relationship_records(
+    rule: CommandabilityRule,
+    command_ids: set[str],
+) -> list[dict[str, Any]]:
+    if rule.command not in command_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"commandability_rules:{rule.id}->"
+                f"{REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND}:"
+                f"commands:{rule.command}"
+            ),
+            "relationship_type": REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND,
+            "from": {
+                "domain": "commandability_rules",
+                "id": rule.id,
+            },
+            "to": {
+                "domain": "commands",
+                "id": rule.command,
+            },
+            "derived_from": {
+                "model_field": "commandability.rules[].command",
+            },
+        }
+    ]
 
 
 def _command_event_relationship_records(command: Command) -> list[dict[str, Any]]:
@@ -636,6 +676,15 @@ def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, 
 
 def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
     specs = {
+        REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND: {
+            "relationship_type": REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND,
+            "display_name": "Commandability rule constrains command",
+            "from_domain": "commandability_rules",
+            "to_domain": "commands",
+            "derived_from": {
+                "model_field": "commandability.rules[].command",
+            },
+        },
         REL_COMMAND_EMITS_EVENT: {
             "relationship_type": REL_COMMAND_EMITS_EVENT,
             "display_name": "Command emits event",

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 41" in result.output
+    assert "Relationships emitted: 42" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,10 +40,11 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 41
+    assert manifest["counts"]["total_relationships"] == 42
     assert manifest["counts"]["relationship_types"] == {
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
+        "commandability_rule_constrains_command": 1,
         "data_product_produced_by_payload": 1,
         "downlink_flow_includes_data_product": 1,
         "event_sourced_from_subsystem": 8,
@@ -57,8 +58,8 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 14
-    assert len(manifest["relationships"]) == 41
+    assert len(manifest["relationship_types"]) == 15
+    assert len(manifest["relationships"]) == 42
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -12,6 +12,117 @@ from orbitfabric.model.loader import MissionModelLoader
 
 DEMO_MISSION = Path("examples/demo-3u/mission")
 
+EXPECTED_RELATIONSHIP_TYPE_COUNTS = {
+    "command_emits_event": 4,
+    "command_targets_subsystem": 4,
+    "commandability_rule_constrains_command": 1,
+    "data_product_produced_by_payload": 1,
+    "downlink_flow_includes_data_product": 1,
+    "event_sourced_from_subsystem": 8,
+    "fault_emits_event": 3,
+    "fault_sourced_from_subsystem": 3,
+    "packet_includes_telemetry": 5,
+    "payload_accepts_command": 2,
+    "payload_belongs_to_subsystem": 1,
+    "payload_generates_event": 2,
+    "payload_may_raise_fault": 1,
+    "payload_produces_telemetry": 1,
+    "telemetry_sourced_from_subsystem": 5,
+}
+
+EXPECTED_RELATIONSHIP_TYPE_SPECS = {
+    "command_emits_event": {
+        "display_name": "Command emits event",
+        "from_domain": "commands",
+        "to_domain": "events",
+        "model_field": "commands[].emits",
+    },
+    "command_targets_subsystem": {
+        "display_name": "Command targets subsystem",
+        "from_domain": "commands",
+        "to_domain": "subsystems",
+        "model_field": "commands[].target",
+    },
+    "commandability_rule_constrains_command": {
+        "display_name": "Commandability rule constrains command",
+        "from_domain": "commandability_rules",
+        "to_domain": "commands",
+        "model_field": "commandability.rules[].command",
+    },
+    "data_product_produced_by_payload": {
+        "display_name": "Data product produced by payload",
+        "from_domain": "data_products",
+        "to_domain": "payloads",
+        "model_field": "data_products[].producer",
+    },
+    "downlink_flow_includes_data_product": {
+        "display_name": "Downlink flow includes data product",
+        "from_domain": "downlink_flows",
+        "to_domain": "data_products",
+        "model_field": "downlink_flows[].eligible_data_products",
+    },
+    "event_sourced_from_subsystem": {
+        "display_name": "Event sourced from subsystem",
+        "from_domain": "events",
+        "to_domain": "subsystems",
+        "model_field": "events[].source",
+    },
+    "fault_emits_event": {
+        "display_name": "Fault emits event",
+        "from_domain": "faults",
+        "to_domain": "events",
+        "model_field": "faults[].emits",
+    },
+    "fault_sourced_from_subsystem": {
+        "display_name": "Fault sourced from subsystem",
+        "from_domain": "faults",
+        "to_domain": "subsystems",
+        "model_field": "faults[].source",
+    },
+    "packet_includes_telemetry": {
+        "display_name": "Packet includes telemetry",
+        "from_domain": "packets",
+        "to_domain": "telemetry",
+        "model_field": "packets[].telemetry",
+    },
+    "payload_accepts_command": {
+        "display_name": "Payload accepts command",
+        "from_domain": "payloads",
+        "to_domain": "commands",
+        "model_field": "payloads[].commands.accepted",
+    },
+    "payload_belongs_to_subsystem": {
+        "display_name": "Payload belongs to subsystem",
+        "from_domain": "payloads",
+        "to_domain": "subsystems",
+        "model_field": "payloads[].subsystem",
+    },
+    "payload_generates_event": {
+        "display_name": "Payload generates event",
+        "from_domain": "payloads",
+        "to_domain": "events",
+        "model_field": "payloads[].events.generated",
+    },
+    "payload_may_raise_fault": {
+        "display_name": "Payload may raise fault",
+        "from_domain": "payloads",
+        "to_domain": "faults",
+        "model_field": "payloads[].faults.possible",
+    },
+    "payload_produces_telemetry": {
+        "display_name": "Payload produces telemetry",
+        "from_domain": "payloads",
+        "to_domain": "telemetry",
+        "model_field": "payloads[].telemetry.produced",
+    },
+    "telemetry_sourced_from_subsystem": {
+        "display_name": "Telemetry sourced from subsystem",
+        "from_domain": "telemetry",
+        "to_domain": "subsystems",
+        "model_field": "telemetry[].source",
+    },
+}
+
 
 def test_relationship_manifest_contains_identity_and_boundaries() -> None:
     model = MissionModelLoader().load(DEMO_MISSION)
@@ -55,173 +166,30 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 41,
-        "relationship_types": {
-            "command_emits_event": 4,
-            "command_targets_subsystem": 4,
-            "data_product_produced_by_payload": 1,
-            "downlink_flow_includes_data_product": 1,
-            "event_sourced_from_subsystem": 8,
-            "fault_emits_event": 3,
-            "fault_sourced_from_subsystem": 3,
-            "packet_includes_telemetry": 5,
-            "payload_accepts_command": 2,
-            "payload_belongs_to_subsystem": 1,
-            "payload_generates_event": 2,
-            "payload_may_raise_fault": 1,
-            "payload_produces_telemetry": 1,
-            "telemetry_sourced_from_subsystem": 5,
-        },
+        "total_relationships": 42,
+        "relationship_types": EXPECTED_RELATIONSHIP_TYPE_COUNTS,
     }
     assert manifest["relationship_types"] == [
         {
-            "relationship_type": "command_emits_event",
-            "display_name": "Command emits event",
-            "from_domain": "commands",
-            "to_domain": "events",
+            "relationship_type": relationship_type,
+            "display_name": spec["display_name"],
+            "from_domain": spec["from_domain"],
+            "to_domain": spec["to_domain"],
             "derived_from": {
-                "model_field": "commands[].emits",
+                "model_field": spec["model_field"],
             },
-            "relationship_count": 4,
-        },
-        {
-            "relationship_type": "command_targets_subsystem",
-            "display_name": "Command targets subsystem",
-            "from_domain": "commands",
-            "to_domain": "subsystems",
-            "derived_from": {
-                "model_field": "commands[].target",
-            },
-            "relationship_count": 4,
-        },
-        {
-            "relationship_type": "data_product_produced_by_payload",
-            "display_name": "Data product produced by payload",
-            "from_domain": "data_products",
-            "to_domain": "payloads",
-            "derived_from": {
-                "model_field": "data_products[].producer",
-            },
-            "relationship_count": 1,
-        },
-        {
-            "relationship_type": "downlink_flow_includes_data_product",
-            "display_name": "Downlink flow includes data product",
-            "from_domain": "downlink_flows",
-            "to_domain": "data_products",
-            "derived_from": {
-                "model_field": "downlink_flows[].eligible_data_products",
-            },
-            "relationship_count": 1,
-        },
-        {
-            "relationship_type": "event_sourced_from_subsystem",
-            "display_name": "Event sourced from subsystem",
-            "from_domain": "events",
-            "to_domain": "subsystems",
-            "derived_from": {
-                "model_field": "events[].source",
-            },
-            "relationship_count": 8,
-        },
-        {
-            "relationship_type": "fault_emits_event",
-            "display_name": "Fault emits event",
-            "from_domain": "faults",
-            "to_domain": "events",
-            "derived_from": {
-                "model_field": "faults[].emits",
-            },
-            "relationship_count": 3,
-        },
-        {
-            "relationship_type": "fault_sourced_from_subsystem",
-            "display_name": "Fault sourced from subsystem",
-            "from_domain": "faults",
-            "to_domain": "subsystems",
-            "derived_from": {
-                "model_field": "faults[].source",
-            },
-            "relationship_count": 3,
-        },
-        {
-            "relationship_type": "packet_includes_telemetry",
-            "display_name": "Packet includes telemetry",
-            "from_domain": "packets",
-            "to_domain": "telemetry",
-            "derived_from": {
-                "model_field": "packets[].telemetry",
-            },
-            "relationship_count": 5,
-        },
-        {
-            "relationship_type": "payload_accepts_command",
-            "display_name": "Payload accepts command",
-            "from_domain": "payloads",
-            "to_domain": "commands",
-            "derived_from": {
-                "model_field": "payloads[].commands.accepted",
-            },
-            "relationship_count": 2,
-        },
-        {
-            "relationship_type": "payload_belongs_to_subsystem",
-            "display_name": "Payload belongs to subsystem",
-            "from_domain": "payloads",
-            "to_domain": "subsystems",
-            "derived_from": {
-                "model_field": "payloads[].subsystem",
-            },
-            "relationship_count": 1,
-        },
-        {
-            "relationship_type": "payload_generates_event",
-            "display_name": "Payload generates event",
-            "from_domain": "payloads",
-            "to_domain": "events",
-            "derived_from": {
-                "model_field": "payloads[].events.generated",
-            },
-            "relationship_count": 2,
-        },
-        {
-            "relationship_type": "payload_may_raise_fault",
-            "display_name": "Payload may raise fault",
-            "from_domain": "payloads",
-            "to_domain": "faults",
-            "derived_from": {
-                "model_field": "payloads[].faults.possible",
-            },
-            "relationship_count": 1,
-        },
-        {
-            "relationship_type": "payload_produces_telemetry",
-            "display_name": "Payload produces telemetry",
-            "from_domain": "payloads",
-            "to_domain": "telemetry",
-            "derived_from": {
-                "model_field": "payloads[].telemetry.produced",
-            },
-            "relationship_count": 1,
-        },
-        {
-            "relationship_type": "telemetry_sourced_from_subsystem",
-            "display_name": "Telemetry sourced from subsystem",
-            "from_domain": "telemetry",
-            "to_domain": "subsystems",
-            "derived_from": {
-                "model_field": "telemetry[].source",
-            },
-            "relationship_count": 5,
-        },
+            "relationship_count": EXPECTED_RELATIONSHIP_TYPE_COUNTS[relationship_type],
+        }
+        for relationship_type, spec in sorted(EXPECTED_RELATIONSHIP_TYPE_SPECS.items())
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 41
+    assert len(relationships) == 42
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
     } >= {
+        "commandability_rules:payload_start_ground_rule->commandability_rule_constrains_command:commands:payload.start_acquisition",
         "commands:eps.get_status->command_emits_event:events:eps.status_requested",
         "commands:eps.get_status->command_targets_subsystem:subsystems:eps",
         "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
@@ -262,131 +230,32 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
     model = MissionModelLoader().load(DEMO_MISSION)
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
-    packet_ids = {packet.id for packet in model.packets}
-    payload_ids = {payload.id for payload in model.payloads}
-    telemetry_ids = {telemetry.id for telemetry in model.telemetry}
-    command_ids = {command.id for command in model.commands}
-    event_ids = {event.id for event in model.events}
-    fault_ids = {fault.id for fault in model.faults}
-    subsystem_ids = {subsystem.id for subsystem in model.subsystems}
-    data_product_ids = {data_product.id for data_product in model.data_products}
-    downlink_flow_ids = {flow.id for flow in model.contacts.downlink_flows}
+    indexed_ids_by_domain = {
+        "commandability_rules": {item.id for item in model.commandability.rules},
+        "commands": {item.id for item in model.commands},
+        "data_products": {item.id for item in model.data_products},
+        "downlink_flows": {item.id for item in model.contacts.downlink_flows},
+        "events": {item.id for item in model.events},
+        "faults": {item.id for item in model.faults},
+        "packets": {item.id for item in model.packets},
+        "payloads": {item.id for item in model.payloads},
+        "subsystems": {item.id for item in model.subsystems},
+        "telemetry": {item.id for item in model.telemetry},
+    }
 
     for relationship in manifest["relationships"]:
-        if relationship["relationship_type"] == "command_emits_event":
-            assert relationship["from"]["domain"] == "commands"
-            assert relationship["from"]["id"] in command_ids
-            assert relationship["to"]["domain"] == "events"
-            assert relationship["to"]["id"] in event_ids
-            assert relationship["derived_from"] == {
-                "model_field": "commands[].emits",
-            }
-        elif relationship["relationship_type"] == "command_targets_subsystem":
-            assert relationship["from"]["domain"] == "commands"
-            assert relationship["from"]["id"] in command_ids
-            assert relationship["to"]["domain"] == "subsystems"
-            assert relationship["to"]["id"] in subsystem_ids
-            assert relationship["derived_from"] == {
-                "model_field": "commands[].target",
-            }
-        elif relationship["relationship_type"] == "data_product_produced_by_payload":
-            assert relationship["from"]["domain"] == "data_products"
-            assert relationship["from"]["id"] in data_product_ids
-            assert relationship["to"]["domain"] == "payloads"
-            assert relationship["to"]["id"] in payload_ids
-            assert relationship["derived_from"] == {
-                "model_field": "data_products[].producer",
-            }
-        elif relationship["relationship_type"] == "downlink_flow_includes_data_product":
-            assert relationship["from"]["domain"] == "downlink_flows"
-            assert relationship["from"]["id"] in downlink_flow_ids
-            assert relationship["to"]["domain"] == "data_products"
-            assert relationship["to"]["id"] in data_product_ids
-            assert relationship["derived_from"] == {
-                "model_field": "downlink_flows[].eligible_data_products",
-            }
-        elif relationship["relationship_type"] == "event_sourced_from_subsystem":
-            assert relationship["from"]["domain"] == "events"
-            assert relationship["from"]["id"] in event_ids
-            assert relationship["to"]["domain"] == "subsystems"
-            assert relationship["to"]["id"] in subsystem_ids
-            assert relationship["derived_from"] == {
-                "model_field": "events[].source",
-            }
-        elif relationship["relationship_type"] == "fault_emits_event":
-            assert relationship["from"]["domain"] == "faults"
-            assert relationship["from"]["id"] in fault_ids
-            assert relationship["to"]["domain"] == "events"
-            assert relationship["to"]["id"] in event_ids
-            assert relationship["derived_from"] == {
-                "model_field": "faults[].emits",
-            }
-        elif relationship["relationship_type"] == "fault_sourced_from_subsystem":
-            assert relationship["from"]["domain"] == "faults"
-            assert relationship["from"]["id"] in fault_ids
-            assert relationship["to"]["domain"] == "subsystems"
-            assert relationship["to"]["id"] in subsystem_ids
-            assert relationship["derived_from"] == {
-                "model_field": "faults[].source",
-            }
-        elif relationship["relationship_type"] == "packet_includes_telemetry":
-            assert relationship["from"]["domain"] == "packets"
-            assert relationship["from"]["id"] in packet_ids
-            assert relationship["to"]["domain"] == "telemetry"
-            assert relationship["to"]["id"] in telemetry_ids
-            assert relationship["derived_from"] == {
-                "model_field": "packets[].telemetry",
-            }
-        elif relationship["relationship_type"] == "payload_accepts_command":
-            assert relationship["from"]["domain"] == "payloads"
-            assert relationship["from"]["id"] in payload_ids
-            assert relationship["to"]["domain"] == "commands"
-            assert relationship["to"]["id"] in command_ids
-            assert relationship["derived_from"] == {
-                "model_field": "payloads[].commands.accepted",
-            }
-        elif relationship["relationship_type"] == "payload_belongs_to_subsystem":
-            assert relationship["from"]["domain"] == "payloads"
-            assert relationship["from"]["id"] in payload_ids
-            assert relationship["to"]["domain"] == "subsystems"
-            assert relationship["to"]["id"] in subsystem_ids
-            assert relationship["derived_from"] == {
-                "model_field": "payloads[].subsystem",
-            }
-        elif relationship["relationship_type"] == "payload_generates_event":
-            assert relationship["from"]["domain"] == "payloads"
-            assert relationship["from"]["id"] in payload_ids
-            assert relationship["to"]["domain"] == "events"
-            assert relationship["to"]["id"] in event_ids
-            assert relationship["derived_from"] == {
-                "model_field": "payloads[].events.generated",
-            }
-        elif relationship["relationship_type"] == "payload_may_raise_fault":
-            assert relationship["from"]["domain"] == "payloads"
-            assert relationship["from"]["id"] in payload_ids
-            assert relationship["to"]["domain"] == "faults"
-            assert relationship["to"]["id"] in fault_ids
-            assert relationship["derived_from"] == {
-                "model_field": "payloads[].faults.possible",
-            }
-        elif relationship["relationship_type"] == "payload_produces_telemetry":
-            assert relationship["from"]["domain"] == "payloads"
-            assert relationship["from"]["id"] in payload_ids
-            assert relationship["to"]["domain"] == "telemetry"
-            assert relationship["to"]["id"] in telemetry_ids
-            assert relationship["derived_from"] == {
-                "model_field": "payloads[].telemetry.produced",
-            }
-        elif relationship["relationship_type"] == "telemetry_sourced_from_subsystem":
-            assert relationship["from"]["domain"] == "telemetry"
-            assert relationship["from"]["id"] in telemetry_ids
-            assert relationship["to"]["domain"] == "subsystems"
-            assert relationship["to"]["id"] in subsystem_ids
-            assert relationship["derived_from"] == {
-                "model_field": "telemetry[].source",
-            }
-        else:
-            raise AssertionError("unexpected relationship type")
+        relationship_type = relationship["relationship_type"]
+        spec = EXPECTED_RELATIONSHIP_TYPE_SPECS[relationship_type]
+        from_domain = spec["from_domain"]
+        to_domain = spec["to_domain"]
+
+        assert relationship["from"]["domain"] == from_domain
+        assert relationship["from"]["id"] in indexed_ids_by_domain[from_domain]
+        assert relationship["to"]["domain"] == to_domain
+        assert relationship["to"]["id"] in indexed_ids_by_domain[to_domain]
+        assert relationship["derived_from"] == {
+            "model_field": spec["model_field"],
+        }
 
 
 def test_relationship_manifest_declares_derivation_policy() -> None:


### PR DESCRIPTION
## Summary

Adds the `commandability_rule_constrains_command` relationship family to the candidate Relationship Manifest Surface.

The new records are derived only from the explicit loaded Mission Model field:

```text
commandability.rules[].command
```

Record shape:

```text
commandability_rules:<rule-id>->commandability_rule_constrains_command:commands:<command-id>
```

## Boundary

This remains a static, Core-owned, read-only relationship manifest record. It does not introduce runtime command authorization, dispatching, security policy evaluation, ground behavior, Studio APIs, plugin APIs, graph behavior, or downstream inference.

## Changes

- Adds the `commandability_rule_constrains_command` relationship type.
- Emits records from indexed `commandability_rules` to indexed `commands` only when the referenced command exists in the loaded Mission Model.
- Updates relationship manifest export and CLI tests for the new deterministic count.
- Does not update documentation in this PR.

## Expected demo impact

For `examples/demo-3u/mission`:

- total relationship records: 41 -> 42
- emitted relationship families: 14 -> 15
- new relationship record:

```text
commandability_rules:payload_start_ground_rule->commandability_rule_constrains_command:commands:payload.start_acquisition
```