### PR TITLE
feat: add autonomous action command relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -7,6 +7,7 @@ from typing import Any
 from orbitfabric import __version__
 from orbitfabric.export.entity_index import entity_index_to_dict
 from orbitfabric.model.mission import (
+    AutonomousActionContract,
     Command,
     CommandabilityRule,
     DataProductContract,
@@ -19,6 +20,7 @@ from orbitfabric.model.mission import (
     TelemetryItem,
 )
 
+REL_AUTONOMOUS_ACTION_DISPATCHES_COMMAND = "autonomous_action_dispatches_command"
 REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND = "commandability_rule_constrains_command"
 REL_COMMAND_EMITS_EVENT = "command_emits_event"
 REL_COMMAND_TARGETS_SUBSYSTEM = "command_targets_subsystem"
@@ -125,9 +127,17 @@ def write_relationship_manifest(
 def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
     records = [
         record
+        for action in sorted(model.commandability.autonomous_actions, key=lambda item: item.id)
+        for record in _autonomous_action_command_relationship_records(
+            action,
+            model.command_ids,
+        )
+    ]
+    records.extend(
+        record
         for command in sorted(model.commands, key=lambda item: item.id)
         for record in _command_event_relationship_records(command)
-    ]
+    )
     records.extend(
         record
         for command in sorted(model.commands, key=lambda item: item.id)
@@ -222,6 +232,37 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         )
     )
     return sorted(records, key=lambda item: item["relationship_id"])
+
+
+def _autonomous_action_command_relationship_records(
+    action: AutonomousActionContract,
+    command_ids: set[str],
+) -> list[dict[str, Any]]:
+    command_id = action.dispatches.command
+    if command_id not in command_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"autonomous_actions:{action.id}->"
+                f"{REL_AUTONOMOUS_ACTION_DISPATCHES_COMMAND}:"
+                f"commands:{command_id}"
+            ),
+            "relationship_type": REL_AUTONOMOUS_ACTION_DISPATCHES_COMMAND,
+            "from": {
+                "domain": "autonomous_actions",
+                "id": action.id,
+            },
+            "to": {
+                "domain": "commands",
+                "id": command_id,
+            },
+            "derived_from": {
+                "model_field": "commandability.autonomous_actions[].dispatches.command",
+            },
+        }
+    ]
 
 
 def _commandability_rule_command_relationship_records(
@@ -676,6 +717,15 @@ def _relationship_type_counts(relationships: list[dict[str, Any]]) -> dict[str, 
 
 def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
     specs = {
+        REL_AUTONOMOUS_ACTION_DISPATCHES_COMMAND: {
+            "relationship_type": REL_AUTONOMOUS_ACTION_DISPATCHES_COMMAND,
+            "display_name": "Autonomous action dispatches command",
+            "from_domain": "autonomous_actions",
+            "to_domain": "commands",
+            "derived_from": {
+                "model_field": "commandability.autonomous_actions[].dispatches.command",
+            },
+        },
         REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND: {
             "relationship_type": REL_COMMANDABILITY_RULE_CONSTRAINS_COMMAND,
             "display_name": "Commandability rule constrains command",

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 42" in result.output
+    assert "Relationships emitted: 44" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,8 +40,9 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 42
+    assert manifest["counts"]["total_relationships"] == 44
     assert manifest["counts"]["relationship_types"] == {
+        "autonomous_action_dispatches_command": 2,
         "command_emits_event": 4,
         "command_targets_subsystem": 4,
         "commandability_rule_constrains_command": 1,
@@ -58,8 +59,8 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_produces_telemetry": 1,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 15
-    assert len(manifest["relationships"]) == 42
+    assert len(manifest["relationship_types"]) == 16
+    assert len(manifest["relationships"]) == 44
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -13,6 +13,7 @@ from orbitfabric.model.loader import MissionModelLoader
 DEMO_MISSION = Path("examples/demo-3u/mission")
 
 EXPECTED_RELATIONSHIP_TYPE_COUNTS = {
+    "autonomous_action_dispatches_command": 2,
     "command_emits_event": 4,
     "command_targets_subsystem": 4,
     "commandability_rule_constrains_command": 1,
@@ -31,6 +32,12 @@ EXPECTED_RELATIONSHIP_TYPE_COUNTS = {
 }
 
 EXPECTED_RELATIONSHIP_TYPE_SPECS = {
+    "autonomous_action_dispatches_command": {
+        "display_name": "Autonomous action dispatches command",
+        "from_domain": "autonomous_actions",
+        "to_domain": "commands",
+        "model_field": "commandability.autonomous_actions[].dispatches.command",
+    },
     "command_emits_event": {
         "display_name": "Command emits event",
         "from_domain": "commands",
@@ -166,7 +173,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 42,
+        "total_relationships": 44,
         "relationship_types": EXPECTED_RELATIONSHIP_TYPE_COUNTS,
     }
     assert manifest["relationship_types"] == [
@@ -184,11 +191,13 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 42
+    assert len(relationships) == 44
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
     } >= {
+        "autonomous_actions:stop_payload_on_battery_critical->autonomous_action_dispatches_command:commands:payload.stop_acquisition",
+        "autonomous_actions:stop_payload_on_battery_low->autonomous_action_dispatches_command:commands:payload.stop_acquisition",
         "commandability_rules:payload_start_ground_rule->commandability_rule_constrains_command:commands:payload.start_acquisition",
         "commands:eps.get_status->command_emits_event:events:eps.status_requested",
         "commands:eps.get_status->command_targets_subsystem:subsystems:eps",
@@ -231,6 +240,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
 
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
     indexed_ids_by_domain = {
+        "autonomous_actions": {item.id for item in model.commandability.autonomous_actions},
         "commandability_rules": {item.id for item in model.commandability.rules},
         "commands": {item.id for item in model.commands},
         "data_products": {item.id for item in model.data_products},


### PR DESCRIPTION
## Summary

Adds the `autonomous_action_dispatches_command` relationship family to the candidate Relationship Manifest Surface.

The new records are derived only from the explicit loaded Mission Model field:

```text
commandability.autonomous_actions[].dispatches.command
```

Record shape:

```text
autonomous_actions:<action-id>->autonomous_action_dispatches_command:commands:<command-id>
```

## Boundary

This remains a static, Core-owned, read-only relationship manifest record. It does not execute autonomous actions, dispatch commands, evaluate triggers, implement recovery behavior, authorize commands, implement security policy behavior, schedule runtime behavior, expose ground behavior, expose Studio APIs, expose plugin APIs, or infer graph edges.

## Changes

- Adds the `autonomous_action_dispatches_command` relationship type.
- Emits records from indexed `autonomous_actions` to indexed `commands` only when the referenced command exists in the loaded Mission Model.
- Updates relationship manifest export and CLI tests for the new deterministic count.
- Does not update documentation in this PR.

## Expected demo impact

For `examples/demo-3u/mission`:

- total relationship records: 42 -> 44
- emitted relationship families: 15 -> 16
- new relationship records:

```text
autonomous_actions:stop_payload_on_battery_critical->autonomous_action_dispatches_command:commands:payload.stop_acquisition
autonomous_actions:stop_payload_on_battery_low->autonomous_action_dispatches_command:commands:payload.stop_acquisition
```