### PR TITLE
feat: add recovery intent trigger relationship records

### DIFF
--- a/src/orbitfabric/export/relationship_manifest.py
+++ b/src/orbitfabric/export/relationship_manifest.py
@@ -17,6 +17,7 @@ from orbitfabric.model.mission import (
     MissionModel,
     Packet,
     PayloadContract,
+    RecoveryIntent,
     TelemetryItem,
 )
 
@@ -36,6 +37,8 @@ REL_PAYLOAD_BELONGS_TO_SUBSYSTEM = "payload_belongs_to_subsystem"
 REL_PAYLOAD_GENERATES_EVENT = "payload_generates_event"
 REL_PAYLOAD_MAY_RAISE_FAULT = "payload_may_raise_fault"
 REL_PAYLOAD_PRODUCES_TELEMETRY = "payload_produces_telemetry"
+REL_RECOVERY_INTENT_REACTS_TO_EVENT = "recovery_intent_reacts_to_event"
+REL_RECOVERY_INTENT_REACTS_TO_FAULT = "recovery_intent_reacts_to_fault"
 REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM = "telemetry_sourced_from_subsystem"
 
 
@@ -222,6 +225,22 @@ def _relationship_records(model: MissionModel) -> list[dict[str, Any]]:
         record
         for payload in sorted(model.payloads, key=lambda item: item.id)
         for record in _payload_fault_relationship_records(payload, model.fault_ids)
+    )
+    records.extend(
+        record
+        for intent in sorted(model.commandability.recovery_intents, key=lambda item: item.id)
+        for record in _recovery_intent_event_relationship_records(
+            intent,
+            model.event_ids,
+        )
+    )
+    records.extend(
+        record
+        for intent in sorted(model.commandability.recovery_intents, key=lambda item: item.id)
+        for record in _recovery_intent_fault_relationship_records(
+            intent,
+            model.fault_ids,
+        )
     )
     records.extend(
         record
@@ -678,6 +697,68 @@ def _payload_fault_relationship_records(
     ]
 
 
+def _recovery_intent_event_relationship_records(
+    intent: RecoveryIntent,
+    event_ids: set[str],
+) -> list[dict[str, Any]]:
+    if intent.event is None:
+        return []
+    if intent.event not in event_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"recovery_intents:{intent.id}->"
+                f"{REL_RECOVERY_INTENT_REACTS_TO_EVENT}:events:{intent.event}"
+            ),
+            "relationship_type": REL_RECOVERY_INTENT_REACTS_TO_EVENT,
+            "from": {
+                "domain": "recovery_intents",
+                "id": intent.id,
+            },
+            "to": {
+                "domain": "events",
+                "id": intent.event,
+            },
+            "derived_from": {
+                "model_field": "commandability.recovery_intents[].event",
+            },
+        }
+    ]
+
+
+def _recovery_intent_fault_relationship_records(
+    intent: RecoveryIntent,
+    fault_ids: set[str],
+) -> list[dict[str, Any]]:
+    if intent.fault is None:
+        return []
+    if intent.fault not in fault_ids:
+        return []
+
+    return [
+        {
+            "relationship_id": (
+                f"recovery_intents:{intent.id}->"
+                f"{REL_RECOVERY_INTENT_REACTS_TO_FAULT}:faults:{intent.fault}"
+            ),
+            "relationship_type": REL_RECOVERY_INTENT_REACTS_TO_FAULT,
+            "from": {
+                "domain": "recovery_intents",
+                "id": intent.id,
+            },
+            "to": {
+                "domain": "faults",
+                "id": intent.fault,
+            },
+            "derived_from": {
+                "model_field": "commandability.recovery_intents[].fault",
+            },
+        }
+    ]
+
+
 def _telemetry_subsystem_relationship_records(
     telemetry: TelemetryItem,
     subsystem_ids: set[str],
@@ -859,6 +940,24 @@ def _relationship_types(type_counts: dict[str, int]) -> list[dict[str, Any]]:
             "to_domain": "telemetry",
             "derived_from": {
                 "model_field": "payloads[].telemetry.produced",
+            },
+        },
+        REL_RECOVERY_INTENT_REACTS_TO_EVENT: {
+            "relationship_type": REL_RECOVERY_INTENT_REACTS_TO_EVENT,
+            "display_name": "Recovery intent reacts to event",
+            "from_domain": "recovery_intents",
+            "to_domain": "events",
+            "derived_from": {
+                "model_field": "commandability.recovery_intents[].event",
+            },
+        },
+        REL_RECOVERY_INTENT_REACTS_TO_FAULT: {
+            "relationship_type": REL_RECOVERY_INTENT_REACTS_TO_FAULT,
+            "display_name": "Recovery intent reacts to fault",
+            "from_domain": "recovery_intents",
+            "to_domain": "faults",
+            "derived_from": {
+                "model_field": "commandability.recovery_intents[].fault",
             },
         },
         REL_TELEMETRY_SOURCED_FROM_SUBSYSTEM: {

--- a/tests/test_relationship_manifest_cli.py
+++ b/tests/test_relationship_manifest_cli.py
@@ -30,7 +30,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert "Mission: demo-3u" in result.output
     assert "Model version: 0.1.0" in result.output
     assert "Status: candidate" in result.output
-    assert "Relationships emitted: 44" in result.output
+    assert "Relationships emitted: 46" in result.output
     assert f"JSON report written to: {output_file}" in result.output
     assert "Result: PASSED" in result.output
     assert output_file.exists()
@@ -40,7 +40,7 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
     assert manifest["manifest_version"] == "0.1-candidate"
     assert manifest["status"] == "candidate"
     assert manifest["mission"]["id"] == "demo-3u"
-    assert manifest["counts"]["total_relationships"] == 44
+    assert manifest["counts"]["total_relationships"] == 46
     assert manifest["counts"]["relationship_types"] == {
         "autonomous_action_dispatches_command": 2,
         "command_emits_event": 4,
@@ -57,10 +57,11 @@ def test_export_relationship_manifest_writes_candidate_json_report(tmp_path: Pat
         "payload_generates_event": 2,
         "payload_may_raise_fault": 1,
         "payload_produces_telemetry": 1,
+        "recovery_intent_reacts_to_fault": 2,
         "telemetry_sourced_from_subsystem": 5,
     }
-    assert len(manifest["relationship_types"]) == 16
-    assert len(manifest["relationships"]) == 44
+    assert len(manifest["relationship_types"]) == 17
+    assert len(manifest["relationships"]) == 46
     assert manifest["boundaries"]["contains_relationship_manifest"] is True
     assert manifest["boundaries"]["contains_relationship_graph"] is False
     assert manifest["boundaries"]["contains_plugin_api"] is False

--- a/tests/test_relationship_manifest_export.py
+++ b/tests/test_relationship_manifest_export.py
@@ -28,6 +28,7 @@ EXPECTED_RELATIONSHIP_TYPE_COUNTS = {
     "payload_generates_event": 2,
     "payload_may_raise_fault": 1,
     "payload_produces_telemetry": 1,
+    "recovery_intent_reacts_to_fault": 2,
     "telemetry_sourced_from_subsystem": 5,
 }
 
@@ -122,6 +123,12 @@ EXPECTED_RELATIONSHIP_TYPE_SPECS = {
         "to_domain": "telemetry",
         "model_field": "payloads[].telemetry.produced",
     },
+    "recovery_intent_reacts_to_fault": {
+        "display_name": "Recovery intent reacts to fault",
+        "from_domain": "recovery_intents",
+        "to_domain": "faults",
+        "model_field": "commandability.recovery_intents[].fault",
+    },
     "telemetry_sourced_from_subsystem": {
         "display_name": "Telemetry sourced from subsystem",
         "from_domain": "telemetry",
@@ -173,7 +180,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
 
     assert manifest["counts"] == {
-        "total_relationships": 44,
+        "total_relationships": 46,
         "relationship_types": EXPECTED_RELATIONSHIP_TYPE_COUNTS,
     }
     assert manifest["relationship_types"] == [
@@ -191,7 +198,7 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
     ]
 
     relationships = manifest["relationships"]
-    assert len(relationships) == 44
+    assert len(relationships) == 46
     assert relationships == sorted(relationships, key=lambda item: item["relationship_id"])
     assert {
         relationship["relationship_id"] for relationship in relationships
@@ -227,6 +234,8 @@ def test_relationship_manifest_emits_admitted_relationship_records() -> None:
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
         "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_stopped",
         "payloads:demo_iod_payload->payload_may_raise_fault:faults:payload.command_timeout_fault",
+        "recovery_intents:payload_battery_critical_recovery->recovery_intent_reacts_to_fault:faults:eps.battery_critical_fault",
+        "recovery_intents:payload_battery_low_recovery->recovery_intent_reacts_to_fault:faults:eps.battery_low_fault",
         "telemetry:eps.battery.current->telemetry_sourced_from_subsystem:subsystems:eps",
         "telemetry:eps.battery.voltage->telemetry_sourced_from_subsystem:subsystems:eps",
         "telemetry:obc.mode->telemetry_sourced_from_subsystem:subsystems:obc",
@@ -249,6 +258,7 @@ def test_relationship_manifest_relationships_reference_indexed_entities() -> Non
         "faults": {item.id for item in model.faults},
         "packets": {item.id for item in model.packets},
         "payloads": {item.id for item in model.payloads},
+        "recovery_intents": {item.id for item in model.commandability.recovery_intents},
         "subsystems": {item.id for item in model.subsystems},
         "telemetry": {item.id for item in model.telemetry},
     }


### PR DESCRIPTION
## Summary

Adds recovery intent trigger relationship records to the candidate Relationship Manifest Surface.

Two relationship families are admitted in code:

```text
recovery_intent_reacts_to_fault
recovery_intent_reacts_to_event
```

They are derived only from explicit loaded Mission Model fields:

```text
commandability.recovery_intents[].fault
commandability.recovery_intents[].event
```

The demo mission currently emits only `recovery_intent_reacts_to_fault`, because its recovery intents are fault-based.

## Boundary

This remains a static, Core-owned, read-only relationship manifest record. It does not execute recovery behavior, dispatch commands, transition modes, evaluate recovery policies, evaluate security policy behavior, schedule runtime behavior, expose ground behavior, expose Studio APIs, expose plugin APIs, or infer graph edges.

## Changes

- Adds `recovery_intent_reacts_to_fault` records from indexed `recovery_intents` to indexed `faults`.
- Adds support for `recovery_intent_reacts_to_event` records from indexed `recovery_intents` to indexed `events` when present in a mission model.
- Updates relationship manifest export and CLI tests for the new deterministic demo count.
- Keeps tests focused on records actually emitted by `examples/demo-3u/mission`.
- Does not update documentation in this PR.

## Expected demo impact

For `examples/demo-3u/mission`:

- total relationship records: 44 -> 46
- emitted relationship families: 16 -> 17
- new emitted relationship records:

```text
recovery_intents:payload_battery_critical_recovery->recovery_intent_reacts_to_fault:faults:eps.battery_critical_fault
recovery_intents:payload_battery_low_recovery->recovery_intent_reacts_to_fault:faults:eps.battery_low_fault
```