### PR TITLE
docs: align project documentation with relationship manifest surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,54 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 ## [Unreleased]
 
-### Next
+### Added
 
-- Prepare `v0.9 - Plugin and Extensibility Layer` as the next controlled extension milestone after Core-owned introspection and entity index surfaces.
+- Added the v0.9.0 development baseline for `Relationship Manifest Surface and Extensibility Boundary`.
+- Added `relationship_manifest_to_dict(model, mission_dir)`.
+- Added `write_relationship_manifest(model, mission_dir, output_file)`.
+- Added deterministic `relationship_manifest.json` generation.
+- Added the `orbitfabric export relationship-manifest` command.
+- Added `manifest_version 0.1-candidate` for the relationship manifest surface.
+- Added `kind orbitfabric.relationship_manifest` for the relationship manifest report.
+- Added Core-owned relationship records derived from explicit loaded Mission Model fields.
+- Added relationship type records and relationship type counts.
+- Added explicit relationship derivation policy.
+- Added explicit boundary flags for the relationship manifest report.
+- Added 19 admitted relationship families to the candidate relationship manifest surface.
+- Added relationship manifest export tests.
+- Added relationship manifest CLI tests.
+- Added Relationship Manifest Surface reference documentation.
+
+### Changed
+
+- Extended Core-owned structured surfaces from domain-level and entity-level reports to relationship-level reports.
+- Extended the public documentation baseline from `v0.8.2 - Entity Index Surface` to the v0.9.0 relationship manifest development baseline.
+- Aligned README, site homepage, roadmap, architecture, project charter, quickstart, development guide, contributing guide and demo walkthrough with the relationship manifest surface.
+- Clarified the structured surface chain: `model_summary.json -> entity_index.json -> relationship_manifest.json`.
+- Clarified that the package and CLI version remain `0.8.2` until the final v0.9.0 release preparation PR.
+- Reinforced that downstream tools should consume Core-owned structured surfaces instead of reconstructing Mission Model relationships from YAML, generated files, textual CLI output or UI state.
+
+### Boundaries
+
+The v0.9.0 relationship manifest development slice intentionally does not introduce:
+
+- new Mission Model semantics;
+- relationship inference;
+- relationship graph;
+- dependency graph;
+- source line or column tracking;
+- YAML AST export;
+- plugin API;
+- plugin discovery;
+- plugin loader;
+- plugin execution;
+- custom lint plugin support;
+- custom generator plugin support;
+- Studio-specific API;
+- runtime behavior;
+- ground behavior.
+
+Relationship Manifest Surface in v0.9.0 is a Core-owned read-only candidate relationship report only.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.8.2 - Entity Index Surface`.
+The current development baseline is `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary`.
 
-In v0.8.2, Entity Index Surface means the first Core-owned read-only entity index surface derived from the loaded Mission Model.
+The package and CLI version remain `0.8.2` until the final v0.9.0 release preparation PR.
 
-The next development focus is `v0.9 - Plugin and Extensibility Layer`.
+In v0.9.0, Relationship Manifest Surface means the first Core-owned read-only relationship surface derived from explicit loaded Mission Model fields and indexed Mission Model entities.
+
+The current development focus is to finish the v0.9.0 release alignment without adding plugin execution, plugin discovery or plugin loaders.
 
 The current baseline proves this Mission Data Chain:
 
@@ -31,6 +33,7 @@ Payload Contract
   -> Ground-Facing Integration Artifacts
   -> Contract Introspection Surface
   -> Entity Index Surface
+  -> Relationship Manifest Surface
 ```
 
 Do not add large integrations before the contract model is coherent.
@@ -59,8 +62,12 @@ Out of scope for the current preview:
 - Basilisk integration;
 - cFS/F Prime bridge;
 - web UI;
-- plugin API;
 - relationship graph export;
+- dependency graph export;
+- plugin API;
+- plugin execution;
+- plugin discovery;
+- plugin loader;
 - real spacecraft data.
 
 Runtime-facing contract bindings must remain generated, deterministic and disposable.
@@ -70,6 +77,8 @@ Ground-facing integration artifacts must remain generated, deterministic, tool-n
 Contract introspection reports must remain Core-owned, deterministic, read-only and disposable.
 
 Entity index reports must remain Core-owned, deterministic, read-only and disposable.
+
+Relationship manifest reports must remain Core-owned, deterministic, read-only, explicitly bounded and disposable.
 
 User implementation code and downstream integration code must live outside `generated/`.
 
@@ -126,7 +135,7 @@ orbitfabric --version
 orbitfabric --help
 ```
 
-Expected current version:
+Expected current version until the final v0.9.0 release preparation PR:
 
 ```text
 orbitfabric 0.8.2
@@ -156,6 +165,9 @@ orbitfabric export model-summary examples/demo-3u/mission/ \
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
+
 orbitfabric gen docs examples/demo-3u/mission/
 
 orbitfabric gen data-flow examples/demo-3u/mission/ \
@@ -180,18 +192,19 @@ orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
 Expected result:
 
 ```text
-ruff check .          -> All checks passed
-pytest                -> passing
-mkdocs                -> passing
-lint                  -> Result: PASSED
-export model-summary  -> Result: PASSED
-export entity-index   -> Result: PASSED
-gen docs              -> Result: PASSED
-gen data-flow         -> Result: PASSED
-gen runtime           -> Result: PASSED
-cmake build           -> passing
-gen ground            -> Result: PASSED
-sim                   -> Result: PASSED
+ruff check .                 -> All checks passed
+pytest                       -> passing
+mkdocs                       -> passing
+lint                         -> Result: PASSED
+export model-summary         -> Result: PASSED
+export entity-index          -> Result: PASSED
+export relationship-manifest -> Result: PASSED
+gen docs                     -> Result: PASSED
+gen data-flow                -> Result: PASSED
+gen runtime                  -> Result: PASSED
+cmake build                  -> passing
+gen ground                   -> Result: PASSED
+sim                          -> Result: PASSED
 ```
 
 ---
@@ -260,6 +273,8 @@ exporter -> raw YAML files
 
 Do not hardcode behavior for `demo-3u` inside the framework core.
 
+Relationship manifest records must remain derived from explicit loaded Mission Model fields and must reference indexed entities rather than synthetic downstream nodes.
+
 ---
 
 ## Commit Style
@@ -271,7 +286,7 @@ Good examples:
 ```text
 Add contact downlink consistency rules
 Generate ground dictionaries
-Align public documentation with v0.8.2
+Align public documentation with relationship manifest surface
 Fix scenario command validation
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces once.
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces and relationship manifest surfaces once.
 Validate them, document them, simulate them and generate deterministic integration and inspection artifacts from the same source of truth.
 
 </div>
@@ -42,13 +42,31 @@ downstream inspection tools
 
 ## Current Status
 
-OrbitFabric is currently at `v0.8.2 - Entity Index Surface`.
+OrbitFabric is currently preparing `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary`.
 
-In v0.8.2, **Entity Index Surface** means the first Core-owned read-only machine-readable surface for inspecting the loaded Mission Model at contract-entity level.
+The package and CLI version remain `0.8.2` until the final v0.9.0 release preparation PR.
 
-It introduces `entity_index.json` and the `orbitfabric export entity-index` command.
+The v0.9.0 development baseline introduces the first Core-owned read-only relationship manifest surface:
 
-It builds on v0.8.1, which introduced `model_summary.json` and the `orbitfabric export model-summary` command.
+```text
+relationship_manifest.json
+```
+
+It builds on:
+
+```text
+v0.8.1 -> model_summary.json
+v0.8.2 -> entity_index.json
+v0.9.0 -> relationship_manifest.json
+```
+
+The current Core-owned structured surface chain is:
+
+```text
+model_summary.json      -> What contract domains are present?
+entity_index.json       -> What contract entities are defined?
+relationship_manifest.json -> How are indexed contract entities related?
+```
 
 OrbitFabric does not generate a ground segment, mission control system, telemetry archive, command uplink service, operator console, decoder runtime, database, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
 
@@ -65,7 +83,8 @@ The current repository includes:
 - the `v0.7.0 - Generated Runtime Skeletons` vertical slice;
 - the `v0.8.0 - Ground Integration Artifacts` vertical slice;
 - the `v0.8.1 - Contract Introspection Surface` vertical slice;
-- the `v0.8.2 - Entity Index Surface` vertical slice.
+- the `v0.8.2 - Entity Index Surface` vertical slice;
+- the v0.9.0 relationship manifest development slice.
 
 The current vertical slice is functional:
 
@@ -90,7 +109,13 @@ The current vertical slice is functional:
 - Core-owned `model_summary.json` contract introspection report;
 - `orbitfabric export entity-index` generation;
 - Core-owned `entity_index.json` entity index report;
+- `orbitfabric export relationship-manifest` generation;
+- Core-owned `relationship_manifest.json` candidate relationship report;
 - synthetic demo mission: `demo-3u`.
+
+The relationship manifest currently exposes a candidate read-only surface with 19 explicitly admitted relationship families and 46 relationship records for `examples/demo-3u/mission`.
+
+It is not a graph engine, dependency graph, plugin API, Studio API, runtime behavior layer or ground behavior layer.
 
 The repository also includes a growing set of example mission slices:
 
@@ -126,6 +151,9 @@ orbitfabric export model-summary examples/demo-3u/mission/ --json generated/repo
 
 orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
 -> passing
+
+orbitfabric export relationship-manifest examples/demo-3u/mission/ --json generated/reports/relationship_manifest.json
+-> passing
 ```
 
 ---
@@ -152,7 +180,8 @@ It models:
 - generated runtime-facing contract bindings;
 - generated ground-facing integration artifacts;
 - Core-owned contract introspection surfaces;
-- Core-owned entity index surfaces.
+- Core-owned entity index surfaces;
+- Core-owned relationship manifest surfaces.
 
 The data-flow evidence chain connects:
 
@@ -170,9 +199,10 @@ command expected effect
         -> ground-facing artifacts
         -> model summary surface
         -> entity index surface
+        -> relationship manifest surface
 ```
 
-The v0.8.2 introspection and indexing chain is:
+The structured surface chain is:
 
 ```text
 Mission Model
@@ -180,10 +210,11 @@ Mission Model
         -> validated MissionModel
         -> model_summary.json
         -> entity_index.json
+        -> relationship_manifest.json
         -> downstream tools consume Core-owned structured surfaces
 ```
 
-Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts, Contract Introspection Surfaces and Entity Index Surfaces are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
+Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces and Relationship Manifest Surfaces are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
 
 ---
 
@@ -217,6 +248,8 @@ OrbitFabric is not:
 - an onboard scheduler;
 - a HAL or RTOS abstraction;
 - a relationship graph;
+- a dependency graph;
+- a plugin execution layer;
 - a plugin API;
 - a Studio-specific backend API.
 
@@ -228,7 +261,9 @@ Contract Introspection Surface in v0.8.1 is a Core-derived read-only model summa
 
 Entity Index Surface in v0.8.2 is a Core-derived read-only entity index.
 
-None of them is flight software, ground software or a visual modeling tool.
+Relationship Manifest Surface in v0.9.0 is a Core-derived read-only candidate relationship manifest.
+
+None of them is flight software, ground software, plugin execution or a visual modeling tool.
 
 ---
 
@@ -273,6 +308,7 @@ Payload Contract
         -> Ground-Facing Integration Artifacts
         -> Contract Introspection Surface
         -> Entity Index Surface
+        -> Relationship Manifest Surface
 ```
 
 ---
@@ -295,7 +331,7 @@ orbitfabric --version
 orbitfabric --help
 ```
 
-Expected:
+Expected until the v0.9.0 release preparation PR:
 
 ```text
 orbitfabric 0.8.2
@@ -334,11 +370,19 @@ orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 ```
 
+Generate the relationship-level manifest report:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
+```
+
 Generated files:
 
 ```text
 generated/reports/model_summary.json
 generated/reports/entity_index.json
+generated/reports/relationship_manifest.json
 ```
 
 `model_summary.json` answers:
@@ -353,7 +397,13 @@ What contract domains are present in this mission?
 What contract entities are defined in this mission?
 ```
 
-Neither surface is a relationship graph, plugin API or Studio-specific API.
+`relationship_manifest.json` answers:
+
+```text
+How are indexed mission contract entities related?
+```
+
+These surfaces are read-only Core-owned reports. They are not graph engines, plugin APIs or Studio-specific APIs.
 
 ---
 
@@ -455,7 +505,8 @@ generated/
 ├── docs/
 ├── reports/
 │   ├── model_summary.json
-│   └── entity_index.json
+│   ├── entity_index.json
+│   └── relationship_manifest.json
 ├── logs/
 ├── runtime/
 │   └── cpp17/
@@ -495,6 +546,7 @@ Useful entry points:
 - `docs/reference/ground-integration-artifacts.md`
 - `docs/reference/contract-introspection-surface.md`
 - `docs/reference/entity-index-surface.md`
+- `docs/reference/relationship-manifest-surface.md`
 - `docs/releases/v0.8.2.md`
 - `docs/adr/`
 
@@ -517,72 +569,3 @@ mkdocs serve
 OrbitFabric is developed as a clean-room open-source project.
 
 Do not add proprietary mission data, private architectures, private protocols, real operational logs, non-public payload details, real bus maps, real pinouts, employer/customer-owned code or NDA-protected material.
-
-All examples must be synthetic or based on public information.
-
-See:
-
-```text
-docs/CLEAN_ROOM_POLICY.md
-```
-
----
-
-## Contributing
-
-Contributions should stay aligned with the Mission Data Contract architecture.
-
-Before contributing, read:
-
-```text
-CONTRIBUTING.md
-```
-
-Required local checks:
-
-```bash
-ruff check .
-pytest
-mkdocs build --strict
-```
-
-Also verify the demo vertical slice:
-
-```bash
-orbitfabric lint examples/demo-3u/mission/ \
-  --json generated/reports/lint_report.json
-
-orbitfabric export model-summary examples/demo-3u/mission/ \
-  --json generated/reports/model_summary.json
-
-orbitfabric export entity-index examples/demo-3u/mission/ \
-  --json generated/reports/entity_index.json
-
-orbitfabric gen docs examples/demo-3u/mission/
-
-orbitfabric gen data-flow examples/demo-3u/mission/ \
-  --output-file generated/docs/data_flow.md
-
-orbitfabric gen runtime examples/demo-3u/mission/
-
-cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
-cmake --build generated/runtime/cpp17/build
-
-orbitfabric gen ground examples/demo-3u/mission/
-
-orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
-  --json generated/reports/payload_data_flow_evidence_report.json \
-  --log generated/logs/payload_data_flow_evidence.log
-```
-
----
-
-## License
-
-OrbitFabric is licensed under the Apache License 2.0.
-
-See:
-
-```text
-LICENSE
-```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Architecture
 
-Version: 0.8.2  
+Version: 0.9.0 development baseline  
 Status: Development preview  
-Scope: Mission Data Contract architecture through Entity Index Surface
+Scope: Mission Data Contract architecture through Relationship Manifest Surface
 
 ---
 
@@ -16,7 +16,7 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, documentation and scenario evidence from one source of truth.
+It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, documentation and scenario evidence from one source of truth.
 
 OrbitFabric is not designed as:
 
@@ -32,17 +32,22 @@ CCSDS/PUS/CFDP implementation
 hardware abstraction layer
 visual modeling tool
 Studio-specific backend API
+plugin execution platform
 ```
 
 Its architectural role is:
 
-> define, validate, simulate, document, introspect, index and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration and downstream inspection tools.
+> define, validate, simulate, document, introspect, index, relate and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration and downstream inspection tools.
 
-The current architectural baseline is `v0.8.2 - Entity Index Surface`.
+The current architectural development baseline is `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary`.
+
+The package and CLI version remain `0.8.2` until the final v0.9.0 release preparation PR.
 
 v0.8.1 introduced the first Core-owned read-only model summary surface derived from the loaded Mission Model.
 
-v0.8.2 introduces the first Core-owned read-only entity index surface derived from the loaded Mission Model.
+v0.8.2 introduced the first Core-owned read-only entity index surface derived from the loaded Mission Model.
+
+v0.9.0 introduces the first Core-owned read-only relationship manifest surface derived from explicit loaded Mission Model fields.
 
 ---
 
@@ -52,9 +57,9 @@ v0.8.2 introduces the first Core-owned read-only entity index surface derived fr
 
 The Mission Model is the source of truth.
 
-Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, simulation behavior and generated documentation must derive from the model.
+Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulation behavior and generated documentation must derive from the model.
 
-No important mission behavior should live only in Python code, documentation, generated files, simulator internals or downstream tools.
+No important mission behavior should live only in Python code, documentation, generated files, simulator internals, plugin outputs or downstream tools.
 
 ### 2.2 Contract Before Runtime
 
@@ -69,6 +74,8 @@ v0.8.0 introduced generated ground-facing contract exports, not ground behavior.
 v0.8.1 introduced a Core-owned model summary report, not relationship graphs or plugins.
 
 v0.8.2 introduced a Core-owned entity index report, not relationship graphs or plugins.
+
+v0.9.0 introduces a Core-owned relationship manifest report, not graph execution, plugin execution or Studio-specific behavior.
 
 ### 2.3 Chain Before Generated Artifacts
 
@@ -88,6 +95,7 @@ Payload behavior
         -> Ground-Facing Integration Artifacts
         -> Contract Introspection Surface
         -> Entity Index Surface
+        -> Relationship Manifest Surface
 ```
 
 ### 2.4 Generated Bindings, Exports and Reports Are Not Behavior
@@ -100,9 +108,11 @@ Generated Contract Introspection reports are Core-owned read-only summaries.
 
 Generated Entity Index reports are Core-owned read-only entity indexes.
 
-They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries and entity-level records.
+Generated Relationship Manifest reports are Core-owned read-only relationship records.
 
-They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graphs or plugin behavior unless those surfaces are explicitly implemented and tested in a later milestone.
+They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries, entity-level records and relationship records.
+
+They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS integration, telemetry polling, fault management, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graph behavior or plugin execution.
 
 ### 2.5 Lint as Engineering Judgment
 
@@ -110,7 +120,7 @@ They must not implement command dispatch, queues, scheduling, HAL, drivers, RTOS
 
 It must detect mission consistency issues, not merely invalid YAML.
 
-A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection or entity-index artifacts depend on it.
+A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection, entity-index or relationship artifacts depend on it.
 
 ### 2.6 Docs from Model
 
@@ -142,6 +152,8 @@ v0.8.1 establishes this principle with `model_summary.json`.
 
 v0.8.2 extends it with `entity_index.json`.
 
+v0.9.0 extends it with `relationship_manifest.json`.
+
 ---
 
 ## 3. High-Level System View
@@ -167,6 +179,7 @@ OrbitFabric
 │   ├── ground-facing contract export inputs
 │   ├── contract introspection inputs
 │   ├── entity index inputs
+│   ├── relationship manifest inputs
 │   └── scenarios
 │
 ├── Toolchain
@@ -179,6 +192,7 @@ OrbitFabric
 │   ├── orbitfabric gen ground
 │   ├── orbitfabric export model-summary
 │   ├── orbitfabric export entity-index
+│   ├── orbitfabric export relationship-manifest
 │   └── orbitfabric sim
 │
 ├── Model Layer
@@ -193,9 +207,9 @@ OrbitFabric
 
 ---
 
-## 4. Current Capability Boundary - v0.8.2
+## 4. Current Capability Boundary - v0.9.0 Development Baseline
 
-OrbitFabric v0.8.2 includes:
+OrbitFabric currently includes:
 
 ```text
 Mission Model YAML
@@ -213,7 +227,6 @@ contract-level data-flow evidence recording
 generated Markdown docs
 JSON lint reports
 JSON scenario reports with data_flow_evidence
-plain-text scenario logs
 RuntimeContract intermediate model
 orbitfabric gen runtime command
 C++17 runtime-facing contract bindings
@@ -228,10 +241,12 @@ orbitfabric export model-summary command
 model_summary.json contract introspection report
 orbitfabric export entity-index command
 entity_index.json entity index report
+orbitfabric export relationship-manifest command
+relationship_manifest.json candidate relationship report
 synthetic demo mission
 ```
 
-OrbitFabric v0.8.2 excludes:
+OrbitFabric currently excludes:
 
 ```text
 flight runtime
@@ -262,10 +277,12 @@ real command authorization
 live uplink services
 flight autonomy runtime
 real FDIR or safing logic
-relationship manifest
 relationship graph
+dependency graph
 plugin API
 plugin discovery
+plugin loader
+plugin execution
 Studio-specific API
 ```
 
@@ -301,7 +318,7 @@ Typed Mission Model
 
 The model is loaded once and consumed by multiple downstream layers.
 
-No generator, simulator, exporter or downstream tool should independently reinterpret raw YAML.
+No generator, simulator, exporter, plugin or downstream tool should independently reinterpret raw YAML.
 
 ---
 
@@ -344,6 +361,9 @@ Contract Introspection Surface
       │
       ▼
 Entity Index Surface
+      │
+      ▼
+Relationship Manifest Surface
 ```
 
 This is the architectural reason OrbitFabric did not jump directly from payload contracts to plugins.
@@ -365,6 +385,7 @@ orbitfabric gen runtime examples/demo-3u/mission/
 orbitfabric gen ground examples/demo-3u/mission/
 orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
 orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
+orbitfabric export relationship-manifest examples/demo-3u/mission/ --json generated/reports/relationship_manifest.json
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 orbitfabric inspect mission examples/demo-3u/mission/
@@ -383,7 +404,8 @@ orbitfabric
 │   └── ground <mission-dir>
 ├── export
 │   ├── model-summary <mission-dir>
-│   └── entity-index <mission-dir>
+│   ├── entity-index <mission-dir>
+│   └── relationship-manifest <mission-dir>
 ├── sim <scenario-file>
 ├── inspect
 │   └── mission <mission-dir>
@@ -391,7 +413,7 @@ orbitfabric
     └── scenario <scenario-file>
 ```
 
-Future commands may include relationship manifest export and tool-specific exporters only after their semantics are implemented and tested explicitly.
+Future commands may include tool-specific exporters and plugin-related commands only after their semantics, trust model and boundaries are implemented and tested explicitly.
 
 ---
 
@@ -463,6 +485,12 @@ v0.8.2 introduced the second export layer surface:
 entity_index.json
 ```
 
+v0.9.0 introduces the third export layer surface:
+
+```text
+relationship_manifest.json
+```
+
 The required dependency direction is:
 
 ```text
@@ -472,6 +500,7 @@ Mission Model
         -> export layer
         -> model_summary.json
         -> entity_index.json
+        -> relationship_manifest.json
 ```
 
 The disallowed direction is:
@@ -483,17 +512,71 @@ export layer
         -> generated runtime files
         -> generated ground files
         -> human-oriented CLI output
+        -> downstream UI state
+        -> plugin assumptions
 ```
 
 The model summary report contains domain-level information only.
 
 The entity index report contains entity-level records only.
 
-Neither surface contains relationship records, source locations, plugin definitions or Studio-specific formatting.
+The relationship manifest report contains admitted Core-owned relationship records only.
+
+None of these surfaces contains source locations, YAML AST data, plugin definitions, Studio-specific formatting, runtime behavior or ground behavior.
 
 ---
 
-## 11. Ground-Facing Generation Layer
+## 11. Relationship Manifest Architecture
+
+The Relationship Manifest Surface is a Core-owned read-only candidate report.
+
+It references entities already exposed by the Entity Index Surface.
+
+It does not create independent synthetic downstream nodes.
+
+Every emitted relationship record must be derived from explicit loaded Mission Model fields.
+
+It must not derive records from:
+
+```text
+naming conventions
+string similarity
+ID prefixes
+source file names
+YAML file ordering
+generated Markdown
+generated runtime files
+generated ground files
+human-oriented CLI output
+Studio UI state
+React component state
+private downstream assumptions
+```
+
+For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 emitted relationship families.
+
+The candidate surface currently admits 19 relationship families documented in `docs/reference/relationship-manifest-surface.md`.
+
+The relationship manifest is not:
+
+```text
+a graph engine
+a dependency graph
+a visualization format
+a Studio API
+a layout format
+a runtime routing table
+a ground routing table
+a scheduler input
+a command dispatcher input
+a plugin API
+```
+
+A downstream tool may render a graph from relationship records, but the engineering meaning of every edge must still come from Core.
+
+---
+
+## 12. Ground-Facing Generation Layer
 
 The generic ground profile generates:
 
@@ -516,7 +599,7 @@ Downstream ground integration code must live outside generated OrbitFabric outpu
 
 ---
 
-## 12. Runtime-Facing Generation Layer
+## 13. Runtime-Facing Generation Layer
 
 The C++17 runtime profile generates:
 
@@ -541,7 +624,7 @@ User implementation code must live outside `generated/`.
 
 ---
 
-## 13. Host-Build, Ground Export and Structured Surface Validation
+## 14. Host-Build, Ground Export and Structured Surface Validation
 
 Runtime-facing bindings can be validated with:
 
@@ -571,13 +654,20 @@ orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 ```
 
+The relationship manifest surface can be validated with:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
+```
+
 These commands confirm that the generated contract surfaces are syntactically valid and reproducible on the host.
 
-They do not validate flight behavior, live ground behavior, relationship graphs or plugin behavior.
+They do not validate flight behavior, live ground behavior, relationship graph behavior or plugin behavior.
 
 ---
 
-## 14. Documentation Generation Layer
+## 15. Documentation Generation Layer
 
 The Generation Layer derives human-readable and machine-readable artifacts from the Mission Model.
 
@@ -613,7 +703,7 @@ Generated documentation and reports are not the source of truth.
 
 ---
 
-## 15. Demo Mission Architecture
+## 16. Demo Mission Architecture
 
 The canonical demo is `demo-3u`.
 
@@ -645,7 +735,7 @@ The demo must stay synthetic and clean-room.
 
 ---
 
-## 16. Reports and Generated Artifact Architecture
+## 17. Reports and Generated Artifact Architecture
 
 Reports are JSON where machine-readable output is required.
 
@@ -661,13 +751,14 @@ ground contract manifest
 ground dictionaries
 model summary report
 entity index report
+relationship manifest report
 ```
 
 Reports and manifests must remain stable enough for tests and CI, but they are still development-preview artifacts before v1.0.
 
 ---
 
-## 17. Layer Dependency Rules
+## 18. Layer Dependency Rules
 
 Allowed dependencies:
 
@@ -707,13 +798,17 @@ RuntimeContract builder -> raw YAML files
 GroundContract builder -> raw YAML files
 profile-specific generator -> raw YAML files
 exporter -> raw YAML files
+relationship exporter -> raw YAML files
+relationship exporter -> generated Markdown
+relationship exporter -> downstream UI state
+plugin output -> Core-owned relationship manifest
 ```
 
 The Model Layer must remain the lowest stable layer.
 
 ---
 
-## 18. Testing Architecture
+## 19. Testing Architecture
 
 Current test strategy covers:
 
@@ -742,7 +837,8 @@ ground CSV export tests
 ground Markdown export tests
 model summary export tests
 entity index export tests
-entity index CLI tests
+relationship manifest export tests
+relationship manifest CLI tests
 CLI smoke tests
 ```
 
@@ -766,6 +862,8 @@ orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
 orbitfabric gen runtime examples/demo-3u/mission/
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
@@ -774,7 +872,7 @@ orbitfabric gen ground examples/demo-3u/mission/
 
 ---
 
-## 19. Future Extension Architecture
+## 20. Future Extension Architecture
 
 Future extensions should be added as generators, plugins or adapters.
 
@@ -785,7 +883,7 @@ Custom Ground Exporters
 Custom Lint Rule Plugins
 Custom Mission Model Extensions
 Runtime Adapter SDK
-Relationship Manifest Surface
+Plugin Metadata Manifests
 Yamcs Export Generator
 OpenC3 Export Generator
 XTCE Export Generator
@@ -797,9 +895,11 @@ These must remain downstream of the Mission Model and Core-owned structured surf
 
 They must not redefine the mission contract.
 
+Plugin execution requires explicit trust and security design before arbitrary or untrusted plugin code is supported.
+
 ---
 
-## 20. Anti-Patterns
+## 21. Anti-Patterns
 
 The following patterns are architecturally wrong:
 
@@ -815,14 +915,15 @@ simulation creep
 storage runtime creep
 downlink runtime creep
 plugin-before-core-surface creep
+relationship-graph-before-relationship-semantics creep
 proprietary example contamination
 ```
 
 ---
 
-## 21. v0.8.2 Acceptance Architecture
+## 22. v0.9.0 Development Acceptance Architecture
 
-OrbitFabric v0.8.2 is architecturally acceptable when this flow works end-to-end:
+OrbitFabric v0.9.0 is architecturally acceptable when this flow works end-to-end:
 
 ```bash
 ruff check .
@@ -837,6 +938,9 @@ orbitfabric export model-summary examples/demo-3u/mission/ \
 
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
+
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
 
 orbitfabric gen docs examples/demo-3u/mission/
 
@@ -865,6 +969,7 @@ And produces:
 valid lint output
 model_summary.json
 entity_index.json
+relationship_manifest.json
 Markdown mission documentation
 scenario execution logs
 scenario JSON reports
@@ -878,23 +983,19 @@ CSV ground dictionaries
 human-reviewable ground Markdown artifacts
 ```
 
-No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph or plugin API is required for v0.8.2.
+No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph or plugin API is required for v0.9.0.
 
 ---
 
-## 22. Next Architectural Step - v0.9
+## 23. Next Architectural Step After v0.9.0
 
-The next architectural step is:
+The next architectural step after v0.9.0 may return to the wider plugin and extensibility roadmap.
 
-```text
-v0.9 - Plugin and Extensibility Layer
-```
-
-The purpose is to introduce controlled extension points after Core-owned domain and entity surfaces exist.
+That work should begin with metadata, capability boundaries and trust model decisions, not arbitrary plugin execution.
 
 ---
 
-## 23. Final Architectural Statement
+## 24. Final Architectural Statement
 
 OrbitFabric is architecturally centered on the Mission Data Contract.
 
@@ -915,6 +1016,8 @@ The v0.8.0 ground-facing artifact layer exposes that contract to ground integrat
 The v0.8.1 contract introspection surface exposes a Core-owned model summary for downstream tools without introducing relationship graphs or plugins.
 
 The v0.8.2 entity index surface exposes Core-owned entity records for downstream tools without introducing relationship graphs or plugins.
+
+The v0.9.0 relationship manifest surface exposes Core-owned relationship records for downstream tools without introducing graph behavior, plugin execution or Studio-specific APIs.
 
 Future plugins must consume the contract.
 

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -20,7 +20,7 @@ Define once. Validate. Simulate. Test. Document. Integrate.
 
 The goal is not to model a real CubeSat.
 
-The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces.
+The goal is to show how a Mission Data Contract can define mission data and operational behavior once, then reuse it across linting, documentation, deterministic scenario execution, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces and relationship manifest surfaces.
 
 ---
 
@@ -104,7 +104,7 @@ onboard_autonomy
         -> recovery intents toward DEGRADED and SAFE
 ```
 
-These are contract assumptions only. They do not implement live uplink, operator authentication, real onboard storage, real downlink queues, real contact scheduling, RF behavior or ground operations.
+These are contract assumptions only. They do not implement live uplink, operator authentication, real onboard storage, real downlink queues, real contact scheduling, RF behavior, ground operations or recovery execution behavior.
 
 ---
 
@@ -186,6 +186,14 @@ It is not real payload file generation, onboard storage, downlink queue executio
 
 ## 7. Export Core-owned structured surfaces
 
+The current Core-owned structured surface chain is:
+
+```text
+model_summary.json      -> What contract domains are present?
+entity_index.json       -> What contract entities are defined?
+relationship_manifest.json -> How are indexed contract entities related?
+```
+
 v0.8.1 adds the first Core-owned Contract Introspection Surface for the same `demo-3u` Mission Model.
 
 Run:
@@ -199,12 +207,6 @@ Generated file:
 
 ```text
 generated/reports/model_summary.json
-```
-
-The report answers:
-
-```text
-What contract domains are present in this mission?
 ```
 
 v0.8.2 adds the first Core-owned Entity Index Surface for the same `demo-3u` Mission Model.
@@ -222,13 +224,28 @@ Generated file:
 generated/reports/entity_index.json
 ```
 
-The report answers:
+v0.9.0 adds the first Core-owned Relationship Manifest Surface for the same `demo-3u` Mission Model.
 
-```text
-What contract entities are defined in this mission?
+Run:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
 ```
 
-Neither report exposes relationship graphs, plugin APIs or Studio-specific APIs.
+Generated file:
+
+```text
+generated/reports/relationship_manifest.json
+```
+
+For `demo-3u`, the relationship manifest currently emits 46 relationship records across 17 emitted relationship families.
+
+The candidate surface admits 19 deliberately narrow relationship families documented in `docs/reference/relationship-manifest-surface.md`.
+
+These reports are read-only Core-owned structured surfaces.
+
+They do not expose relationship graph behavior, dependency graph behavior, plugin APIs, plugin execution, runtime behavior, ground behavior or Studio-specific APIs.
 
 ---
 
@@ -461,6 +478,7 @@ command accepted
   -> ground-facing artifacts generated from the same model
   -> model summary exported from the same model
   -> entity index exported from the same model
+  -> relationship manifest exported from the same model
 ```
 
 ---

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,7 +47,7 @@ orbitfabric --version
 orbitfabric --help
 ```
 
-Expected current version:
+Expected current package version until the final v0.9.0 release preparation PR:
 
 ```text
 orbitfabric 0.8.2
@@ -75,7 +75,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.8.2 Vertical Slice
+## Verify the Current v0.9.0 Development Slice
 
 Run mission lint:
 
@@ -96,6 +96,13 @@ Export the Core-owned entity index report:
 ```bash
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
+```
+
+Export the Core-owned relationship manifest report:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
 ```
 
 Generate documentation:
@@ -149,15 +156,16 @@ orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
 Expected results:
 
 ```text
-lint                  -> Result: PASSED
-export model-summary  -> Result: PASSED
-export entity-index   -> Result: PASSED
-gen docs              -> Result: PASSED
-gen data-flow         -> Result: PASSED
-gen runtime           -> Result: PASSED
-cmake build           -> passing
-gen ground            -> Result: PASSED
-sim                   -> Result: PASSED
+lint                         -> Result: PASSED
+export model-summary         -> Result: PASSED
+export entity-index          -> Result: PASSED
+export relationship-manifest -> Result: PASSED
+gen docs                     -> Result: PASSED
+gen data-flow                -> Result: PASSED
+gen runtime                  -> Result: PASSED
+cmake build                  -> passing
+gen ground                   -> Result: PASSED
+sim                          -> Result: PASSED
 ```
 
 The generated Core-owned structured reports should include:
@@ -165,6 +173,7 @@ The generated Core-owned structured reports should include:
 ```text
 generated/reports/model_summary.json
 generated/reports/entity_index.json
+generated/reports/relationship_manifest.json
 ```
 
 The generated mission documentation should include:
@@ -254,6 +263,8 @@ Generated contract introspection reports are disposable.
 
 Generated entity index reports are disposable.
 
+Generated relationship manifest reports are disposable.
+
 User implementation code and downstream integration code must live outside `generated/`.
 
 ---
@@ -285,7 +296,7 @@ For new behavior, follow this order:
 2. add or update lint rules
 3. add tests
 4. update generated docs or reports if needed
-5. update runtime-facing, ground-facing or introspection exporters if needed
+5. update runtime-facing, ground-facing, introspection, entity-index or relationship exporters if needed
 6. update user-facing documentation
 ```
 
@@ -295,7 +306,7 @@ Do not add generated artifacts that bypass validation.
 
 Do not add runtime or ground integration artifacts before the relevant contract layer exists.
 
-Do not add plugin mechanisms before Core-owned introspection and entity surfaces exist.
+Do not add plugin execution mechanisms before Core-owned structured surfaces and plugin boundaries are explicitly defined.
 
 Do not put user code inside generated runtime bindings.
 
@@ -304,6 +315,8 @@ Do not present generated ground artifacts as live ground behavior.
 Do not present contract introspection reports as relationship graphs or Studio-specific APIs.
 
 Do not present entity index reports as relationship graphs, dependency graphs, plugin APIs or Studio-specific APIs.
+
+Do not present relationship manifest reports as graph engines, dependency graphs, runtime routing tables, ground routing tables, plugin APIs or Studio-specific APIs.
 
 ---
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Project Charter
 
-Version: 0.8.2
+Version: 0.9.0 development baseline
 Status: Draft
 Scope: Mission Data Contract foundation, Mission Data Chain and generated contract-facing artifacts
 
@@ -10,9 +10,9 @@ Scope: Mission Data Contract foundation, Mission Data Chain and generated contra
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground and downstream tooling.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces and relationship manifest surfaces once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground and downstream tooling.
 
-OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework or a visual modeling backend.
+OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework, a plugin execution platform or a visual modeling backend.
 
 It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing integration, ground integration and downstream inspection tools.
 
@@ -48,7 +48,8 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - runtime-facing generated contract bindings;
 - ground-facing generated integration artifacts;
 - Core-owned contract introspection surfaces;
-- Core-owned entity index surfaces.
+- Core-owned entity index surfaces;
+- Core-owned relationship manifest surfaces.
 
 The Mission Data Contract is the single source of truth for all derived artifacts.
 
@@ -78,7 +79,7 @@ This creates drift.
 
 A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize. A generated software boundary may diverge from the mission model it was supposed to represent. A downstream tool may infer contract semantics differently from the Core.
 
-OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable and indexable through Core-owned structured surfaces.
+OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable, indexable and relatable through Core-owned structured surfaces.
 
 ---
 
@@ -128,19 +129,19 @@ The correct long-term role is:
 
 ### 6.1 Mission Model First
 
-OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system or a visual tool.
+OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system, a plugin or a visual tool.
 
-The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, simulator and documentation must be derived from the model, not the other way around.
+The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulator and documentation must be derived from the model, not the other way around.
 
 ### 6.2 Contract Before Code
 
 The first valuable artifact is the contract.
 
-Code generation, runtime execution, ground integration, inspection surfaces, entity surfaces and integration bridges are secondary and must not redefine the model.
+Code generation, runtime execution, ground integration, inspection surfaces, relationship surfaces, entity surfaces and integration bridges are secondary and must not redefine the model.
 
 ### 6.3 Mission Data Chain Before Generated Artifacts
 
-OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index or plugin-facing artifacts.
+OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index, relationship or plugin-facing artifacts.
 
 The current chain is:
 
@@ -157,13 +158,14 @@ payload behavior
         -> ground-facing integration artifacts
         -> contract introspection surface
         -> entity index surface
+        -> relationship manifest surface
 ```
 
 Only after these concepts are sufficiently clear should OrbitFabric derive plugin, tool-specific or external integration layers from them.
 
 ### 6.4 Generated Artifacts Are Disposable
 
-Generated runtime-facing contract bindings, ground-facing integration artifacts, contract introspection reports and entity index reports are reproducible outputs.
+Generated runtime-facing contract bindings, ground-facing integration artifacts, contract introspection reports, entity index reports and relationship manifest reports are reproducible outputs.
 
 They are not the source of truth.
 
@@ -215,7 +217,9 @@ v0.8.1 introduces `model_summary.json` as the first such surface.
 
 v0.8.2 introduces `entity_index.json` as the second such surface.
 
-v0.9 may introduce plugin extensibility only after these Core-owned surfaces exist.
+v0.9.0 introduces `relationship_manifest.json` as the third such surface.
+
+Future plugin extensibility must build on these surfaces without silently redefining Core semantics.
 
 ### 6.9 Clean-Room Development
 
@@ -229,6 +233,8 @@ The core must stay small.
 
 Extensibility should come through plugins, generators, custom lint rules and adapters, not through a bloated core.
 
+Plugin execution requires explicit trust, metadata and boundary design before arbitrary or untrusted plugin code is supported.
+
 ### 6.11 Practical Before Perfect
 
 OrbitFabric must favor useful, testable, well-documented behavior over broad but shallow standard compliance.
@@ -237,9 +243,9 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 ---
 
-## 7. Completed Early Scope
+## 7. Current Development Baseline
 
-The current v0.8.2 baseline includes:
+The current v0.9.0 development baseline includes:
 
 - Mission Model YAML files;
 - model loading;
@@ -263,6 +269,7 @@ The current v0.8.2 baseline includes:
 - generated ground Markdown review artifacts;
 - Core-owned model summary export;
 - Core-owned entity index export;
+- Core-owned relationship manifest export;
 - readable logs;
 - JSON reports;
 - one complete demo mission named `demo-3u`.
@@ -273,6 +280,7 @@ The current baseline supports these commands:
 orbitfabric lint examples/demo-3u/mission/
 orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
 orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
+orbitfabric export relationship-manifest examples/demo-3u/mission/ --json generated/reports/relationship_manifest.json
 orbitfabric gen docs examples/demo-3u/mission/
 orbitfabric gen data-flow examples/demo-3u/mission/
 orbitfabric gen runtime examples/demo-3u/mission/
@@ -297,7 +305,7 @@ They are the foundation for later tool-specific exporters and plugin extensibili
 
 ---
 
-## 9. Contract Introspection and Entity Index Direction
+## 9. Contract Introspection, Entity Index and Relationship Manifest Direction
 
 Core-owned structured surfaces make the loaded Mission Model visible to downstream tools without letting those tools infer Core semantics privately.
 
@@ -323,14 +331,29 @@ The v0.8.2 entity index report describes:
 - source file metadata;
 - explicit boundary flags.
 
+The v0.9.0 relationship manifest report describes:
+
+- mission identity;
+- source mission directory;
+- relationship records;
+- relationship IDs;
+- relationship types;
+- source and target indexed entities;
+- relationship type counts;
+- derivation policy;
+- explicit boundary flags.
+
 These reports must not describe or implement:
 
-- relationship graph;
-- dependency graph;
+- relationship graph execution;
+- dependency graph execution;
 - source line or column tracking;
 - YAML AST export;
 - plugin API;
-- Studio-specific API.
+- plugin execution;
+- Studio-specific API;
+- runtime behavior;
+- ground behavior.
 
 ---
 
@@ -352,6 +375,7 @@ Payload or subsystem activity
         -> ground-facing integration artifacts
         -> contract introspection surface
         -> entity index surface
+        -> relationship manifest surface
         -> future plugins
 ```
 
@@ -396,8 +420,8 @@ Early OrbitFabric versions must not include:
 - payload driver support;
 - physical payload simulation;
 - live ground operations;
-- plugin APIs before Core-owned surfaces are stable;
-- relationship graphs before entity indexing is stable.
+- plugin APIs before Core-owned surfaces and plugin boundaries are stable;
+- relationship graphs before entity indexing and relationship semantics are stable.
 
 These items may become future integration targets, generated artifacts or external consumers only after the Mission Model, lint engine, scenario runner, mission data chain contracts and generated contract-facing artifacts prove valuable.
 
@@ -409,7 +433,7 @@ The initial demo mission is `demo-3u`.
 
 It is a synthetic 3U CubeSat-like mission used only to demonstrate OrbitFabric concepts.
 
-It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface and entity index surface.
+It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface, entity index surface and relationship manifest surface.
 
 The demo assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
 
@@ -430,7 +454,7 @@ The recommended technical baseline is:
 - C++17 for the first generated runtime-facing binding profile;
 - CMake for host-build smoke validation;
 - JSON, CSV and Markdown for the first generated ground-facing artifact package;
-- JSON for Core-owned introspection and entity index reports;
+- JSON for Core-owned introspection, entity index and relationship manifest reports;
 - GitHub Actions for CI;
 - Apache-2.0 license.
 
@@ -440,13 +464,13 @@ It is not a flight runtime.
 
 The generated ground-facing package is intentionally tool-neutral and reviewable.
 
-It is not a ground runtime.
-
 The generated model summary report is intentionally Core-owned and read-only.
 
 The generated entity index report is intentionally Core-owned and read-only.
 
-Neither is a relationship graph, plugin API or Studio-specific API.
+The generated relationship manifest report is intentionally Core-owned, read-only and candidate.
+
+None is a relationship graph engine, plugin API, plugin execution mechanism or Studio-specific API.
 
 ---
 
@@ -497,10 +521,11 @@ OrbitFabric is successful in the early public preview if a user can:
 9. generate ground-facing JSON, CSV and Markdown artifacts from the same Mission Model;
 10. export a Core-owned model summary report from the same Mission Model;
 11. export a Core-owned entity index report from the same Mission Model;
-12. understand the project positioning from the README in less than one minute;
-13. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
-14. understand how payload contracts fit into the Mission Data Contract;
-15. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts and Core-owned surfaces fit into the roadmap before plugin extensibility.
+12. export a Core-owned relationship manifest report from the same Mission Model;
+13. understand the project positioning from the README in less than one minute;
+14. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
+15. understand how payload contracts fit into the Mission Data Contract;
+16. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts and Core-owned surfaces fit into the roadmap before plugin execution.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
 
@@ -557,35 +582,4 @@ The project should prefer:
 - generated contract-facing artifacts over hidden implementation assumptions;
 - Core-owned structured surfaces over downstream semantic inference;
 - clean interfaces over premature integrations;
-- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing and plugin generation.
-
-The project should reject:
-
-- speculative feature expansion;
-- premature standard compliance;
-- hardware-specific shortcuts;
-- hidden behavior not represented in the Mission Model;
-- undocumented assumptions;
-- private mission-derived examples;
-- flight runtime generation from an immature model;
-- ground integration exports that imply unimplemented ground behavior;
-- plugins that bypass or redefine the Mission Data Contract;
-- downstream tools that privately reconstruct Mission Model semantics from raw YAML.
-
----
-
-## 18. Final Position
-
-OrbitFabric must remain a disciplined Mission Data Contract framework.
-
-The project should not try to look large. It should try to be coherent.
-
-The first versions must prove one thing convincingly:
-
-> A small spacecraft mission can be described once, validated semantically, simulated operationally, tested through scenarios, documented automatically, exposed through generated contract-facing artifacts and inspected through Core-owned structured surfaces from a single source of truth.
-
-The current version extends that proof to entity indexing:
-
-> Payload behavior, data products, onboard storage intent, downlink priorities, contact assumptions, commandability constraints, recovery expectations, runtime-facing contract bindings and ground-facing integration artifacts can feed Core-owned model summary and entity index reports without duplicating or redefining the mission contract.
-
-That is the core of OrbitFabric.
+- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing, relationship manifests and plugin generation.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -28,6 +28,7 @@ Mission Model YAML
   -> human-reviewable ground Markdown artifacts
   -> model_summary.json contract introspection report
   -> entity_index.json entity index report
+  -> relationship_manifest.json candidate relationship report
   -> JSON lint reports
   -> JSON simulation reports with data-flow evidence
   -> simulation logs
@@ -39,7 +40,7 @@ Generated runtime-facing contract bindings are not flight software.
 
 Generated ground integration artifacts are not ground software.
 
-Contract introspection and entity index surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.
+Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.
 
 ---
 
@@ -104,7 +105,7 @@ orbitfabric --version
 orbitfabric --help
 ```
 
-Expected version for the current development preview:
+Expected version until the final v0.9.0 release preparation PR:
 
 ```text
 orbitfabric 0.8.2
@@ -190,11 +191,19 @@ orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 ```
 
+Generate the relationship-level manifest:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
+```
+
 Generated output:
 
 ```text
 generated/reports/model_summary.json
 generated/reports/entity_index.json
+generated/reports/relationship_manifest.json
 ```
 
 `model_summary.json` answers:
@@ -209,7 +218,15 @@ What contract domains are present in this mission?
 What contract entities are defined in this mission?
 ```
 
-Neither surface exposes relationship graphs, plugin APIs or Studio-specific APIs.
+`relationship_manifest.json` answers:
+
+```text
+How are indexed mission contract entities related?
+```
+
+These surfaces are Core-owned, read-only and derived from the loaded Mission Model.
+
+They do not expose plugin execution, graph engines, Studio-specific APIs, runtime behavior or ground behavior.
 
 ---
 
@@ -341,7 +358,9 @@ The current demo proves that OrbitFabric can:
 - run semantic lint rules;
 - generate Markdown documentation;
 - inspect a Mission Model summary;
+- export a model summary from the loaded Mission Model;
 - export an entity index from the loaded Mission Model;
+- export a relationship manifest from the loaded Mission Model;
 - validate scenarios without executing them;
 - execute deterministic operational sequences;
 - record contract-level data-flow evidence;
@@ -380,8 +399,10 @@ The current demo does not prove:
 - command dispatch runtime behavior;
 - telemetry polling runtime behavior;
 - HAL or RTOS integration;
-- relationship graph export;
+- relationship graph behavior;
+- dependency graph behavior;
 - plugin API behavior;
+- plugin execution behavior;
 - qualification for operational spacecraft use.
 
 Those are intentionally outside the current development preview scope.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Roadmap
 
-Version: v0.8.2  
+Version: v0.9.0 development baseline  
 Status: Development preview  
 Scope: v0.3 to v1.0 planning
 
@@ -37,14 +37,15 @@ Mission Model
         -> ground integration artifacts
         -> contract introspection surfaces
         -> entity index surfaces
-        -> plugins and extensibility
+        -> relationship manifest surfaces
+        -> plugins and controlled extensibility
 ```
 
 Every milestone must reinforce the core identity:
 
 > OrbitFabric is a Mission Data Contract framework.
 
-The current architectural objective is to keep the Mission Data Chain explicit, inspectable and consumable by generated artifacts and downstream tools without turning OrbitFabric into flight software, a ground segment or a visual modeling tool.
+The current architectural objective is to keep the Mission Data Chain explicit, inspectable and consumable by generated artifacts and downstream tools without turning OrbitFabric into flight software, a ground segment, a visual modeling tool or a plugin execution platform.
 
 ---
 
@@ -64,13 +65,15 @@ v0.7.0  Generated Runtime Skeletons                           completed
 v0.8.0  Ground Integration Artifacts                          completed
 v0.8.1  Contract Introspection Surface                        completed
 v0.8.2  Entity Index Surface                                  completed
-v0.9    Plugin and Extensibility Layer                        next
+v0.9.0  Relationship Manifest Surface and Extensibility Boundary in progress
 v1.0    Stable Mission Data Contract                          future
 ```
 
-The immediate target after v0.8.2 is now `v0.9 - Plugin and Extensibility Layer`.
+The immediate target after v0.8.2 is now `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary`.
 
-This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9 can now introduce controlled extension points without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files or human-oriented CLI output.
+This is the first v0.9 slice. It keeps the original `Plugin and Extensibility Layer` roadmap direction, but starts with the Core-owned relationship surface required before downstream tools or future plugins can safely reason about relationships.
+
+This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduces the first Core-owned relationship-level surface. Future plugin extensibility can build on these surfaces without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files or human-oriented CLI output.
 
 ---
 
@@ -133,22 +136,6 @@ The precise architectural meaning is:
 runtime-facing contract bindings
 ```
 
-v0.7.0 introduced:
-
-```text
-RuntimeContract intermediate model
-orbitfabric gen runtime command
-cpp17 generation profile
-runtime_contract_manifest.json
-generated IDs and enums
-generated static metadata registries
-generated command argument structs
-generated abstract adapter interfaces
-host-buildable CMake smoke target
-Runtime Contract Bindings reference documentation
-v0.7.0 release notes
-```
-
 v0.7.0 intentionally did not implement flight-ready runtime, command dispatch runtime, command queues, telemetry polling runtime, event routing runtime, fault manager runtime, scheduler, HAL, drivers, RTOS abstraction, binary serialization, CCSDS/PUS/CFDP behavior, storage runtime, downlink runtime, user-code merge or protected regions.
 
 ---
@@ -167,22 +154,6 @@ The precise architectural meaning is:
 
 ```text
 ground-facing Mission Data Contract exports
-```
-
-v0.8.0 introduced:
-
-```text
-GroundContract intermediate model
-orbitfabric gen ground command
-generic generation profile
-ground_contract_manifest.json
-JSON ground dictionaries
-CSV ground dictionaries
-generated ground artifact README.md
-generated ground_dictionaries.md review document
-Ground Integration Artifacts reference documentation
-ADR-0012 Ground Integration Artifacts Boundary
-v0.8.0 release notes
 ```
 
 v0.8.0 intentionally did not implement a live ground segment, mission control system, telemetry archive, telemetry database, command uplink service, Yamcs integration, OpenC3 integration, XTCE compliance, CCSDS/PUS/CFDP implementation, binary packet decoder, binary telecommand encoder, RF behavior, pass scheduling or station automation.
@@ -259,33 +230,115 @@ orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
 ```
 
-v0.8.2 intentionally does not introduce:
+v0.8.2 intentionally did not introduce new Mission Model semantics, relationship manifest implementation, relationship graph, dependency graph, source line or column tracking, YAML AST export, plugin API, plugin discovery, Studio-specific API, runtime behavior or ground behavior.
+
+---
+
+## 9. Active Slice - v0.9.0 Relationship Manifest Surface and Extensibility Boundary
+
+v0.9.0 introduces the first Core-owned read-only relationship manifest surface.
+
+It answers:
 
 ```text
-new Mission Model semantics
-relationship manifest
+How are indexed mission contract entities related?
+```
+
+The relationship manifest builds directly on `entity_index.json`.
+
+The intended downstream chain is now:
+
+```text
+model_summary.json          -> domain navigation
+entity_index.json           -> entity navigation
+relationship_manifest.json  -> relationship navigation
+```
+
+v0.9.0 currently includes:
+
+```text
+relationship_manifest_to_dict(model, mission_dir)
+write_relationship_manifest(model, mission_dir, output_file)
+orbitfabric export relationship-manifest command
+relationship_manifest.json report
+manifest_version 0.1-candidate
+kind orbitfabric.relationship_manifest
+relationship records
+relationship type records
+relationship type counts
+explicit derivation policy
+explicit boundary flags
+Relationship Manifest Surface reference documentation
+ADR-0014 v0.9 plugin and relationship surface boundaries
+```
+
+Command:
+
+```bash
+orbitfabric export relationship-manifest examples/demo-3u/mission/ \
+  --json generated/reports/relationship_manifest.json
+```
+
+The current candidate surface admits nineteen deliberately narrow relationship families:
+
+```text
+autonomous_action_dispatches_command
+command_emits_event
+command_targets_subsystem
+commandability_rule_constrains_command
+data_product_produced_by_payload
+data_product_produced_by_subsystem
+downlink_flow_includes_data_product
+event_sourced_from_subsystem
+fault_emits_event
+fault_sourced_from_subsystem
+packet_includes_telemetry
+payload_accepts_command
+payload_belongs_to_subsystem
+payload_generates_event
+payload_may_raise_fault
+payload_produces_telemetry
+recovery_intent_reacts_to_event
+recovery_intent_reacts_to_fault
+telemetry_sourced_from_subsystem
+```
+
+For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 relationship families.
+
+v0.9.0 relationship manifest work intentionally does not introduce:
+
+```text
+relationship inference
 relationship graph
 dependency graph
 source line or column tracking
 YAML AST export
-plugin API
+plugin execution
 plugin discovery
+plugin loader
+custom lint plugin support
+custom generator plugin support
 Studio-specific API
 runtime behavior
 ground behavior
 ```
 
+The relationship manifest is a candidate Core-owned surface. It is deterministic, read-only and derived from explicit loaded Mission Model fields. It is not a graph engine, visualization format, plugin API, Studio API, runtime routing table, ground routing table, scheduler input or command dispatcher input.
+
 ---
 
-## 9. Next Milestone - v0.9 Plugin and Extensibility Layer
+## 10. Deferred v0.9 Plugin and Extensibility Work
 
-v0.9 should introduce controlled extension points only after the Core exposes the required introspection and entity surfaces.
+The wider v0.9 roadmap direction remains controlled plugin and extensibility support.
 
-Candidate features:
+Candidate future features include:
 
 ```text
 extension boundary documentation
 public versus internal surface classification
+plugin metadata manifest
+plugin capability manifest
+plugin-generated report manifest
 custom lint rule plugins
 custom generator plugins
 custom data product validators
@@ -301,23 +354,17 @@ rule documentation generator
 semantic versioning policy
 ```
 
-Plugins must extend OrbitFabric without silently redefining core semantics.
+These are not part of the current relationship manifest slice.
+
+Plugins must extend OrbitFabric without silently redefining Core semantics.
 
 Plugins must not bypass Mission Model loading, validation, linting or Core-owned structured surfaces.
 
-Relationship manifests may be introduced in v0.9 only if the Core can derive them deterministically and without fragile heuristics.
-
-Candidate relationship surface:
-
-```text
-relationship_manifest.json
-```
-
-The relationship manifest must remain partial or experimental if the Core does not yet own enough explicit relationship semantics.
+Plugin execution requires explicit trust and security design before arbitrary or untrusted plugin code is supported.
 
 ---
 
-## 10. Future Milestone - v1.0 Stable Mission Data Contract
+## 11. Future Milestone - v1.0 Stable Mission Data Contract
 
 v1.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
 
@@ -334,6 +381,7 @@ stable RuntimeContract semantics
 stable GroundContract semantics
 stable contract introspection surface
 stable entity index surface
+stable relationship manifest surface
 stable runtime-facing contract binding surface
 stable ground-facing artifact package
 stable CLI commands
@@ -352,7 +400,7 @@ v1.0 should mean stable Mission Data Contract framework, not a complete space so
 
 ---
 
-## 11. Backlog Parking Lot
+## 12. Backlog Parking Lot
 
 These ideas are valid but must not distract from the active milestone.
 
@@ -385,16 +433,19 @@ ADCS abstract mode examples
 thermal abstract mode examples
 security policy model
 command authorization model
-relationship manifest
 second payload example
 payload lifecycle expansion
 additional runtime generation profiles
 example user implementation outside generated/
+plugin metadata manifest
+plugin capability manifest
+custom lint plugin support
+custom generator plugin support
 ```
 
 ---
 
-## 12. Priority Rules
+## 13. Priority Rules
 
 When deciding what to implement next, use these rules.
 
@@ -413,27 +464,26 @@ When deciding what to implement next, use these rules.
 13. Tool-specific Claims Require Tests.
 14. Core Surfaces Before Plugins.
 15. Downstream Tools Consume, Not Infer.
+16. Relationship Semantics Before Relationship Visualization.
 
 ---
 
-## 13. Immediate Work Plan
+## 14. Immediate Work Plan
 
 The immediate work package is:
 
 ```text
-v0.9 - Plugin and Extensibility Layer
+v0.9.0 - Relationship Manifest Surface and Extensibility Boundary
 ```
 
-Required sequence:
+Required completion sequence:
 
 ```text
-1. classify public versus internal Core surfaces
-2. define plugin boundaries without allowing semantic override
-3. define discovery and metadata rules
-4. start with narrow, testable extension points
-5. require plugins to consume loaded MissionModel or Core-owned structured surfaces
-6. keep relationship manifests out unless they can be derived deterministically
-7. preserve the Mission Data Contract as source of truth
+1. keep relationship_manifest.json candidate and explicitly bounded
+2. align README, roadmap, architecture and project documentation
+3. add v0.9.0 release notes
+4. prepare the v0.9.0 release without adding plugin execution
+5. defer plugin loader, discovery and execution to later reviewed work
 ```
 
 Do not let plugins reconstruct contract semantics from raw YAML, generated files or human-oriented CLI output.
@@ -442,11 +492,11 @@ Do not let downstream tools become a second source of truth.
 
 ---
 
-## 14. Final Roadmap Statement
+## 15. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
-> defining, validating, simulating, documenting, introspecting and generating contract-facing artifacts from a Mission Data Contract for a small spacecraft.
+> defining, validating, simulating, documenting, introspecting, indexing, relating and generating contract-facing artifacts from a Mission Data Contract for a small spacecraft.
 
 The v0.6 roadmap step completed the first end-to-end contract-level Mission Data Flow Evidence slice.
 
@@ -458,7 +508,9 @@ The v0.8.1 roadmap step completed the first Core-owned contract introspection su
 
 The v0.8.2 roadmap step completed the first Core-owned entity index surface for downstream tools.
 
-Only after the mission data chain, commandability, autonomy, end-to-end evidence, runtime-facing binding layer, ground-facing artifact layer, contract introspection and entity indexing are clear should OrbitFabric grow into plugin extensibility.
+The v0.9.0 roadmap step introduces the first Core-owned relationship manifest surface and preserves the plugin/extensibility boundary before plugin execution.
+
+Only after the mission data chain, commandability, autonomy, end-to-end evidence, runtime-facing binding layer, ground-facing artifact layer, contract introspection, entity indexing and relationship semantics are clear should OrbitFabric grow into plugin execution.
 
 The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,21 +2,29 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces and entity index surfaces in a single Mission Data Contract.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces and relationship manifest surfaces in a single Mission Data Contract.
 
 From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic integration and inspection artifacts.
 
 ## Current development preview
 
-OrbitFabric is currently at:
+OrbitFabric is currently preparing:
 
 ```text
-v0.8.2 - Entity Index Surface
+v0.9.0 - Relationship Manifest Surface and Extensibility Boundary
 ```
 
-In v0.8.2, Entity Index Surface means the first **Core-owned read-only entity index surface** derived from the loaded Mission Model.
+The package and CLI version remain `0.8.2` until the final v0.9.0 release preparation PR.
 
-It builds on v0.8.1, which introduced the domain-level `model_summary.json` surface.
+The current v0.9.0 development baseline adds the first **Core-owned read-only relationship manifest surface** derived from explicit loaded Mission Model fields.
+
+It builds on:
+
+```text
+v0.8.1 -> model_summary.json
+v0.8.2 -> entity_index.json
+v0.9.0 -> relationship_manifest.json
+```
 
 The current public preview includes:
 
@@ -50,6 +58,8 @@ The current public preview includes:
 - generated `model_summary.json` contract introspection report;
 - `orbitfabric export entity-index`;
 - generated `entity_index.json` entity index report;
+- `orbitfabric export relationship-manifest`;
+- generated `relationship_manifest.json` candidate relationship report;
 - a clean-room synthetic `demo-3u` mission.
 
 ## Core Idea
@@ -70,6 +80,15 @@ Mission Model
   -> generated ground-facing integration artifacts
   -> Core-owned contract introspection surfaces
   -> Core-owned entity index surfaces
+  -> Core-owned relationship manifest surfaces
+```
+
+The current Core-owned structured surface chain is:
+
+```text
+model_summary.json      -> domain navigation
+entity_index.json       -> entity navigation
+relationship_manifest.json -> relationship navigation
 ```
 
 OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
@@ -80,4 +99,4 @@ Generated runtime-facing contract bindings are not flight software.
 
 Generated ground integration artifacts are not ground software.
 
-Contract introspection and entity index surfaces are not plugin APIs, relationship graphs or Studio-specific APIs.
+Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.


### PR DESCRIPTION
## Summary

Aligns the public project documentation with the current v0.9.0 development baseline after introducing the Core-owned Relationship Manifest Surface.

This PR updates documentation only. It does not change package version, CLI version, code, tests, generated artifacts or runtime behavior.

## Changes

- Updates README and documentation home page to describe the current v0.9.0 development baseline.
- Adds `relationship_manifest.json` to the Core-owned structured surface chain.
- Aligns the roadmap with `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary`.
- Updates architecture documentation with the Relationship Manifest Surface as a Core-owned read-only relationship-level report.
- Updates Project Charter to include relationship manifest surfaces in the Mission Data Contract chain.
- Updates Quickstart, Development Guide and Contributing Guide with `orbitfabric export relationship-manifest` validation.
- Updates Demo Walkthrough with the third structured surface and its demo counts.
- Updates CHANGELOG `[Unreleased]` with the relationship manifest development slice.

## Boundary

Docs-only PR.

No package version bump.

No CLI version change.

No source code changes.

No test changes.

No generated artifacts.

No new relationship families.

No plugin API.

No plugin discovery.

No plugin loader.

No plugin execution.

No relationship graph.

No dependency graph.

No runtime behavior.

No ground behavior.

No Studio-specific API.

## Notes

The package and CLI version intentionally remain `0.8.2` until the final v0.9.0 release preparation PR.

The documentation now treats v0.9.0 as the active development baseline, not yet as a tagged release.