### PR TITLE
Release v0.10.1 documentation consistency alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,50 @@ No changes yet.
 
 ---
 
+## [v0.10.1] - Documentation and Published Site Consistency
+
+### Added
+
+- Added v0.10.1 release notes.
+- Added the v0.10.1 release notes page to the MkDocs navigation.
+
+### Changed
+
+- Updated the package and CLI version to `0.10.1`.
+- Marked `v0.10.1 - Documentation and Published Site Consistency` as completed in the roadmap.
+- Marked `v0.11.0 - Extensibility Boundary Contract, no execution` as the next milestone.
+- Clarified README wording around Relationship Manifest family counts.
+- Aligned the public documentation homepage with the v0.10.1 release baseline.
+- Preserved the v0.10.0 stability and compatibility classification baseline as the current compatibility foundation before v1.0.0.
+
+### Boundaries
+
+The v0.10.1 documentation consistency slice intentionally does not introduce:
+
+- new Mission Model semantics;
+- new YAML fields;
+- new model domains;
+- new CLI behavior beyond version reporting;
+- new JSON report fields;
+- new generated surfaces;
+- new lint diagnostics;
+- new scenario behavior;
+- schema migration tooling;
+- JSON Schema publication;
+- plugin execution;
+- plugin discovery;
+- plugin loader;
+- relationship graph;
+- dependency graph;
+- runtime behavior;
+- ground behavior;
+- Studio-specific API;
+- stable v1.0 compatibility guarantee.
+
+v0.10.1 is a documentation consistency and release-alignment milestone only.
+
+---
+
 ## [v0.10.0] - Stability and Compatibility Contract
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.10.0 - Stability and Compatibility Contract`.
+The current public baseline is `v0.10.1 - Documentation and Published Site Consistency`.
 
-In v0.10.0, Stability and Compatibility Contract means the first classification baseline for public, preview, candidate, generated and internal OrbitFabric surfaces before v1.0.0.
+In v0.10.1, Documentation and Published Site Consistency means the public documentation and release baseline have been aligned after the v0.10.0 stability and compatibility classification baseline.
 
-The current development focus is to preserve the v0.10.0 compatibility boundary while preparing documentation consistency work and future extensibility work without adding plugin execution, plugin discovery or plugin loaders prematurely.
+The current development focus is to prepare `v0.11.0 - Extensibility Boundary Contract, no execution` without adding plugin execution, plugin discovery or plugin loaders prematurely.
 
 The current baseline proves this Mission Data Chain:
 
@@ -142,7 +142,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.10.0
+orbitfabric 0.10.1
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ downstream inspection tools
 
 ## Current Status
 
-OrbitFabric is currently at `v0.10.0 - Stability and Compatibility Contract`.
+OrbitFabric is currently at `v0.10.1 - Documentation and Published Site Consistency`.
 
-v0.10.0 introduces the first stability and compatibility classification baseline before v1.0.0.
+v0.10.1 closes the documentation and published-site consistency pass after v0.10.0.
+
+It introduces no new Mission Model semantics, CLI behavior, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.
 
 It builds on:
 
@@ -53,6 +55,7 @@ v0.8.1  -> model_summary.json
 v0.8.2  -> entity_index.json
 v0.9.0  -> relationship_manifest.json
 v0.10.0 -> stability and compatibility classification
+v0.10.1 -> documentation and published-site consistency
 ```
 
 The current Core-owned structured surface chain is:
@@ -92,7 +95,8 @@ The current repository includes:
 - the `v0.8.1 - Contract Introspection Surface` vertical slice;
 - the `v0.8.2 - Entity Index Surface` vertical slice;
 - the `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary` vertical slice;
-- the `v0.10.0 - Stability and Compatibility Contract` vertical slice.
+- the `v0.10.0 - Stability and Compatibility Contract` vertical slice;
+- the `v0.10.1 - Documentation and Published Site Consistency` vertical slice.
 
 The current vertical slice is functional:
 
@@ -281,6 +285,8 @@ Relationship Manifest Surface in v0.9.0 is a Core-derived read-only candidate re
 
 Stability and Compatibility Contract in v0.10.0 is a classification baseline for public, preview, candidate, generated and internal surfaces before v1.0.0.
 
+Documentation and Published Site Consistency in v0.10.1 is a documentation consistency and release-alignment pass.
+
 None of them is flight software, ground software, plugin execution or a visual modeling tool.
 
 ---
@@ -353,7 +359,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.10.0
+orbitfabric 0.10.1
 ```
 
 ---
@@ -598,6 +604,7 @@ Useful entry points:
 - `docs/reference/scenario-evidence-stability.md`
 - `docs/reference/release-compatibility-policy.md`
 - `docs/releases/v0.10.0.md`
+- `docs/releases/v0.10.1.md`
 - `docs/adr/`
 
 Build the documentation site locally:
@@ -618,4 +625,4 @@ mkdocs serve
 
 OrbitFabric is developed as a clean-room open-source project.
 
-Do not add proprietary mission data, private architectures, private protocols, real operational logs, non-public payload details, real bus maps, real pinouts, employer/customer-owned code or NDA-protected material.
+Do not add private, confidential, proprietary, restricted or non-public mission material to this repository.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -50,7 +50,7 @@ orbitfabric --help
 Expected current package version:
 
 ```text
-orbitfabric 0.10.0
+orbitfabric 0.10.1
 ```
 
 ---
@@ -75,7 +75,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.10.0 Slice
+## Verify the Current v0.10.1 Slice
 
 Run mission lint:
 
@@ -105,7 +105,7 @@ orbitfabric export relationship-manifest examples/demo-3u/mission/ \
   --json generated/reports/relationship_manifest.json
 ```
 
-Review the v0.10.0 compatibility classification references:
+Review the v0.10.0 compatibility classification references, which remain the current compatibility foundation before v1.0.0:
 
 ```text
 Stability and Compatibility Contract

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -111,7 +111,7 @@ orbitfabric --help
 Expected version:
 
 ```text
-orbitfabric 0.10.0
+orbitfabric 0.10.1
 ```
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Roadmap
 
-Version: v0.10.0 to v1.0 stability path  
+Version: v0.10.1 to v1.0 stability path  
 Status: Development preview  
 Scope: v0.3 to v1.0 planning
 
@@ -71,23 +71,23 @@ v0.8.1  Contract Introspection Surface                        completed
 v0.8.2  Entity Index Surface                                  completed
 v0.9.0  Relationship Manifest Surface and Extensibility Boundary completed
 v0.10.0 Stability and Compatibility Contract                  completed
-v0.10.1 Documentation and Published Site Consistency          next
-v0.11.0 Extensibility Boundary Contract, no execution         future
+v0.10.1 Documentation and Published Site Consistency          completed
+v0.11.0 Extensibility Boundary Contract, no execution         next
 v0.12.0 v1.0 Release Candidate Hardening                      future
 v1.0.0  Stable Mission Data Contract                          future
 ```
 
-The current completed milestone is `v0.10.0 - Stability and Compatibility Contract`.
+The current completed milestone is `v0.10.1 - Documentation and Published Site Consistency`.
 
-The immediate target after v0.10.0 is `v0.10.1 - Documentation and Published Site Consistency`.
+The immediate target after v0.10.1 is `v0.11.0 - Extensibility Boundary Contract, no execution`.
 
-This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified the compatibility expectations around those public and preview surfaces before v1.0.
+This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified the compatibility expectations around those public and preview surfaces before v1.0. v0.10.1 verified and preserved documentation and published-site consistency before the extensibility boundary work.
 
-The next step is not plugin execution. The next step is to verify and preserve consistency between repository documentation and the published documentation site.
+The next step is not plugin execution. The next step is to define the extensibility boundary without plugin execution.
 
-v0.10.1 does not introduce plugin execution, plugin discovery, plugin loaders, relationship graphs, dependency graphs, runtime behavior, ground behavior, Studio-specific APIs or new Mission Model semantics.
+v0.11.0 must not introduce plugin execution, plugin discovery, plugin loaders, relationship graphs, dependency graphs, runtime behavior, ground behavior, Studio-specific APIs or new Mission Model semantics unless explicitly scoped and reviewed.
 
-Future extensibility can build on Core-owned structured surfaces without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files, textual CLI output or UI state.
+Future extensibility must build on Core-owned structured surfaces without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files, textual CLI output or UI state.
 
 ---
 
@@ -400,17 +400,47 @@ stable v1.0 compatibility guarantee
 
 ---
 
-## 11. Next Milestone - v0.10.1 Documentation and Published Site Consistency
+## 11. Completed Slice - v0.10.1 Documentation and Published Site Consistency
 
-v0.10.1 should verify and preserve consistency between repository documentation and the published documentation site.
+v0.10.1 verified and preserved consistency between repository documentation and the published documentation site.
 
-It should ensure that the public documentation remains aligned with the released baseline and the roadmap toward v1.0.
+It ensured that the public documentation remains aligned with the released baseline and the roadmap toward v1.0.
 
-This milestone is documentation consistency work only. It should not introduce model, CLI, export, generator, runtime, ground or plugin behavior.
+It also clarified README wording around Relationship Manifest family counts:
+
+```text
+19 admitted relationship families at the candidate surface level
+46 emitted relationship records for examples/demo-3u/mission
+17 emitted relationship families for examples/demo-3u/mission
+```
+
+v0.10.1 intentionally does not introduce:
+
+```text
+new Mission Model semantics
+new YAML fields
+new model domains
+new CLI behavior beyond version reporting
+new JSON report fields
+new generated surfaces
+new lint diagnostics
+new scenario behavior
+schema migration tooling
+JSON Schema publication
+plugin execution
+plugin discovery
+plugin loader
+relationship graph
+dependency graph
+runtime behavior
+ground behavior
+Studio-specific API
+stable v1.0 compatibility guarantee
+```
 
 ---
 
-## 12. Future Milestone - v0.11.0 Extensibility Boundary Contract, no execution
+## 12. Next Milestone - v0.11.0 Extensibility Boundary Contract, no execution
 
 v0.11.0 should define the extensibility boundary without executing plugins.
 
@@ -536,23 +566,23 @@ When deciding what to implement next, use these rules.
 
 ## 17. Immediate Work Plan
 
-The immediate work package after v0.10.0 is:
+The immediate work package after v0.10.1 is:
 
 ```text
-v0.10.1 - Documentation and Published Site Consistency
+v0.11.0 - Extensibility Boundary Contract, no execution
 ```
 
 Required next-step discipline:
 
 ```text
-1. verify repository documentation against the published documentation site
-2. preserve consistency between public docs and release baseline
-3. avoid model, CLI, export, generator, runtime, ground or plugin behavior changes
-4. keep compatibility documentation aligned with the v1.0 path
+1. define the extensibility boundary without executing plugins
+2. preserve Core-owned structured surfaces as the only downstream semantic source
+3. avoid runtime, ground, Studio-specific or plugin execution behavior
+4. keep the Mission Model as the source of truth
 5. keep downstream tools consuming Core-owned structured surfaces
 ```
 
-Do not start plugin execution, plugin discovery or plugin loader work in v0.10.1.
+Do not start plugin execution, plugin discovery or plugin loader work in v0.11.0.
 
 Do not let plugins reconstruct contract semantics from raw YAML, generated files or human-oriented CLI output.
 
@@ -580,7 +610,7 @@ The v0.9.0 roadmap step completed the first Core-owned relationship manifest sur
 
 The v0.10.0 roadmap step completed the first stability and compatibility classification baseline before v1.0.
 
-The v0.10.1 roadmap step should verify and preserve consistency between repository documentation and the published documentation site.
+The v0.10.1 roadmap step completed the documentation and published-site consistency pass.
 
 The v0.11.0 roadmap step should define the extensibility boundary without plugin execution.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,12 @@ From that contract, OrbitFabric validates consistency, generates documentation, 
 OrbitFabric is currently at:
 
 ```text
-v0.10.0 - Stability and Compatibility Contract
+v0.10.1 - Documentation and Published Site Consistency
 ```
 
-v0.10.0 adds the first **stability and compatibility classification baseline** for the path toward v1.0.0.
+v0.10.1 closes the documentation and published-site consistency pass after the first **stability and compatibility classification baseline** introduced in v0.10.0.
+
+It introduces no Mission Model semantics, CLI behavior, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.
 
 It builds on:
 
@@ -23,6 +25,7 @@ v0.8.1  -> model_summary.json
 v0.8.2  -> entity_index.json
 v0.9.0  -> relationship_manifest.json
 v0.10.0 -> stability and compatibility classification
+v0.10.1 -> documentation and published-site consistency
 ```
 
 The current public preview includes:

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -37,7 +37,7 @@ orbitfabric --version
 Current example:
 
 ```text
-orbitfabric 0.10.0
+orbitfabric 0.10.1
 ```
 
 This version answers the question:
@@ -90,7 +90,7 @@ Current lint report example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mission": "demo-3u",
   "model_version": "0.1.0"
 }
@@ -279,6 +279,14 @@ They do not introduce new version fields, schema migration tooling, JSON Schema 
 
 ---
 
+## Documentation consistency context
+
+v0.10.1 closes the documentation and published-site consistency pass after v0.10.0.
+
+It updates the OrbitFabric tool/package version and release documentation, but it does not introduce new Mission Model semantics, generated surface formats, JSON report fields, CLI behavior beyond version reporting, plugin execution, runtime behavior or ground behavior.
+
+---
+
 ## Why the versions differ
 
 During development previews, OrbitFabric may evolve faster than the Mission Model contract.
@@ -286,7 +294,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.10.0
+OrbitFabric tool/package version: 0.10.1
 Mission Model version:           0.1.0
 ```
 
@@ -294,13 +302,13 @@ This is valid.
 
 It means:
 
-- the tool has gained new capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces and Stability/Compatibility Classification references;
+- the tool has gained capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces and Stability/Compatibility Classification references;
 - the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record the relevant tool and model context.
 
 ---
 
-## Current v0.10.0 rule
+## Current v0.10.1 rule
 
 For the current development preview:
 
@@ -357,4 +365,4 @@ Possible future additions include:
 - JSON Schema export for Mission Model validation;
 - compatibility checks for generated artifact profiles.
 
-These are not part of the current v0.10.0 development preview.
+These are not part of the current v0.10.1 development preview.

--- a/docs/releases/v0.10.1.md
+++ b/docs/releases/v0.10.1.md
@@ -1,0 +1,96 @@
+# v0.10.1 - Documentation and Published Site Consistency
+
+OrbitFabric v0.10.1 closes the documentation and published-site consistency pass after v0.10.0.
+
+This release is intentionally narrow.
+
+It does not introduce Mission Model semantics, CLI behavior, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.
+
+---
+
+## Purpose
+
+The purpose of v0.10.1 is to verify and preserve consistency between:
+
+```text
+repository documentation
+published documentation site
+release notes
+roadmap
+README
+reference documentation
+MkDocs navigation
+```
+
+The milestone confirms that the public documentation baseline reflects `v0.10.0 - Stability and Compatibility Contract` before OrbitFabric moves toward the next extensibility boundary milestone.
+
+---
+
+## Changed
+
+v0.10.1 includes:
+
+```text
+README wording clarification for Relationship Manifest family counts
+repository documentation and published-site consistency audit
+v0.10.1 release notes
+roadmap release alignment
+package and CLI version bump to 0.10.1
+```
+
+The README now separates:
+
+```text
+19 admitted relationship families at the candidate surface level
+46 emitted relationship records for examples/demo-3u/mission
+17 emitted relationship families for examples/demo-3u/mission
+```
+
+This aligns README wording with the existing Roadmap, Architecture and Relationship Manifest reference documentation.
+
+---
+
+## Boundary
+
+v0.10.1 intentionally does not introduce:
+
+```text
+new Mission Model semantics
+new YAML fields
+new model domains
+new CLI behavior
+new JSON report fields
+new generated surfaces
+new lint diagnostics
+new scenario behavior
+schema migration tooling
+JSON Schema publication
+plugin execution
+plugin discovery
+plugin loader
+relationship graph
+dependency graph
+runtime behavior
+ground behavior
+Studio-specific API
+stable v1.0 compatibility guarantee
+```
+
+v0.10.1 is a documentation consistency and release-alignment milestone only.
+
+---
+
+## Result
+
+After v0.10.1, the public documentation baseline is considered consistent enough to proceed toward:
+
+```text
+v0.11.0 - Extensibility Boundary Contract, no execution
+```
+
+That next milestone must still preserve the existing boundary:
+
+```text
+plugins and downstream tools consume Core-owned structured surfaces;
+they do not reconstruct Mission Data Contract semantics from raw YAML, generated files, CLI text or UI state.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - v0.8.2 Entity Index Surface: releases/v0.8.2.md
       - v0.9.0 Relationship Manifest Surface and Extensibility Boundary: releases/v0.9.0.md
       - v0.10.0 Stability and Compatibility Contract: releases/v0.10.0.md
+      - v0.10.1 Documentation and Published Site Consistency: releases/v0.10.1.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
   "model-first"
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 2 - Pre-Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
@@ -34,19 +34,16 @@ classifiers = [
   "Topic :: Software Development :: Code Generators"
 ]
 dependencies = [
-  "typer>=0.12",
-  "rich>=13.7",
   "pydantic>=2.7",
+  "typer>=0.12",
   "PyYAML>=6.0"
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
-  "ruff>=0.6",
-  "mkdocs>=1.6",
-  "mkdocs-material>=9.5",
-  "pymdown-extensions>=10.0"
+  "ruff>=0.5",
+  "mkdocs-material>=9.5"
 ]
 
 [project.scripts]
@@ -55,9 +52,14 @@ orbitfabric = "orbitfabric.cli:app"
 [tool.hatch.build.targets.wheel]
 packages = ["src/orbitfabric"]
 
-[tool.ruff]
-line-length = 100
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.10.0"
+version = "0.10.1"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,7 +23,7 @@ keywords = [
   "model-first"
 ]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
@@ -34,16 +34,19 @@ classifiers = [
   "Topic :: Software Development :: Code Generators"
 ]
 dependencies = [
-  "pydantic>=2.7",
   "typer>=0.12",
+  "rich>=13.7",
+  "pydantic>=2.7",
   "PyYAML>=6.0"
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
-  "ruff>=0.5",
-  "mkdocs-material>=9.5"
+  "ruff>=0.6",
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.5",
+  "pymdown-extensions>=10.0"
 ]
 
 [project.scripts]
@@ -52,14 +55,9 @@ orbitfabric = "orbitfabric.cli:app"
 [tool.hatch.build.targets.wheel]
 packages = ["src/orbitfabric"]
 
+[tool.ruff]
+line-length = 100
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
-
-[tool.ruff]
-line-length = 100
-target-version = "py311"
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B"]
-ignore = []

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"


### PR DESCRIPTION
## Summary

Release-align `v0.10.1 - Documentation and Published Site Consistency`.

This PR closes the v0.10.1 documentation consistency milestone and prepares `main` for the next milestone:

```text
v0.11.0 - Extensibility Boundary Contract, no execution
```

v0.10.1 is intentionally narrow. It does not introduce Mission Model semantics, CLI behavior beyond version reporting, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.

## Changes

- Added `docs/releases/v0.10.1.md`.
- Exposed v0.10.1 release notes in `mkdocs.yml`.
- Bumped package metadata from `0.10.0` to `0.10.1`.
- Bumped `orbitfabric.__version__` from `0.10.0` to `0.10.1`.
- Aligned README current status with v0.10.1.
- Aligned docs homepage current status with v0.10.1.
- Added a v0.10.1 changelog entry.
- Marked v0.10.1 as completed in the roadmap.
- Marked v0.11.0 as the next milestone in the roadmap.
- Updated Quickstart expected CLI version to `orbitfabric 0.10.1`.
- Updated Development Guide version references to v0.10.1.
- Updated Contributing Guide current baseline to v0.10.1.
- Updated Versioning Model examples and current rule to v0.10.1.

## Affected Area

Select all that apply:

- [ ] Mission Model
- [ ] Model loading / validation
- [ ] Semantic lint rules
- [ ] Scenario loading / validation
- [ ] Scenario simulation
- [ ] JSON reports
- [ ] Documentation generation
- [ ] Generated artifacts
- [ ] Example missions
- [ ] CI / tooling
- [x] Public documentation
- [x] Release alignment
- [ ] Other

## Mission Data Contract Impact

Does this PR change Mission Data Contract semantics?

- [x] No
- [ ] Yes

If yes, describe the impact clearly.

N/A.

## Architectural Boundary

This PR intentionally does not implement or modify:

- Mission Model semantics;
- YAML fields;
- model loading or validation;
- CLI behavior beyond version reporting;
- JSON report fields;
- generated surfaces;
- lint diagnostics;
- scenario behavior;
- relationship manifest export behavior;
- relationship graph behavior;
- dependency graph behavior;
- plugin API;
- plugin discovery;
- plugin loader;
- plugin execution;
- runtime behavior;
- ground behavior;
- Studio-specific API.

It is release alignment and documentation consistency only.

## Clean-Room Confirmation

By opening this PR, I confirm that this contribution does not include:

- [x] proprietary mission data
- [x] private spacecraft architecture
- [x] private packet formats
- [x] real operational logs
- [x] non-public payload details
- [x] real bus maps or pinouts
- [x] employer-owned or customer-owned code
- [x] export-controlled or NDA-protected material

All examples are synthetic or derived only from public information.

## Validation

Select the checks that were run.

- [ ] `ruff check .`
- [ ] `pytest`
- [ ] `mkdocs build --strict`
- [ ] `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
- [ ] `orbitfabric gen docs examples/demo-3u/mission/`
- [ ] `orbitfabric gen data-flow examples/demo-3u/mission/ --output-file generated/docs/data_flow.md`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml --json generated/reports/payload_data_flow_evidence_report.json --log generated/logs/payload_data_flow_evidence.log`

Not run locally in this environment. GitHub Actions should validate the PR head after the final documentation consistency sweep.

## Generated Artifacts

- [x] This PR does not commit generated artifacts.
- [ ] This PR intentionally updates generated artifacts.

If generated artifacts are committed, explain why.

N/A.

## Notes for Review

This PR is the final release-alignment sweep for v0.10.1.

The v0.10.0 stability and compatibility classification remains the compatibility foundation before v1.0.0. v0.10.1 only closes the documentation and published-site consistency pass and prepares the roadmap for v0.11.0.