### PR TITLE
release: align documentation for v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,76 @@ No changes yet.
 
 ---
 
+## [v0.11.0] - Extensibility Boundary Contract, no execution
+
+### Added
+
+- Added ADR-0015 for the Extensibility Boundary Contract, No Execution.
+- Added the Extensibility Boundary Contract reference page.
+- Added the Extensibility Boundary Contract page to the MkDocs Reference navigation.
+- Added v0.11.0 release notes.
+- Added the v0.11.0 release notes page to the MkDocs Releases navigation.
+- Added non-normative guidance for future descriptive extension metadata.
+- Added explicit Core ownership rules for Mission Data Contract semantics.
+- Added explicit extension ownership rules for future extension-owned outputs.
+- Added provenance expectations for future extension-owned artifacts.
+- Added a semantic override ban for future extensions.
+- Added explicit downstream consumer rules for Core-owned surfaces and extension-owned artifacts.
+- Added compatibility-sensitive extensibility boundary expectations before v1.0.0.
+
+### Changed
+
+- Updated the package and CLI version to `0.11.0`.
+- Marked `v0.11.0 - Extensibility Boundary Contract, no execution` as completed in the roadmap.
+- Marked `v0.12.0 - v1.0 Release Candidate Hardening` as the next milestone.
+- Aligned README with the v0.11.0 release baseline.
+- Aligned the public documentation homepage with the v0.11.0 release baseline.
+- Aligned Quickstart, Development Guide, Contributing Guide and Versioning Model with the v0.11.0 release baseline.
+- Aligned Architecture and Project Charter headers with the v0.11.0 extensibility boundary baseline.
+
+### Boundaries
+
+The v0.11.0 extensibility boundary slice intentionally does not introduce:
+
+- new Mission Model semantics;
+- new YAML fields;
+- new model domains;
+- new CLI behavior beyond version reporting;
+- new JSON report fields;
+- new generated Core surfaces;
+- new lint diagnostics;
+- new scenario behavior;
+- metadata schema;
+- JSON metadata shape;
+- metadata manifest format;
+- metadata parser;
+- metadata loader;
+- metadata validator;
+- new extension command;
+- plugin discovery;
+- plugin loading;
+- plugin execution;
+- custom lint plugin execution;
+- custom generator plugin execution;
+- dynamic extension runtime;
+- third-party code execution;
+- remote plugin registry;
+- plugin marketplace;
+- extension installation;
+- extension dependency resolution;
+- relationship graph;
+- dependency graph;
+- runtime behavior;
+- ground behavior;
+- Studio-specific API;
+- schema migration tooling;
+- JSON Schema publication;
+- stable v1.0 compatibility guarantee.
+
+v0.11.0 is an extensibility boundary and release-alignment milestone only.
+
+---
+
 ## [v0.10.1] - Documentation and Published Site Consistency
 
 ### Added
@@ -248,351 +318,6 @@ The Contract Introspection Surface intentionally does not introduce:
 - Studio-specific API;
 - runtime behavior;
 - ground behavior.
-
----
-
-## [v0.8.0] - Ground Integration Artifacts
-
-### Added
-
-- Added the `GroundContract` intermediate model for ground-facing generation.
-- Added the `orbitfabric gen ground` command.
-- Added the initial `generic` ground generation profile.
-- Added `ground_contract_manifest.json` generation.
-- Added JSON ground dictionaries for telemetry, commands, events, faults, data products and packets.
-- Added CSV ground dictionaries for review workflows.
-- Added generated `README.md` for the ground artifact directory.
-- Added generated `ground_dictionaries.md` for human engineering review.
-- Added manifest boundary flags for ground runtime, operator console, transport, database, Yamcs, OpenC3 and XTCE claims.
-- Added Ground Integration Artifacts reference documentation.
-- Added ADR-0012 for the Ground Integration Artifacts boundary.
-- Added v0.8.0 release notes.
-
-### Changed
-
-- Extended the public documentation baseline from v0.7.0 to v0.8.0.
-- Extended the Mission Data Chain from runtime-facing contract bindings to ground-facing contract exports.
-- Updated README, architecture, roadmap, quickstart, development guide, contributing guide, versioning documentation and demo walkthrough for v0.8.0.
-- Updated the package and CLI version to `0.8.0`.
-- Marked `v0.9 - Plugin and Extensibility Layer` as the next roadmap milestone.
-
-### Boundaries
-
-The Ground Integration Artifacts slice intentionally does not introduce:
-
-- live ground segment;
-- mission control system;
-- operator console;
-- telemetry archive;
-- telemetry database;
-- command uplink service;
-- telecommand transport;
-- telemetry downlink runtime;
-- network/session/routing behavior;
-- command authentication or authorization;
-- security enforcement;
-- Yamcs integration;
-- OpenC3 integration;
-- XTCE compliance;
-- CCSDS/PUS/CFDP implementation;
-- binary packet decoder;
-- binary telecommand encoder;
-- offset/bitfield layout model;
-- calibration model;
-- RF/link-budget behavior;
-- pass scheduling;
-- station automation.
-
-Ground Integration Artifacts in v0.8.0 are ground-facing contract exports only.
-
----
-
-## [v0.7.0] - Generated Runtime Skeletons
-
-### Added
-
-- Added the `RuntimeContract` intermediate model for software-facing generation.
-- Added deterministic runtime naming and symbol generation.
-- Added deterministic generated numeric identifiers with `Invalid = 0` reserved per enum domain.
-- Added the `orbitfabric gen runtime` command.
-- Added the initial `cpp17` runtime generation profile.
-- Added `runtime_contract_manifest.json` generation.
-- Added generated C++17 mission identifier headers through `mission_ids.hpp`.
-- Added generated C++17 runtime value enums through `mission_enums.hpp`.
-- Added generated C++17 static metadata registries through `mission_registries.hpp`.
-- Added generated C++17 command argument structs through `command_args.hpp`.
-- Added generated C++17 abstract adapter interfaces through `adapter_interfaces.hpp`.
-- Added generated C++17 host-build smoke files through `CMakeLists.txt` and `src/orbitfabric_runtime_contract_smoke.cpp`.
-- Added host-build smoke validation for generated runtime-facing contract bindings.
-- Added Runtime Contract Bindings reference documentation.
-- Added v0.7.0 release notes.
-
-### Changed
-
-- Extended the public documentation baseline from v0.6.0 to v0.7.0.
-- Extended the Mission Data Chain from data-flow evidence to runtime-facing contract bindings.
-- Updated README, architecture, roadmap, quickstart, development guide, contributing guide and versioning documentation for v0.7.0.
-- Updated the package and CLI version to `0.7.0`.
-- Marked `v0.8 - Ground Integration Artifacts` as the next roadmap milestone.
-
-### Boundaries
-
-The Generated Runtime Skeletons slice intentionally does not introduce:
-
-- flight-ready runtime;
-- complete OBC framework;
-- command dispatch runtime;
-- command queues;
-- telemetry polling runtime;
-- event routing runtime;
-- fault manager runtime;
-- scheduler;
-- HAL;
-- drivers;
-- RTOS abstraction;
-- binary serialization;
-- CCSDS/PUS/CFDP behavior;
-- storage runtime;
-- downlink runtime;
-- user-code merge;
-- protected regions;
-- flight-ready software.
-
-Generated Runtime Skeletons in v0.7.0 are runtime-facing contract bindings only.
-
----
-
-## [v0.6.0] - End-to-End Mission Data Flow Evidence
-
-### Added
-
-- Added command-declared data product effects through `expected_effects.data_products`.
-- Added `OF-CMD-008` and `OF-CMD-009` diagnostics for command data product effects.
-- Added simulation data-flow evidence records.
-- Added `data_flow_evidence` to simulation JSON reports.
-- Added `summary.data_flow_evidence` to simulation JSON reports.
-- Added scenario `expect.data_flow` assertions.
-- Added `OF-SCN-014` through `OF-SCN-017` diagnostics for scenario data-flow expectation references.
-- Added the synthetic `payload_data_flow_evidence` demo scenario.
-- Added generated `data_flow.md` documentation output.
-- Added the `orbitfabric gen data-flow` command.
-- Added a dedicated Data Flow Evidence reference page.
-- Added v0.6.0 release notes.
-
-### Changed
-
-- Extended the standard `orbitfabric gen docs` output to include `generated/docs/data_flow.md`.
-- Extended the synthetic `demo-3u` mission evidence chain from commandability/autonomy to contract-level data-flow evidence.
-- Updated public documentation, architecture, roadmap, quickstart, demo walkthrough and report references for v0.6.0.
-- Bumped package and CLI version to `0.6.0`.
-
-### Boundaries
-
-The End-to-End Mission Data Flow Evidence slice intentionally does not introduce:
-
-- real payload file generation;
-- real onboard storage runtime;
-- file-system behavior;
-- compression behavior;
-- real downlink queue execution;
-- real contact scheduling;
-- RF behavior;
-- live ground integration;
-- CCSDS/PUS/CFDP runtime behavior;
-- runtime skeleton generation;
-- flight-ready software.
-
----
-
-## [v0.5.0] - Commandability and Autonomy Contracts
-
-### Added
-
-- Added the Commandability and Autonomy Contract Model as an optional mission model domain.
-- Added optional `mission/commandability.yaml` loading.
-- Added command sources.
-- Added commandability rules.
-- Added autonomous action contracts.
-- Added recovery intents.
-- Added semantic lint rules for commandability/autonomy consistency.
-- Added `OF-CAB-*`, `OF-AUT-*` and `OF-REC-*` lint rule families.
-- Added generated Commandability and Autonomy Contract documentation.
-- Added generated `commandability.md` documentation output.
-- Added one synthetic commandability/autonomy slice to the `demo-3u` mission.
-
-### Changed
-
-- Extended the synthetic `demo-3u` mission with contract-level commandability and recovery assumptions.
-- Extended generated mission documentation to include commandability/autonomy references when commandability contracts are present.
-- Extended the Mission Data Chain from contact/downlink assumptions to commandability, autonomy and recovery assumptions.
-
-### Boundaries
-
-The Commandability and Autonomy Contract slice intentionally does not introduce:
-
-- real command authentication;
-- real command authorization;
-- live uplink services;
-- operator consoles;
-- command queues;
-- onboard schedulers;
-- autonomy runtime;
-- real FDIR or safing behavior;
-- Yamcs/OpenC3 runtime services;
-- real spacecraft operations.
-
----
-
-## [v0.4.0] - Contact Windows and Downlink Flow Contracts
-
-### Added
-
-- Added the Contact Windows and Downlink Flow Contract Model as an optional mission model domain.
-- Added optional `mission/contacts.yaml` loading.
-- Added contact profiles.
-- Added link profiles.
-- Added contact windows with declared capacity assumptions.
-- Added downlink flow contracts.
-- Added data product eligibility for downlink flows.
-- Added Mission Model ID helpers for contact/downlink domains.
-- Added duplicate ID validation for contact profiles, link profiles, contact windows and downlink flows.
-- Added semantic lint rules for contact/downlink references and downlink flow consistency.
-- Added `OF-CON-*` lint rules for contact assumptions.
-- Added `OF-DL-*` lint rules for downlink flow assumptions.
-- Added generated Contact and Downlink Contract documentation.
-- Added generated `contacts.md` documentation output.
-- Added one synthetic contact/downlink slice to the `demo-3u` mission.
-- Added ADR-0009 for Contact Windows and Downlink Flow Contracts.
-- Added reference documentation for the Contact and Downlink Contract Model.
-
-### Changed
-
-- Extended the synthetic `demo-3u` mission with contract-level contact/downlink assumptions.
-- Extended generated mission documentation to include contact/downlink references when contact contracts are present.
-- Extended the Mission Data Chain from downlink intent to declared contact and downlink flow assumptions.
-- Reinforced the boundary between contract assumptions and runtime/ground behavior.
-
-### Boundaries
-
-The Contact Windows and Downlink Flow Contract slice intentionally does not introduce:
-
-- orbit propagation;
-- TLE parsing;
-- ground track computation;
-- antenna pointing;
-- RF link budget simulation;
-- real contact scheduling;
-- real downlink execution;
-- onboard downlink queues;
-- live ground links;
-- CCSDS/PUS/CFDP implementation;
-- Yamcs/OpenC3 runtime integration;
-- runtime skeleton generation;
-- ground export generation;
-- real spacecraft operations.
-
----
-
-## [v0.3.0] - Data Product and Storage Contracts
-
-### Added
-
-- Added the Data Product Contract Model as an optional mission model domain.
-- Added optional `mission/data_products.yaml` loading.
-- Added the `DataProductContract` model.
-- Added data product producer type support.
-- Added data product type support.
-- Added estimated data product size support.
-- Added data product priority support.
-- Added storage intent fields.
-- Added storage class support.
-- Added retention intent support.
-- Added overflow policy support.
-- Added downlink intent fields.
-- Added downlink policy support.
-- Added semantic lint rules for Data Product Contracts.
-- Added data product producer reference checks.
-- Added optional payload reference checks.
-- Added storage intent warnings for missing retention and overflow policy.
-- Added downlink intent warnings for high-priority data products.
-- Added generated data product documentation.
-- Added generated `data_products.md` documentation output.
-- Added invalid data product fixtures and tests.
-- Added one synthetic data product to the `demo-3u` mission.
-- Added ADR-0008 for Data Product and Storage Contracts.
-
-### Changed
-
-- Extended the synthetic `demo-3u` mission with a clean-room payload data product.
-- Extended generated mission documentation to include Data Product Contract references when data products are present.
-- Reinforced the Mission Data Chain direction introduced by ADR-0007.
-- Moved OrbitFabric one step further from payload behavior modeling toward explicit mission data chain modeling.
-
-### Boundaries
-
-The Data Product and Storage Contract slice intentionally does not introduce:
-
-- real onboard storage runtime;
-- file-system abstraction;
-- compression engines;
-- payload data processing pipelines;
-- contact window modeling;
-- RF link modeling;
-- downlink runtime;
-- ground segment export;
-- runtime skeleton generation;
-- real payload data.
-
----
-
-## [v0.2.2] - Payload Contract Release Alignment
-
-### Changed
-
-- Aligned README, public documentation, roadmap, changelog, release notes and package version around the Payload Contract Model.
-- Documented `v0.2.2` as the Payload Contract Release Alignment baseline.
-- Added release notes for `v0.2.2`.
-- Prepared public communication material for the Payload Contract Model.
-
----
-
-## [v0.2.1] - Payload Contract Model
-
-### Added
-
-- Added the Payload / IOD Payload Contract Model as an optional mission model domain.
-- Added optional `mission/payloads.yaml` loading.
-- Added the `PayloadContract` model.
-- Added payload profile support.
-- Added minimal payload lifecycle support.
-- Added payload contract semantic linting.
-- Added payload lint rules `OF-PAY-001` through `OF-PAY-010`.
-- Added payload reference checks for linked subsystems, telemetry, commands, events and faults.
-- Added generated payload contract documentation.
-- Added generated `payloads.md` documentation output.
-- Added minimal payload-aware scenario behavior.
-- Added nominal payload lifecycle simulation for `READY -> ACQUIRING -> READY`.
-- Added invalid payload contract fixtures.
-- Added negative tests for mutated payload contract fixtures.
-- Added ADR-0006 for the Payload Contract Model.
-
-### Changed
-
-- Extended the synthetic `demo-3u` mission with a clean-room IOD payload contract.
-- Extended the demo scenario to include payload lifecycle behavior during `battery_low_during_payload`.
-- Reinforced OrbitFabric's positioning as a Mission Data Contract Layer.
-
-### Boundaries
-
-The Payload Contract Model intentionally does not introduce:
-
-- payload firmware;
-- payload drivers;
-- payload runtime execution;
-- physical payload simulation;
-- hardware bus integration;
-- payload data processing pipelines;
-- ground segment implementation.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ The project is currently in pre-1.0 development. Contributions should stay focus
 
 ## Current Project Focus
 
-The current public baseline is `v0.10.1 - Documentation and Published Site Consistency`.
+The current public baseline is `v0.11.0 - Extensibility Boundary Contract, no execution`.
 
-In v0.10.1, Documentation and Published Site Consistency means the public documentation and release baseline have been aligned after the v0.10.0 stability and compatibility classification baseline.
+In v0.11.0, Extensibility Boundary Contract means the project has documented how future extension-owned outputs may relate to Core-owned Mission Data Contract semantics without introducing plugin discovery, plugin loading, plugin execution or a plugin runtime.
 
-The current development focus is to prepare `v0.11.0 - Extensibility Boundary Contract, no execution` without adding plugin execution, plugin discovery or plugin loaders prematurely.
+The current development focus is to prepare `v0.12.0 - v1.0 Release Candidate Hardening` without broadening OrbitFabric into flight software, ground software, visual modeling, plugin discovery, plugin loading or plugin execution.
 
 The current baseline proves this Mission Data Chain:
 
@@ -33,9 +33,10 @@ Payload Contract
   -> Entity Index Surface
   -> Relationship Manifest Surface
   -> Stability and Compatibility Classification
+  -> Extensibility Boundary Contract
 ```
 
-Do not add large integrations before the contract model, Core-owned structured surfaces and compatibility boundaries are coherent.
+Do not add large integrations before the contract model, Core-owned structured surfaces, compatibility boundaries and extensibility boundary are coherent.
 
 Out of scope for the current preview:
 
@@ -67,9 +68,13 @@ Out of scope for the current preview:
 - JSON Schema publication;
 - stable v1.0 compatibility guarantee;
 - plugin API;
-- plugin execution;
 - plugin discovery;
-- plugin loader;
+- plugin loading;
+- plugin execution;
+- metadata schema;
+- metadata parser;
+- metadata loader;
+- metadata validator;
 - real spacecraft data.
 
 Runtime-facing contract bindings must remain generated, deterministic and disposable.
@@ -84,9 +89,11 @@ Relationship manifest reports must remain Core-owned, deterministic, read-only, 
 
 Compatibility classification references must remain documentation contracts, not implementation behavior, schema migration tooling, plugin execution or a v1.0 stability guarantee.
 
+The Extensibility Boundary Contract must remain a boundary contract, not metadata schema, plugin discovery, plugin loading, plugin execution or a plugin runtime.
+
 User implementation code and downstream integration code must live outside `generated/`.
 
-Future plugin and extensibility work must not allow plugins to silently redefine core Mission Data Contract semantics or bypass validation.
+Future plugin and extensibility work must not allow plugins to silently redefine Core Mission Data Contract semantics or bypass validation.
 
 ---
 
@@ -142,7 +149,7 @@ orbitfabric --help
 Expected current version:
 
 ```text
-orbitfabric 0.10.1
+orbitfabric 0.11.0
 ```
 
 ---
@@ -228,8 +235,8 @@ Rules:
 
 - keep modules small;
 - keep the Mission Model as the source of truth;
-- do not parse YAML independently in generators, simulators or exporters;
-- consume validated model objects;
+- do not parse YAML independently in generators, simulators, exporters or downstream tools;
+- consume validated model objects and Core-owned structured surfaces;
 - prefer explicit diagnostics;
 - write tests for new lint rules, generators, exporters and simulator behavior;
 - do not introduce heavy dependencies without a clear reason.
@@ -273,6 +280,8 @@ RuntimeContract builder -> raw YAML files
 GroundContract builder -> raw YAML files
 profile-specific generator -> raw YAML files
 exporter -> raw YAML files
+extension output -> Core-owned semantics
+plugin output -> Core-owned relationship manifest
 ```
 
 Do not hardcode behavior for `demo-3u` inside the framework core.
@@ -280,6 +289,8 @@ Do not hardcode behavior for `demo-3u` inside the framework core.
 Relationship manifest records must remain derived from explicit loaded Mission Model fields and must reference indexed entities rather than synthetic downstream nodes.
 
 Compatibility classification references must not become a second source of Mission Data Contract semantics.
+
+The Extensibility Boundary Contract must not become a plugin execution surface without a separate architectural review.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Model-first Mission Data Fabric for small spacecraft**
 
-Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces and compatibility classification references once.
+Define telemetry, commands, events, faults, modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classification references and extensibility boundary contracts once.
 Validate them, document them, simulate them and generate deterministic integration, inspection and compatibility artifacts from the same source of truth.
 
 </div>
@@ -19,7 +19,7 @@ Validate them, document them, simulate them and generate deterministic integrati
 
 OrbitFabric is a **model-first Mission Data Fabric** for small spacecraft.
 
-It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation, runtime-facing bindings, ground-facing integration artifacts, Core-owned introspection surfaces and downstream inspection tools.
+It lets teams define mission data contracts once, using a structured Mission Model, and then reuse that contract across validation, documentation, testing, simulation, runtime-facing bindings, ground-facing integration artifacts, Core-owned introspection surfaces, compatibility references and downstream inspection tools.
 
 OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
 
@@ -34,6 +34,7 @@ documentation
 runtime-facing integration
 ground integration
 downstream inspection tools
+future extension-owned outputs
 ```
 
 > Define once. Validate. Simulate. Test. Document. Integrate.
@@ -42,11 +43,11 @@ downstream inspection tools
 
 ## Current Status
 
-OrbitFabric is currently at `v0.10.1 - Documentation and Published Site Consistency`.
+OrbitFabric is currently at `v0.11.0 - Extensibility Boundary Contract, no execution`.
 
-v0.10.1 closes the documentation and published-site consistency pass after v0.10.0.
+v0.11.0 defines the extensibility boundary without introducing plugin execution.
 
-It introduces no new Mission Model semantics, CLI behavior, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.
+It introduces no new Mission Model semantics, YAML fields, CLI behavior beyond version reporting, JSON report fields, generated Core surfaces, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin discovery, plugin loading, plugin execution, metadata schema, metadata parser, metadata loader, metadata validator or Studio-specific APIs.
 
 It builds on:
 
@@ -56,6 +57,7 @@ v0.8.2  -> entity_index.json
 v0.9.0  -> relationship_manifest.json
 v0.10.0 -> stability and compatibility classification
 v0.10.1 -> documentation and published-site consistency
+v0.11.0 -> extensibility boundary contract, no execution
 ```
 
 The current Core-owned structured surface chain is:
@@ -66,16 +68,15 @@ entity_index.json           -> What contract entities are defined?
 relationship_manifest.json  -> How are indexed contract entities related?
 ```
 
-v0.10.0 adds compatibility classification references for:
+v0.11.0 adds the first documented extensibility boundary around those Core-owned semantics:
 
 ```text
-Mission Model stability expectations
-CLI command stability
-JSON report compatibility expectations
-lint rule code evolution
-generated and exported surface stability
-scenario evidence stability
-release compatibility policy
+Mission Model remains the source of truth.
+Core owns Mission Data Contract semantics.
+Extensions consume Core-owned structured surfaces.
+Extension-owned outputs remain distinguishable from Core-owned outputs.
+Extensions must not override Core semantics.
+Execution is out of scope.
 ```
 
 OrbitFabric does not generate a ground segment, mission control system, telemetry archive, command uplink service, operator console, decoder runtime, database, Yamcs integration, OpenC3 integration or XTCE-compliant mission database.
@@ -96,7 +97,8 @@ The current repository includes:
 - the `v0.8.2 - Entity Index Surface` vertical slice;
 - the `v0.9.0 - Relationship Manifest Surface and Extensibility Boundary` vertical slice;
 - the `v0.10.0 - Stability and Compatibility Contract` vertical slice;
-- the `v0.10.1 - Documentation and Published Site Consistency` vertical slice.
+- the `v0.10.1 - Documentation and Published Site Consistency` vertical slice;
+- the `v0.11.0 - Extensibility Boundary Contract, no execution` vertical slice.
 
 The current vertical slice is functional:
 
@@ -124,6 +126,8 @@ The current vertical slice is functional:
 - `orbitfabric export relationship-manifest` generation;
 - Core-owned `relationship_manifest.json` candidate relationship report;
 - stability and compatibility classification references;
+- Extensibility Boundary Contract reference documentation;
+- ADR-0015 for the extensibility boundary;
 - synthetic demo mission: `demo-3u`.
 
 The relationship manifest candidate surface admits 19 deliberately narrow relationship families.
@@ -131,6 +135,8 @@ The relationship manifest candidate surface admits 19 deliberately narrow relati
 For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 emitted relationship families.
 
 It is not a graph engine, dependency graph, plugin API, Studio API, runtime behavior layer or ground behavior layer.
+
+The Extensibility Boundary Contract is not a plugin API, plugin loader, metadata schema, metadata manifest format or execution mechanism.
 
 The repository also includes a growing set of example mission slices:
 
@@ -197,7 +203,8 @@ It models:
 - Core-owned contract introspection surfaces;
 - Core-owned entity index surfaces;
 - Core-owned relationship manifest surfaces;
-- stability and compatibility classifications before v1.0.0.
+- stability and compatibility classifications before v1.0.0;
+- extensibility boundary rules before any plugin execution exists.
 
 The data-flow evidence chain connects:
 
@@ -217,6 +224,7 @@ command expected effect
         -> entity index surface
         -> relationship manifest surface
         -> compatibility classification
+        -> extensibility boundary
 ```
 
 The structured surface chain is:
@@ -228,10 +236,10 @@ Mission Model
         -> model_summary.json
         -> entity_index.json
         -> relationship_manifest.json
-        -> downstream tools consume Core-owned structured surfaces
+        -> downstream tools and future extensions consume Core-owned structured surfaces
 ```
 
-Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces and Stability/Compatibility References are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior or live ground operations.
+Payload, Data Product, Contact/Downlink, Commandability/Autonomy, Data-Flow Evidence, Runtime Contract Binding, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces, Stability/Compatibility References and the Extensibility Boundary Contract are part of the Mission Data Contract architecture. They do not describe payload firmware, payload drivers, hardware buses, onboard services, physical payload simulation, real storage execution, real contact scheduling, real downlink runtime behavior, live uplink services, operator authentication, command queues, onboard schedulers, autonomy runtime, real FDIR behavior, plugin execution or live ground operations.
 
 ---
 
@@ -267,7 +275,13 @@ OrbitFabric is not:
 - a relationship graph;
 - a dependency graph;
 - a plugin execution layer;
+- a plugin loader;
+- a plugin discovery mechanism;
 - a plugin API;
+- a metadata schema;
+- a metadata parser;
+- a metadata loader;
+- a metadata validator;
 - a Studio-specific backend API;
 - schema migration tooling;
 - a JSON Schema publication layer;
@@ -286,6 +300,8 @@ Relationship Manifest Surface in v0.9.0 is a Core-derived read-only candidate re
 Stability and Compatibility Contract in v0.10.0 is a classification baseline for public, preview, candidate, generated and internal surfaces before v1.0.0.
 
 Documentation and Published Site Consistency in v0.10.1 is a documentation consistency and release-alignment pass.
+
+Extensibility Boundary Contract in v0.11.0 is a boundary contract for future extension-owned outputs without execution.
 
 None of them is flight software, ground software, plugin execution or a visual modeling tool.
 
@@ -334,6 +350,7 @@ Payload Contract
         -> Entity Index Surface
         -> Relationship Manifest Surface
         -> Stability and Compatibility Classification
+        -> Extensibility Boundary Contract
 ```
 
 ---
@@ -359,7 +376,7 @@ orbitfabric --help
 Expected:
 
 ```text
-orbitfabric 0.10.1
+orbitfabric 0.11.0
 ```
 
 ---
@@ -432,9 +449,11 @@ These surfaces are read-only Core-owned reports. They are not graph engines, plu
 
 ---
 
-## Review Stability and Compatibility References
+## Review Stability, Compatibility and Extensibility References
 
 v0.10.0 adds the first compatibility classification baseline before v1.0.0.
+
+v0.11.0 adds the first Extensibility Boundary Contract before any plugin execution exists.
 
 Key references:
 
@@ -443,15 +462,16 @@ Stability and Compatibility Contract
 Mission Model Stability Contract
 CLI Contract v1 Preview
 Generated Surfaces Stability
+Extensibility Boundary Contract
 Lint Rule Code Stability
 JSON Report Compatibility
 Scenario Evidence Stability
 Release Compatibility Policy
 ```
 
-These references classify existing surfaces.
+These references classify existing surfaces and define the future extensibility boundary.
 
-They do not add Mission Model semantics, CLI behavior, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, schema migration tooling, JSON Schema publication, runtime behavior, ground behavior, plugin execution or a stable v1.0 guarantee.
+They do not add Mission Model semantics, CLI behavior beyond version reporting, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, schema migration tooling, JSON Schema publication, runtime behavior, ground behavior, plugin discovery, plugin loading, plugin execution or a stable v1.0 guarantee.
 
 ---
 
@@ -599,12 +619,14 @@ Useful entry points:
 - `docs/reference/mission-model-stability-contract.md`
 - `docs/reference/cli-contract-v1.md`
 - `docs/reference/generated-surfaces-stability.md`
+- `docs/reference/extensibility-boundary-contract.md`
 - `docs/reference/lint-rule-code-stability.md`
 - `docs/reference/json-report-compatibility.md`
 - `docs/reference/scenario-evidence-stability.md`
 - `docs/reference/release-compatibility-policy.md`
 - `docs/releases/v0.10.0.md`
 - `docs/releases/v0.10.1.md`
+- `docs/releases/v0.11.0.md`
 - `docs/adr/`
 
 Build the documentation site locally:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Architecture
 
-Version: 0.10.0  
+Version: 0.11.0  
 Status: Development preview  
-Scope: Mission Data Contract architecture through Stability and Compatibility Contract
+Scope: Mission Data Contract architecture through Extensibility Boundary Contract, no execution
 
 ---
 
@@ -16,7 +16,7 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, stability and compatibility classifications, documentation and scenario evidence from one source of truth.
+It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, stability and compatibility classifications, extensibility boundary rules, documentation and scenario evidence from one source of truth.
 
 OrbitFabric is not designed as:
 
@@ -32,14 +32,16 @@ CCSDS/PUS/CFDP implementation
 hardware abstraction layer
 visual modeling tool
 Studio-specific backend API
+plugin discovery mechanism
+plugin loading mechanism
 plugin execution platform
 ```
 
 Its architectural role is:
 
-> define, validate, simulate, document, introspect, index, relate, classify and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration and downstream inspection tools.
+> define, validate, simulate, document, introspect, index, relate, classify, bound extensibility and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration, downstream inspection tools and future extension-owned outputs.
 
-The current architectural baseline is `v0.10.0 - Stability and Compatibility Contract`.
+The current architectural baseline is `v0.11.0 - Extensibility Boundary Contract, no execution`.
 
 v0.8.1 introduced the first Core-owned read-only model summary surface derived from the loaded Mission Model.
 
@@ -47,7 +49,9 @@ v0.8.2 introduced the first Core-owned read-only entity index surface derived fr
 
 v0.9.0 introduced the first Core-owned read-only relationship manifest surface derived from explicit loaded Mission Model fields.
 
-v0.10.0 introduces the first stability and compatibility classification baseline for public, preview, candidate, generated and internal surfaces before v1.0.0.
+v0.10.0 introduced the first stability and compatibility classification baseline for public, preview, candidate, generated and internal surfaces before v1.0.0.
+
+v0.11.0 introduces the first extensibility boundary contract before any plugin execution exists.
 
 ---
 
@@ -57,9 +61,9 @@ v0.10.0 introduces the first stability and compatibility classification baseline
 
 The Mission Model is the source of truth.
 
-Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulation behavior, generated documentation and compatibility classifications must derive from or describe the Mission Model and its Core-owned surfaces.
+Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulation behavior, generated documentation, compatibility classifications and extensibility boundary rules must derive from or describe the Mission Model and its Core-owned surfaces.
 
-No important mission behavior should live only in Python code, documentation, generated files, simulator internals, plugin outputs or downstream tools.
+No important mission behavior should live only in Python code, documentation, generated files, simulator internals, plugin outputs, extension-owned outputs or downstream tools.
 
 ### 2.2 Contract Before Runtime
 
@@ -77,7 +81,9 @@ v0.8.2 introduced a Core-owned entity index report, not relationship graphs or p
 
 v0.9.0 introduced a Core-owned relationship manifest report, not graph execution, plugin execution or Studio-specific behavior.
 
-v0.10.0 introduces compatibility classification references, not schema migration tooling, plugin execution, runtime behavior, ground behavior or a stable v1.0 guarantee.
+v0.10.0 introduced compatibility classification references, not schema migration tooling, plugin execution, runtime behavior, ground behavior or a stable v1.0 guarantee.
+
+v0.11.0 introduces an extensibility boundary contract, not metadata schema, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or Studio-specific APIs.
 
 ### 2.3 Chain Before Generated Artifacts
 
@@ -99,9 +105,10 @@ Payload behavior
         -> Entity Index Surface
         -> Relationship Manifest Surface
         -> Stability and Compatibility Classification
+        -> Extensibility Boundary Contract
 ```
 
-### 2.4 Generated Bindings, Exports, Reports and Classifications Are Not Behavior
+### 2.4 Generated Bindings, Exports, Reports, Classifications and Boundaries Are Not Behavior
 
 Generated Runtime Skeletons are contract bindings.
 
@@ -115,9 +122,11 @@ Generated Relationship Manifest reports are Core-owned read-only relationship re
 
 Stability and compatibility references classify public, preview, candidate, generated and internal surfaces.
 
-They may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries, entity-level records, relationship records and compatibility expectations.
+The Extensibility Boundary Contract defines how future extension-owned outputs may relate to Core-owned semantics without becoming a second source of truth.
 
-They must not implement command dispatch, queues, scheduling, hardware access, telemetry polling, fault handling runtime, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graph behavior or plugin execution.
+These surfaces and references may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries, entity-level records, relationship records, compatibility expectations and extensibility boundary expectations.
+
+They must not implement command dispatch, queues, scheduling, hardware access, telemetry polling, fault handling runtime, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graph behavior, plugin discovery, plugin loading or plugin execution.
 
 ### 2.5 Lint as Engineering Judgment
 
@@ -125,7 +134,7 @@ They must not implement command dispatch, queues, scheduling, hardware access, t
 
 It must detect mission consistency issues, not merely invalid YAML.
 
-A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection, entity-index or relationship artifacts depend on it.
+A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection, entity-index, relationship or extension-owned artifacts depend on it.
 
 ### 2.6 Docs from Model
 
@@ -161,6 +170,8 @@ v0.9.0 extends it with `relationship_manifest.json`.
 
 v0.10.0 classifies these and other public surfaces as compatibility-sensitive before v1.0.0.
 
+v0.11.0 extends the same rule to future extension-owned outputs: extensions consume Core-owned surfaces and must not redefine Core semantics.
+
 ---
 
 ## 3. High-Level System View
@@ -188,6 +199,7 @@ OrbitFabric
 │   ├── entity index inputs
 │   ├── relationship manifest inputs
 │   ├── stability and compatibility classifications
+│   ├── extensibility boundary rules
 │   └── scenarios
 │
 ├── Toolchain
@@ -211,12 +223,12 @@ OrbitFabric
 ├── Export Layer
 ├── Generation Layer
 ├── Compatibility Classification Layer
-└── Future Extension Layer
+└── Extensibility Boundary Layer
 ```
 
 ---
 
-## 4. Current Capability Boundary - v0.10.0
+## 4. Current Capability Boundary - v0.11.0
 
 OrbitFabric currently includes:
 
@@ -253,6 +265,8 @@ entity_index.json entity index report
 orbitfabric export relationship-manifest command
 relationship_manifest.json candidate relationship report
 stability and compatibility classification references
+Extensibility Boundary Contract reference
+ADR-0015 extensibility boundary decision
 release compatibility policy
 synthetic demo mission
 ```
@@ -286,6 +300,10 @@ relationship graph
 dependency graph
 schema migration tooling
 JSON Schema publication
+metadata schema
+metadata parser
+metadata loader
+metadata validator
 plugin API
 plugin discovery
 plugin loader
@@ -326,7 +344,7 @@ Typed Mission Model
 
 The model is loaded once and consumed by multiple downstream layers.
 
-No generator, simulator, exporter, plugin or downstream tool should independently reinterpret raw YAML.
+No generator, simulator, exporter, plugin, extension-owned output or downstream tool should independently reinterpret raw YAML.
 
 ---
 
@@ -375,11 +393,14 @@ Relationship Manifest Surface
       │
       ▼
 Stability and Compatibility Classification
+      │
+      ▼
+Extensibility Boundary Contract
 ```
 
 This is the architectural reason OrbitFabric did not jump directly from payload contracts to plugins.
 
-Plugins and downstream tools are useful only after the mission data chain, Core-owned structured surfaces and compatibility boundaries are explicit enough to consume safely.
+Plugins, extension-owned outputs and downstream tools are useful only after the mission data chain, Core-owned structured surfaces, compatibility boundaries and extensibility boundaries are explicit enough to consume safely.
 
 ---
 
@@ -425,6 +446,8 @@ orbitfabric
 ```
 
 Future commands may include tool-specific exporters and plugin-related commands only after their semantics, trust model and boundaries are implemented and tested explicitly.
+
+v0.11.0 does not add extension commands.
 
 ---
 
@@ -494,6 +517,8 @@ relationship_manifest.json
 
 v0.10.0 classifies these Core-owned structured surfaces as compatibility-sensitive candidate or preview surfaces before v1.0.0.
 
+v0.11.0 defines how future extension-owned outputs may consume these surfaces without redefining them.
+
 The required dependency direction is:
 
 ```text
@@ -504,6 +529,7 @@ Mission Model
         -> model_summary.json
         -> entity_index.json
         -> relationship_manifest.json
+        -> downstream tools and future extensions consume Core-owned structured surfaces
 ```
 
 The disallowed direction is:
@@ -517,6 +543,7 @@ export layer
         -> human-oriented CLI output
         -> downstream UI state
         -> plugin assumptions
+        -> extension-owned assumptions
 ```
 
 The model summary report contains domain-level information only.
@@ -525,7 +552,7 @@ The entity index report contains entity-level records only.
 
 The relationship manifest report contains admitted Core-owned relationship records only.
 
-None of these surfaces contains source locations, YAML AST data, plugin definitions, Studio-specific formatting, runtime behavior or ground behavior.
+None of these surfaces contains source locations, YAML AST data, plugin definitions, extension definitions, Studio-specific formatting, runtime behavior or ground behavior.
 
 ---
 
@@ -554,6 +581,7 @@ human-oriented CLI output
 Studio UI state
 React component state
 private downstream assumptions
+extension-owned assumptions
 ```
 
 For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 emitted relationship families.
@@ -573,13 +601,14 @@ a ground routing table
 a scheduler input
 a command dispatcher input
 a plugin API
+an extension API
 ```
 
 A downstream tool may render a graph from relationship records, but the engineering meaning of every edge must still come from Core.
 
 ---
 
-## 12. Stability and Compatibility Architecture
+## 12. Stability, Compatibility and Extensibility Architecture
 
 v0.10.0 classifies OrbitFabric's public and preview surfaces before v1.0.0.
 
@@ -595,11 +624,22 @@ scenario evidence stability
 release compatibility policy
 ```
 
+v0.11.0 adds the Extensibility Boundary Contract, which states:
+
+```text
+Mission Model remains the source of truth.
+Core owns Mission Data Contract semantics.
+Extensions consume Core-owned structured surfaces.
+Extension-owned outputs remain distinguishable from Core-owned outputs.
+Extensions must not override Core semantics.
+Execution is out of scope.
+```
+
 These references are documentation contracts.
 
-They define how existing surfaces should evolve, but they do not add new Mission Model semantics, YAML fields, report fields, generated surfaces, CLI behavior, lint diagnostics or scenario behavior.
+They define how existing surfaces should evolve and how future extension-owned outputs may relate to Core-owned semantics, but they do not add new Mission Model semantics, YAML fields, report fields, generated surfaces, CLI behavior beyond version reporting, lint diagnostics or scenario behavior.
 
-They also do not introduce schema migration tooling, JSON Schema publication, runtime behavior, ground behavior, plugin execution, graph behavior, Studio-specific APIs or a stable v1.0 compatibility guarantee.
+They also do not introduce schema migration tooling, JSON Schema publication, metadata schema, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior, graph behavior, Studio-specific APIs or a stable v1.0 compatibility guarantee.
 
 ---
 
@@ -785,6 +825,8 @@ Reports and manifests must remain stable enough for tests and CI, but they are s
 
 v0.10.0 classifies JSON report compatibility expectations without changing report structure or introducing JSON Schema publication.
 
+v0.11.0 does not introduce new JSON report fields or extension metadata schemas.
+
 ---
 
 ## 19. Layer Dependency Rules
@@ -831,6 +873,7 @@ relationship exporter -> raw YAML files
 relationship exporter -> generated Markdown
 relationship exporter -> downstream UI state
 plugin output -> Core-owned relationship manifest
+extension output -> Core-owned semantics
 ```
 
 The Model Layer must remain the lowest stable layer.
@@ -903,7 +946,7 @@ orbitfabric gen ground examples/demo-3u/mission/
 
 ## 21. Future Extension Architecture
 
-Future extensions should be added as generators, plugins or adapters.
+Future extensions should be added as generators, plugins or adapters only after their semantics, trust model and boundary rules are reviewed explicitly.
 
 Possible future layers:
 
@@ -923,6 +966,8 @@ cFS/F Prime Integration Bridges
 These must remain downstream of the Mission Model and Core-owned structured surfaces.
 
 They must not redefine the mission contract.
+
+v0.11.0 defines the boundary but does not introduce discovery, loading or execution.
 
 Plugin execution requires explicit trust and boundary design before arbitrary plugin code is supported.
 
@@ -946,14 +991,15 @@ downlink runtime creep
 plugin-before-core-surface creep
 relationship-graph-before-relationship-semantics creep
 compatibility-claim-before-classification creep
+execution-before-boundary creep
 proprietary example contamination
 ```
 
 ---
 
-## 23. v0.10.0 Acceptance Architecture
+## 23. v0.11.0 Acceptance Architecture
 
-OrbitFabric v0.10.0 is architecturally acceptable when this flow works end-to-end:
+OrbitFabric v0.11.0 is architecturally acceptable when this flow works end-to-end:
 
 ```bash
 ruff check .
@@ -1012,20 +1058,22 @@ JSON ground dictionaries
 CSV ground dictionaries
 human-reviewable ground Markdown artifacts
 stability and compatibility classification references
+Extensibility Boundary Contract reference
+ADR-0015
 release compatibility policy
 ```
 
-No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph, plugin API, schema migration tooling, JSON Schema publication or stable v1.0 guarantee is required for v0.10.0.
+No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph, metadata schema, plugin discovery, plugin loading, plugin execution, schema migration tooling, JSON Schema publication or stable v1.0 guarantee is required for v0.11.0.
 
 ---
 
-## 24. Next Architectural Step After v0.10.0
+## 24. Next Architectural Step After v0.11.0
 
-The next architectural step after v0.10.0 is v0.10.1 Documentation and Published Site Consistency.
+The next architectural step after v0.11.0 is v0.12.0 Release Candidate Hardening.
 
-That work should verify and preserve consistency between repository documentation and the published documentation site.
+That work should focus on consistency, release hygiene, validation coverage, compatibility review, golden-output confidence and removal of ambiguity before declaring a stable Mission Data Contract.
 
-It should not introduce model, CLI, export, generator, runtime, ground or plugin behavior.
+It should not introduce model, runtime, ground, graph, Studio-specific, plugin discovery, plugin loading or plugin execution behavior.
 
 ---
 
@@ -1054,6 +1102,8 @@ The v0.8.2 entity index surface exposes Core-owned entity records for downstream
 The v0.9.0 relationship manifest surface exposes Core-owned relationship records for downstream tools without introducing graph behavior, plugin execution or Studio-specific APIs.
 
 The v0.10.0 stability and compatibility contract classifies public, preview, candidate, generated and internal surfaces before v1.0.0 without introducing implementation behavior or a stable v1.0 guarantee.
+
+The v0.11.0 extensibility boundary contract defines how future extension-owned outputs may relate to Core-owned semantics without introducing plugin discovery, plugin loading or plugin execution.
 
 Future plugins must consume the contract.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -50,7 +50,7 @@ orbitfabric --help
 Expected current package version:
 
 ```text
-orbitfabric 0.10.1
+orbitfabric 0.11.0
 ```
 
 ---
@@ -75,7 +75,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.10.1 Slice
+## Verify the Current v0.11.0 Slice
 
 Run mission lint:
 
@@ -105,13 +105,14 @@ orbitfabric export relationship-manifest examples/demo-3u/mission/ \
   --json generated/reports/relationship_manifest.json
 ```
 
-Review the v0.10.0 compatibility classification references, which remain the current compatibility foundation before v1.0.0:
+Review the compatibility and extensibility references, which remain the current documentation foundation before v1.0.0:
 
 ```text
 Stability and Compatibility Contract
 Mission Model Stability Contract
 CLI Contract v1 Preview
 Generated Surfaces Stability
+Extensibility Boundary Contract
 Lint Rule Code Stability
 JSON Report Compatibility
 Scenario Evidence Stability
@@ -320,6 +321,8 @@ Do not add generated artifacts that bypass validation.
 Do not add runtime or ground integration artifacts before the relevant contract layer exists.
 
 Do not add plugin execution mechanisms before Core-owned structured surfaces and plugin boundaries are explicitly defined.
+
+Do not turn the Extensibility Boundary Contract into metadata schema, plugin discovery, plugin loading or plugin execution without a separate architectural review.
 
 Do not put user code inside generated runtime bindings.
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Project Charter
 
-Version: 0.10.0
+Version: 0.11.0
 Status: Draft
-Scope: Mission Data Contract foundation, Mission Data Chain, generated contract-facing artifacts and stability classification
+Scope: Mission Data Contract foundation, Mission Data Chain, generated contract-facing artifacts, stability classification and extensibility boundary contract
 
 ---
 
@@ -10,11 +10,11 @@ Scope: Mission Data Contract foundation, Mission Data Chain, generated contract-
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces and compatibility classifications once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground and downstream tooling.
+Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classifications and extensibility boundary rules once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground, downstream tooling and future extension-owned outputs.
 
-OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework, a plugin execution platform or a visual modeling backend.
+OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework, a plugin execution platform, a plugin loader, a plugin discovery mechanism or a visual modeling backend.
 
-It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing integration, ground integration and downstream inspection tools.
+It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing integration, ground integration, downstream inspection tools and future extension-owned outputs.
 
 The guiding principle is:
 
@@ -50,7 +50,8 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - Core-owned contract introspection surfaces;
 - Core-owned entity index surfaces;
 - Core-owned relationship manifest surfaces;
-- stability and compatibility classifications.
+- stability and compatibility classifications;
+- extensibility boundary rules.
 
 The Mission Data Contract is the single source of truth for all derived artifacts.
 
@@ -74,13 +75,14 @@ The same information is commonly duplicated and reinterpreted across multiple pl
 - storage and downlink planning notes;
 - contact and pass assumptions;
 - generated integration code;
-- downstream inspection tools.
+- downstream inspection tools;
+- extension-owned outputs.
 
 This creates drift.
 
-A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize. A generated software boundary may diverge from the mission model it was supposed to represent. A downstream tool may infer contract semantics differently from the Core.
+A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize. A generated software boundary may diverge from the mission model it was supposed to represent. A downstream tool may infer contract semantics differently from the Core. A future extension may accidentally become a second semantic source if the ownership boundary is not explicit.
 
-OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable, indexable, relatable and compatibility-classified through Core-owned structured surfaces and references.
+OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable, indexable, relatable, compatibility-classified and extensibility-bounded through Core-owned structured surfaces and references.
 
 ---
 
@@ -96,7 +98,8 @@ The initial target users are:
 - research labs needing repeatable mission simulations and test scenarios;
 - space software architects who need a coherent contract between payload behavior, onboard data handling and ground-facing artifacts;
 - ground software engineers who need reviewable mission data dictionaries before integration starts;
-- downstream tool builders who need stable Core-owned surfaces instead of reconstructing semantics from raw YAML.
+- downstream tool builders who need stable Core-owned surfaces instead of reconstructing semantics from raw YAML;
+- future extension authors who need a clear boundary between Core-owned semantics and extension-owned outputs.
 
 The target is not purely educational.
 
@@ -130,19 +133,19 @@ The correct long-term role is:
 
 ### 6.1 Mission Model First
 
-OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system, a plugin or a visual tool.
+OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system, a plugin, an extension-owned output or a visual tool.
 
-The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulator, documentation and compatibility classifications must derive from or describe the model, not the other way around.
+The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulator, documentation, compatibility classifications and extensibility boundary rules must derive from or describe the model, not the other way around.
 
 ### 6.2 Contract Before Code
 
 The first valuable artifact is the contract.
 
-Code generation, runtime execution, ground integration, inspection surfaces, relationship surfaces, entity surfaces, compatibility references and integration bridges are secondary and must not redefine the model.
+Code generation, runtime execution, ground integration, inspection surfaces, relationship surfaces, entity surfaces, compatibility references, extension-owned outputs and integration bridges are secondary and must not redefine the model.
 
 ### 6.3 Mission Data Chain Before Generated Artifacts
 
-OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index, relationship or plugin-facing artifacts.
+OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index, relationship or extension-facing artifacts.
 
 The current chain is:
 
@@ -161,6 +164,7 @@ payload behavior
         -> entity index surface
         -> relationship manifest surface
         -> stability and compatibility classification
+        -> extensibility boundary contract
 ```
 
 Only after these concepts are sufficiently clear should OrbitFabric derive plugin, tool-specific or external integration layers from them.
@@ -211,7 +215,7 @@ However, it must generate artifacts useful for ground integration:
 
 ### 6.8 Core Surfaces Before Plugins
 
-Downstream tools must consume Core-owned structured surfaces.
+Downstream tools and future extensions must consume Core-owned structured surfaces.
 
 They must not reconstruct Mission Model semantics from raw YAML, generated artifacts or human-oriented CLI output.
 
@@ -222,6 +226,8 @@ v0.8.2 introduces `entity_index.json` as the second such surface.
 v0.9.0 introduces `relationship_manifest.json` as the third such surface.
 
 v0.10.0 classifies public, preview, candidate, generated and internal surfaces before v1.0.0.
+
+v0.11.0 defines the extensibility boundary before any plugin execution exists.
 
 Future plugin extensibility must build on these surfaces without silently redefining Core semantics.
 
@@ -235,9 +241,11 @@ It must not contain proprietary mission details, real non-public architectures, 
 
 The core must stay small.
 
-Extensibility should come through plugins, generators, custom lint rules and adapters, not through a bloated core.
+Extensibility should come through plugins, generators, custom lint rules and adapters only after the ownership, provenance, trust and execution boundaries are explicit.
 
 Plugin execution requires explicit trust, metadata and boundary design before arbitrary or untrusted plugin code is supported.
+
+v0.11.0 does not introduce plugin discovery, plugin loading or plugin execution.
 
 ### 6.11 Practical Before Perfect
 
@@ -249,7 +257,7 @@ CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations ar
 
 ## 7. Current Baseline
 
-The current v0.10.0 baseline includes:
+The current v0.11.0 baseline includes:
 
 - Mission Model YAML files;
 - model loading;
@@ -275,6 +283,8 @@ The current v0.10.0 baseline includes:
 - Core-owned entity index export;
 - Core-owned relationship manifest export;
 - stability and compatibility classification references;
+- Extensibility Boundary Contract reference;
+- ADR-0015 extensibility boundary decision;
 - release compatibility policy;
 - readable logs;
 - JSON reports;
@@ -295,6 +305,8 @@ orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 ```
 
+There are no extension commands in v0.11.0.
+
 ---
 
 ## 8. Ground Integration Artifact Direction
@@ -311,7 +323,7 @@ They are the foundation for later tool-specific exporters and plugin extensibili
 
 ---
 
-## 9. Contract Introspection, Entity Index, Relationship Manifest and Compatibility Direction
+## 9. Contract Introspection, Entity Index, Relationship Manifest, Compatibility and Extensibility Direction
 
 Core-owned structured surfaces make the loaded Mission Model visible to downstream tools without letting those tools infer Core semantics privately.
 
@@ -323,13 +335,21 @@ The v0.9.0 relationship manifest report describes mission identity, source missi
 
 The v0.10.0 compatibility references classify how public, preview, candidate, generated and internal surfaces should evolve before v1.0.0.
 
+The v0.11.0 extensibility boundary defines how future extension-owned outputs may relate to Core-owned semantics without becoming a second source of truth.
+
 These surfaces and references must not describe or implement:
 
 - relationship graph execution;
 - dependency graph execution;
 - source line or column tracking;
 - YAML AST export;
+- metadata schema;
+- metadata parser;
+- metadata loader;
+- metadata validator;
 - plugin API;
+- plugin discovery;
+- plugin loading;
 - plugin execution;
 - schema migration tooling;
 - JSON Schema publication;
@@ -360,7 +380,8 @@ Payload or subsystem activity
         -> entity index surface
         -> relationship manifest surface
         -> stability and compatibility classification
-        -> future plugins
+        -> extensibility boundary contract
+        -> future extensions
 ```
 
 This direction is essential for small spacecraft and CubeSat missions because the value of mission data depends on the full path from onboard generation to ground consumption and downstream inspection.
@@ -406,10 +427,14 @@ Early OrbitFabric versions must not include:
 - live ground operations;
 - schema migration tooling before versioning semantics are stable;
 - JSON Schema publication before schema semantics are stable;
+- metadata schema before the extension boundary is stable;
 - plugin APIs before Core-owned surfaces and plugin boundaries are stable;
+- plugin discovery before trust and boundary design are stable;
+- plugin loading before trust and boundary design are stable;
+- plugin execution before trust and boundary design are stable;
 - relationship graphs before entity indexing and relationship semantics are stable.
 
-These items may become future integration targets, generated artifacts or external consumers only after the Mission Model, lint engine, scenario runner, mission data chain contracts and generated contract-facing artifacts prove valuable.
+These items may become future integration targets, generated artifacts or external consumers only after the Mission Model, lint engine, scenario runner, mission data chain contracts, generated contract-facing artifacts, Core-owned surfaces and extensibility boundary prove valuable.
 
 ---
 
@@ -419,7 +444,7 @@ The initial demo mission is `demo-3u`.
 
 It is a synthetic 3U CubeSat-like mission used only to demonstrate OrbitFabric concepts.
 
-It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface, entity index surface, relationship manifest surface and stability/compatibility classification.
+It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface, entity index surface, relationship manifest surface, stability/compatibility classification and extensibility boundary documentation.
 
 The demo assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
 
@@ -441,7 +466,7 @@ The recommended technical baseline is:
 - CMake for host-build smoke validation;
 - JSON, CSV and Markdown for the first generated ground-facing artifact package;
 - JSON for Core-owned introspection, entity index and relationship manifest reports;
-- Markdown for stability and compatibility classification references;
+- Markdown for stability, compatibility and extensibility boundary references;
 - GitHub Actions for CI;
 - Apache-2.0 license.
 
@@ -459,7 +484,9 @@ The generated relationship manifest report is intentionally Core-owned, read-onl
 
 The stability and compatibility references are intentionally classification documents, not implementation behavior or a stable v1.0 guarantee.
 
-None is a relationship graph engine, plugin API, plugin execution mechanism or Studio-specific API.
+The extensibility boundary is intentionally a documentation contract, not metadata schema, plugin discovery, plugin loading or plugin execution.
+
+None is a relationship graph engine, plugin execution mechanism or Studio-specific API.
 
 ---
 
@@ -514,7 +541,7 @@ OrbitFabric is successful in the early public preview if a user can:
 13. understand the project positioning from the README in less than one minute;
 14. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
 15. understand how payload contracts fit into the Mission Data Contract;
-16. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts and Core-owned surfaces fit into the roadmap before plugin execution;
+16. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts, Core-owned surfaces, compatibility references and extensibility boundaries fit into the roadmap before plugin execution;
 17. understand which surfaces are public preview, candidate, internal or disposable before v1.0.0.
 
 A minimal but strong preview is better than a broad, fragile and unfinished feature set.
@@ -572,5 +599,6 @@ The project should prefer:
 - generated contract-facing artifacts over hidden implementation assumptions;
 - Core-owned structured surfaces over downstream semantic inference;
 - compatibility classifications over implicit stability assumptions;
+- extensibility boundary contracts over premature plugin execution;
 - clean interfaces over premature integrations;
-- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing, relationship manifests, stability guarantees and plugin generation.
+- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing, relationship manifests, stability guarantees and plugin execution.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -30,6 +30,7 @@ Mission Model YAML
   -> entity_index.json entity index report
   -> relationship_manifest.json candidate relationship report
   -> stability and compatibility classification references
+  -> Extensibility Boundary Contract reference
   -> JSON lint reports
   -> JSON simulation reports with data-flow evidence
   -> simulation logs
@@ -43,7 +44,7 @@ Generated ground integration artifacts are not ground software.
 
 Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.
 
-Compatibility classification references are not runtime behavior, ground behavior, schema migration tooling, plugin execution or a v1.0 stability guarantee.
+Compatibility classification references and the Extensibility Boundary Contract are not runtime behavior, ground behavior, schema migration tooling, plugin discovery, plugin loading, plugin execution or a v1.0 stability guarantee.
 
 ---
 
@@ -111,7 +112,7 @@ orbitfabric --help
 Expected version:
 
 ```text
-orbitfabric 0.10.1
+orbitfabric 0.11.0
 ```
 
 ---
@@ -233,9 +234,11 @@ They do not expose plugin execution, graph engines, Studio-specific APIs, runtim
 
 ---
 
-## 11. Review compatibility classification references
+## 11. Review stability, compatibility and extensibility references
 
 v0.10.0 adds compatibility classification references for the path toward v1.0.0.
+
+v0.11.0 adds the Extensibility Boundary Contract before any plugin execution exists.
 
 Key references include:
 
@@ -244,15 +247,16 @@ Stability and Compatibility Contract
 Mission Model Stability Contract
 CLI Contract v1 Preview
 Generated Surfaces Stability
+Extensibility Boundary Contract
 Lint Rule Code Stability
 JSON Report Compatibility
 Scenario Evidence Stability
 Release Compatibility Policy
 ```
 
-These references classify existing public and preview surfaces.
+These references classify existing public and preview surfaces and define how future extension-owned outputs must remain distinguishable from Core-owned outputs.
 
-They do not introduce new Mission Model semantics, CLI behavior, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, plugin execution, runtime behavior, ground behavior or a stable v1.0 compatibility guarantee.
+They do not introduce new Mission Model semantics, CLI behavior beyond version reporting, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or a stable v1.0 compatibility guarantee.
 
 ---
 
@@ -388,6 +392,7 @@ The current demo proves that OrbitFabric can:
 - export an entity index from the loaded Mission Model;
 - export a relationship manifest from the loaded Mission Model;
 - classify public, preview, candidate, generated and internal compatibility surfaces;
+- document the extensibility boundary before plugin execution;
 - validate scenarios without executing them;
 - execute deterministic operational sequences;
 - record contract-level data-flow evidence;
@@ -429,7 +434,10 @@ The current demo does not prove:
 - relationship graph behavior;
 - dependency graph behavior;
 - plugin API behavior;
+- plugin discovery behavior;
+- plugin loading behavior;
 - plugin execution behavior;
+- metadata schema behavior;
 - v1.0 compatibility guarantee;
 - qualification for operational spacecraft use.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # OrbitFabric - Roadmap
 
-Version: v0.10.1 to v1.0 stability path  
+Version: v0.11.0 to v1.0 stability path  
 Status: Development preview  
 Scope: v0.3 to v1.0 planning
 
@@ -19,7 +19,8 @@ The project must not try to become, at the same time:
 - a formal verification tool;
 - a hardware abstraction layer;
 - a CubeSat tutorial;
-- a payload runtime framework.
+- a payload runtime framework;
+- a plugin execution platform.
 
 The correct growth path is:
 
@@ -49,61 +50,47 @@ Every milestone must reinforce the core identity:
 
 > OrbitFabric is a Mission Data Contract framework.
 
-The current architectural objective is to keep the Mission Data Chain explicit, inspectable and consumable by generated artifacts and downstream tools without turning OrbitFabric into flight software, a ground segment, a visual modeling tool or a plugin execution platform.
+The current architectural objective is to keep the Mission Data Chain explicit, inspectable, compatibility-classified and safely extensible without turning OrbitFabric into flight software, a ground segment, a visual modeling tool or a plugin execution platform.
 
 ---
 
 ## 2. Roadmap Overview
 
 ```text
-v0.1    Mission Contract MVP                                  completed
-v0.2    Model Hardening                                       completed line
-v0.2.1  Payload Contract Model                                completed
-v0.2.2  Payload Contract Release Alignment                    completed
-v0.2.3  Mission Data Chain Roadmap Alignment                  completed
-v0.3.0  Data Product and Storage Contracts                    completed
-v0.4.0  Contact Windows and Downlink Flow Contracts           completed
-v0.5.0  Commandability and Autonomy Contracts                 completed
-v0.6.0  End-to-End Mission Data Flow Evidence                 completed
-v0.7.0  Generated Runtime Skeletons                           completed
-v0.8.0  Ground Integration Artifacts                          completed
-v0.8.1  Contract Introspection Surface                        completed
-v0.8.2  Entity Index Surface                                  completed
+v0.1    Mission Contract MVP                                     completed
+v0.2    Model Hardening                                          completed line
+v0.2.1  Payload Contract Model                                   completed
+v0.2.2  Payload Contract Release Alignment                       completed
+v0.2.3  Mission Data Chain Roadmap Alignment                     completed
+v0.3.0  Data Product and Storage Contracts                       completed
+v0.4.0  Contact Windows and Downlink Flow Contracts              completed
+v0.5.0  Commandability and Autonomy Contracts                    completed
+v0.6.0  End-to-End Mission Data Flow Evidence                    completed
+v0.7.0  Generated Runtime Skeletons                              completed
+v0.8.0  Ground Integration Artifacts                             completed
+v0.8.1  Contract Introspection Surface                           completed
+v0.8.2  Entity Index Surface                                     completed
 v0.9.0  Relationship Manifest Surface and Extensibility Boundary completed
-v0.10.0 Stability and Compatibility Contract                  completed
-v0.10.1 Documentation and Published Site Consistency          completed
-v0.11.0 Extensibility Boundary Contract, no execution         next
-v0.12.0 v1.0 Release Candidate Hardening                      future
-v1.0.0  Stable Mission Data Contract                          future
+v0.10.0 Stability and Compatibility Contract                     completed
+v0.10.1 Documentation and Published Site Consistency             completed
+v0.11.0 Extensibility Boundary Contract, no execution            completed
+v0.12.0 v1.0 Release Candidate Hardening                         next
+v1.0.0  Stable Mission Data Contract                             future
 ```
 
-The current completed milestone is `v0.10.1 - Documentation and Published Site Consistency`.
+The current completed milestone is `v0.11.0 - Extensibility Boundary Contract, no execution`.
 
-The immediate target after v0.10.1 is `v0.11.0 - Extensibility Boundary Contract, no execution`.
+The immediate target after v0.11.0 is `v0.12.0 - v1.0 Release Candidate Hardening`.
 
-This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified the compatibility expectations around those public and preview surfaces before v1.0. v0.10.1 verified and preserved documentation and published-site consistency before the extensibility boundary work.
+This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified compatibility expectations around public and preview surfaces before v1.0. v0.10.1 verified documentation and published-site consistency. v0.11.0 defined the extensibility boundary without plugin execution.
 
-The next step is not plugin execution. The next step is to define the extensibility boundary without plugin execution.
+The next step is not plugin execution. The next step is release candidate hardening toward a stable Mission Data Contract.
 
-v0.11.0 must not introduce plugin execution, plugin discovery, plugin loaders, relationship graphs, dependency graphs, runtime behavior, ground behavior, Studio-specific APIs or new Mission Model semantics unless explicitly scoped and reviewed.
-
-Future extensibility must build on Core-owned structured surfaces without forcing plugins or downstream tools to reconstruct Mission Data Contract semantics from raw YAML, generated files, textual CLI output or UI state.
+v0.12.0 should focus on consistency, release hygiene, validation coverage, golden-output confidence, compatibility review and ambiguity removal before v1.0.0.
 
 ---
 
-## 3. Completed Baseline - v0.1 Mission Contract MVP
-
-v0.1 proved that a user can:
-
-1. define a mission once;
-2. lint it semantically;
-3. generate documentation;
-4. execute an operational scenario;
-5. receive readable logs and JSON reports.
-
----
-
-## 4. Completed Model and Mission Data Chain Slices
+## 3. Completed Model and Mission Data Chain Slices
 
 OrbitFabric has completed the following model and Mission Data Chain slices:
 
@@ -134,49 +121,29 @@ They intentionally did not implement payload firmware, physical payload simulati
 
 ---
 
-## 5. Completed Slice - v0.7.0 Generated Runtime Skeletons
+## 4. Completed Slice - v0.7.0 Generated Runtime Skeletons
 
-v0.7.0 introduced the first generated runtime-facing contract binding layer derived from the Mission Data Contract.
+v0.7.0 introduced generated runtime-facing contract bindings.
 
-The public milestone name was:
+They expose identifiers, typed command argument structures, static metadata registries, abstract adapter interfaces and host-build smoke validation.
 
-```text
-Generated Runtime Skeletons
-```
-
-The precise architectural meaning is:
-
-```text
-runtime-facing contract bindings
-```
-
-v0.7.0 intentionally did not implement flight-ready runtime, command dispatch runtime, command queues, telemetry polling runtime, event routing runtime, fault manager runtime, scheduler, HAL, drivers, RTOS abstraction, binary serialization, CCSDS/PUS/CFDP behavior, storage runtime, downlink runtime, user-code merge or protected regions.
+They intentionally do not implement flight-ready runtime, command dispatch runtime, command queues, telemetry polling runtime, event routing runtime, fault manager runtime, scheduler, HAL, drivers, RTOS abstraction, binary serialization, CCSDS/PUS/CFDP behavior, storage runtime, downlink runtime, user-code merge or protected regions.
 
 ---
 
-## 6. Completed Slice - v0.8.0 Ground Integration Artifacts
+## 5. Completed Slice - v0.8.0 Ground Integration Artifacts
 
-v0.8.0 introduced the first generated ground-facing artifact package derived from the Mission Data Contract.
+v0.8.0 introduced generated ground-facing Mission Data Contract exports.
 
-The public milestone name is:
+They expose deterministic JSON, CSV and Markdown artifacts for engineering review and downstream ground integration work.
 
-```text
-Ground Integration Artifacts
-```
-
-The precise architectural meaning is:
-
-```text
-ground-facing Mission Data Contract exports
-```
-
-v0.8.0 intentionally did not implement a live ground segment, mission control system, telemetry archive, telemetry database, command uplink service, Yamcs integration, OpenC3 integration, XTCE compliance, CCSDS/PUS/CFDP implementation, binary packet decoder, binary telecommand encoder, RF behavior, pass scheduling or station automation.
+They intentionally do not implement a live ground segment, mission control system, telemetry archive, telemetry database, command uplink service, Yamcs integration, OpenC3 integration, XTCE compliance, CCSDS/PUS/CFDP implementation, binary packet decoder, binary telecommand encoder, RF behavior, pass scheduling or station automation.
 
 ---
 
-## 7. Completed Slice - v0.8.1 Contract Introspection Surface
+## 6. Completed Slice - v0.8.1 Contract Introspection Surface
 
-v0.8.1 introduced the first Core-owned read-only contract introspection surface.
+v0.8.1 introduced `model_summary.json`, the first Core-owned read-only contract introspection surface.
 
 It answers:
 
@@ -184,32 +151,13 @@ It answers:
 What contract domains are present in this mission?
 ```
 
-v0.8.1 introduced:
-
-```text
-orbitfabric.export package
-model_summary_to_dict(model, mission_dir)
-write_model_summary(model, mission_dir, output_file)
-orbitfabric export model-summary command
-model_summary.json report
-summary_version 0.1
-kind orbitfabric.model_summary
-contract domain records
-domain-level counts
-source file metadata
-required/present status
-explicit boundary flags
-Contract Introspection Surface reference documentation
-v0.8.1 release notes
-```
-
-v0.8.1 intentionally did not introduce entity records, relationship manifests, relationship graphs, source locations, YAML AST export, plugin API, Studio-specific API, runtime behavior, ground behavior or new Mission Model semantics.
+It intentionally did not introduce entity records, relationship manifests, relationship graphs, source locations, YAML AST export, plugin API, Studio-specific API, runtime behavior, ground behavior or new Mission Model semantics.
 
 ---
 
-## 8. Completed Slice - v0.8.2 Entity Index Surface
+## 7. Completed Slice - v0.8.2 Entity Index Surface
 
-v0.8.2 introduced the first Core-owned read-only entity index surface.
+v0.8.2 introduced `entity_index.json`, the first Core-owned read-only entity index surface.
 
 It answers:
 
@@ -217,40 +165,13 @@ It answers:
 What contract entities are defined in this mission?
 ```
 
-v0.8.2 introduced:
-
-```text
-entity_index_to_dict(model, mission_dir)
-write_entity_index(model, mission_dir, output_file)
-orbitfabric export entity-index command
-entity_index.json report
-index_version 0.1
-kind orbitfabric.entity_index
-entity-level records
-per-domain entity counts
-per-domain model counts
-source file metadata
-required/present domain status
-indexed/not-indexed domain status
-explicit boundary flags
-Entity Index Surface reference documentation
-v0.8.2 release notes
-```
-
-Command:
-
-```bash
-orbitfabric export entity-index examples/demo-3u/mission/ \
-  --json generated/reports/entity_index.json
-```
-
-v0.8.2 intentionally did not introduce new Mission Model semantics, relationship manifest implementation, relationship graph, dependency graph, source line or column tracking, YAML AST export, plugin API, plugin discovery, Studio-specific API, runtime behavior or ground behavior.
+It intentionally did not introduce new Mission Model semantics, relationship manifest export, relationship graph, dependency graph, source line or column tracking, YAML AST export, plugin API, plugin discovery, Studio-specific API, runtime behavior or ground behavior.
 
 ---
 
-## 9. Completed Slice - v0.9.0 Relationship Manifest Surface and Extensibility Boundary
+## 8. Completed Slice - v0.9.0 Relationship Manifest Surface and Extensibility Boundary
 
-v0.9.0 introduces the first Core-owned read-only relationship manifest surface.
+v0.9.0 introduced `relationship_manifest.json`, the first Core-owned read-only relationship manifest surface.
 
 It answers:
 
@@ -258,95 +179,17 @@ It answers:
 How are indexed mission contract entities related?
 ```
 
-The relationship manifest builds directly on `entity_index.json`.
+The current candidate surface admits nineteen deliberately narrow relationship families.
 
-The intended downstream chain is now:
+For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 emitted relationship families.
 
-```text
-model_summary.json          -> domain navigation
-entity_index.json           -> entity navigation
-relationship_manifest.json  -> relationship navigation
-```
-
-v0.9.0 includes:
-
-```text
-relationship_manifest_to_dict(model, mission_dir)
-write_relationship_manifest(model, mission_dir, output_file)
-orbitfabric export relationship-manifest command
-relationship_manifest.json report
-manifest_version 0.1-candidate
-kind orbitfabric.relationship_manifest
-relationship records
-relationship type records
-relationship type counts
-explicit derivation policy
-explicit boundary flags
-Relationship Manifest Surface reference documentation
-ADR-0014 v0.9 plugin and relationship surface boundaries
-v0.9.0 release notes
-```
-
-Command:
-
-```bash
-orbitfabric export relationship-manifest examples/demo-3u/mission/ \
-  --json generated/reports/relationship_manifest.json
-```
-
-The current candidate surface admits nineteen deliberately narrow relationship families:
-
-```text
-autonomous_action_dispatches_command
-command_emits_event
-command_targets_subsystem
-commandability_rule_constrains_command
-data_product_produced_by_payload
-data_product_produced_by_subsystem
-downlink_flow_includes_data_product
-event_sourced_from_subsystem
-fault_emits_event
-fault_sourced_from_subsystem
-packet_includes_telemetry
-payload_accepts_command
-payload_belongs_to_subsystem
-payload_generates_event
-payload_may_raise_fault
-payload_produces_telemetry
-recovery_intent_reacts_to_event
-recovery_intent_reacts_to_fault
-telemetry_sourced_from_subsystem
-```
-
-For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 relationship families.
-
-v0.9.0 intentionally does not introduce:
-
-```text
-relationship inference
-relationship graph
-dependency graph
-source line or column tracking
-YAML AST export
-plugin execution
-plugin discovery
-plugin loader
-custom lint plugin support
-custom generator plugin support
-Studio-specific API
-runtime behavior
-ground behavior
-```
-
-The relationship manifest is a candidate Core-owned surface. It is deterministic, read-only and derived from explicit loaded Mission Model fields. It is not a graph engine, visualization format, plugin API, Studio API, runtime routing table, ground routing table, scheduler input or command dispatcher input.
+v0.9.0 intentionally did not introduce relationship inference, relationship graph, dependency graph, source line or column tracking, YAML AST export, plugin execution, plugin discovery, plugin loader, custom lint plugin support, custom generator plugin support, Studio-specific API, runtime behavior or ground behavior.
 
 ---
 
-## 10. Completed Slice - v0.10.0 Stability and Compatibility Contract
+## 9. Completed Slice - v0.10.0 Stability and Compatibility Contract
 
 v0.10.0 introduced the first stability and compatibility classification baseline before v1.0.
-
-It defines how OrbitFabric treats public, preview, candidate, generated and internal surfaces.
 
 The classification scope includes:
 
@@ -360,109 +203,76 @@ scenario evidence stability
 release compatibility policy
 ```
 
-v0.10.0 introduced these reference documents:
-
-```text
-Stability and Compatibility Contract
-Mission Model Stability Contract
-CLI Contract v1 Preview
-Generated Surfaces Stability
-Lint Rule Code Stability
-JSON Report Compatibility
-Scenario Evidence Stability
-Release Compatibility Policy
-v0.10.0 release notes
-```
-
-v0.10.0 intentionally does not introduce:
-
-```text
-new Mission Model semantics
-new YAML fields
-new model domains
-new CLI behavior
-new JSON report fields
-new generated surfaces
-new lint diagnostics
-new scenario behavior
-schema migration tooling
-JSON Schema publication
-plugin execution
-plugin discovery
-plugin loader
-relationship graph
-dependency graph
-runtime behavior
-ground behavior
-Studio-specific API
-stable v1.0 compatibility guarantee
-```
+v0.10.0 intentionally did not introduce new Mission Model semantics, new YAML fields, new CLI behavior, new JSON report fields, new generated surfaces, new lint diagnostics, new scenario behavior, schema migration tooling, JSON Schema publication, plugin execution, plugin discovery, plugin loader, relationship graph, dependency graph, runtime behavior, ground behavior, Studio-specific API or a stable v1.0 compatibility guarantee.
 
 ---
 
-## 11. Completed Slice - v0.10.1 Documentation and Published Site Consistency
+## 10. Completed Slice - v0.10.1 Documentation and Published Site Consistency
 
 v0.10.1 verified and preserved consistency between repository documentation and the published documentation site.
 
-It ensured that the public documentation remains aligned with the released baseline and the roadmap toward v1.0.
+It clarified README wording around Relationship Manifest family counts and preserved the v0.10.0 compatibility baseline as the current compatibility foundation before v1.0.0.
 
-It also clarified README wording around Relationship Manifest family counts:
-
-```text
-19 admitted relationship families at the candidate surface level
-46 emitted relationship records for examples/demo-3u/mission
-17 emitted relationship families for examples/demo-3u/mission
-```
-
-v0.10.1 intentionally does not introduce:
-
-```text
-new Mission Model semantics
-new YAML fields
-new model domains
-new CLI behavior beyond version reporting
-new JSON report fields
-new generated surfaces
-new lint diagnostics
-new scenario behavior
-schema migration tooling
-JSON Schema publication
-plugin execution
-plugin discovery
-plugin loader
-relationship graph
-dependency graph
-runtime behavior
-ground behavior
-Studio-specific API
-stable v1.0 compatibility guarantee
-```
+v0.10.1 intentionally did not introduce new Mission Model semantics, new YAML fields, new CLI behavior beyond version reporting, new JSON report fields, new generated surfaces, new lint diagnostics, new scenario behavior, schema migration tooling, JSON Schema publication, plugin execution, plugin discovery, plugin loader, relationship graph, dependency graph, runtime behavior, ground behavior, Studio-specific API or a stable v1.0 compatibility guarantee.
 
 ---
 
-## 12. Next Milestone - v0.11.0 Extensibility Boundary Contract, no execution
+## 11. Completed Slice - v0.11.0 Extensibility Boundary Contract, no execution
 
-v0.11.0 should define the extensibility boundary without executing plugins.
+v0.11.0 defines the extensibility boundary without executing plugins.
 
-It may document what future extension metadata would be allowed to describe, but it must not introduce plugin discovery, plugin loading, plugin execution or arbitrary third-party code execution.
+It introduces:
 
-Plugins must never become a second source of Mission Data Contract semantics.
+```text
+ADR-0015 - Extensibility Boundary Contract, No Execution
+Extensibility Boundary Contract reference documentation
+non-normative guidance for future descriptive extension metadata
+explicit Core ownership rules
+explicit extension ownership rules
+provenance expectations for future extension-owned artifacts
+semantic override ban
+explicit downstream consumer rules
+compatibility-sensitive extensibility boundary expectations before v1.0.0
+```
+
+The stable rule is:
+
+```text
+Mission Model remains the source of truth.
+Core owns Mission Data Contract semantics.
+Extensions consume Core-owned structured surfaces.
+Extension-owned outputs remain distinguishable from Core-owned outputs.
+Extensions must not override Core semantics.
+Execution is out of scope.
+```
+
+v0.11.0 intentionally does not introduce new Mission Model semantics, new YAML fields, new CLI behavior beyond version reporting, new JSON report fields, new generated Core surfaces, new lint diagnostics, new scenario behavior, metadata schema, metadata parser, metadata loader, metadata validator, plugin discovery, plugin loading, plugin execution, custom lint plugin execution, custom generator plugin execution, relationship graph, dependency graph, runtime behavior, ground behavior, Studio-specific API, schema migration tooling, JSON Schema publication or a stable v1.0 compatibility guarantee.
 
 ---
 
-## 13. Future Milestone - v0.12.0 v1.0 Release Candidate Hardening
+## 12. Next Milestone - v0.12.0 v1.0 Release Candidate Hardening
 
 v0.12.0 should harden the release candidate path toward v1.0.0.
 
-The focus should be consistency, documentation, validation coverage, release hygiene and removal of ambiguity before declaring a stable Mission Data Contract.
+The focus should be:
 
-It should not broaden OrbitFabric into flight software, ground software, simulation runtime, visual modeling or plugin execution.
+```text
+consistency
+release hygiene
+validation coverage
+golden-output confidence
+compatibility review
+removal of ambiguity
+v1.0 candidate surface selection
+```
+
+It should not broaden OrbitFabric into flight software, ground software, simulation runtime, visual modeling, plugin discovery, plugin loading or plugin execution.
 
 ---
 
-## 14. Future Milestone - v1.0.0 Stable Mission Data Contract
+## 13. Future Milestone - v1.0.0 Stable Mission Data Contract
 
-v1.0.0 should be the first version where the Mission Data Contract is stable enough for external users to build around.
+v1.0.0 should be the first version where the Mission Data Contract is stable enough for external users and downstream consumers to build around.
 
 Possible requirements:
 
@@ -478,6 +288,7 @@ stable GroundContract semantics
 stable contract introspection surface
 stable entity index surface
 stable relationship manifest surface
+stable extensibility boundary semantics
 stable runtime-facing contract binding surface
 stable ground-facing artifact package
 stable CLI commands
@@ -496,7 +307,7 @@ v1.0.0 should mean stable Mission Data Contract framework, not a complete space 
 
 ---
 
-## 15. Backlog Parking Lot
+## 14. Backlog Parking Lot
 
 These ideas are valid but must not distract from the active milestone.
 
@@ -537,11 +348,14 @@ plugin metadata manifest
 plugin capability manifest
 custom lint plugin support
 custom generator plugin support
+plugin discovery
+plugin loading
+plugin execution
 ```
 
 ---
 
-## 16. Priority Rules
+## 15. Priority Rules
 
 When deciding what to implement next, use these rules.
 
@@ -561,28 +375,30 @@ When deciding what to implement next, use these rules.
 14. Core Surfaces Before Plugins.
 15. Downstream Tools Consume, Not Infer.
 16. Relationship Semantics Before Relationship Visualization.
+17. Boundary Before Execution.
 
 ---
 
-## 17. Immediate Work Plan
+## 16. Immediate Work Plan
 
-The immediate work package after v0.10.1 is:
+The immediate work package after v0.11.0 is:
 
 ```text
-v0.11.0 - Extensibility Boundary Contract, no execution
+v0.12.0 - v1.0 Release Candidate Hardening
 ```
 
 Required next-step discipline:
 
 ```text
-1. define the extensibility boundary without executing plugins
-2. preserve Core-owned structured surfaces as the only downstream semantic source
-3. avoid runtime, ground, Studio-specific or plugin execution behavior
-4. keep the Mission Model as the source of truth
-5. keep downstream tools consuming Core-owned structured surfaces
+1. identify v1.0 candidate stable surfaces
+2. harden public documentation consistency
+3. review compatibility-sensitive surfaces
+4. strengthen regression confidence around generated and exported outputs
+5. remove ambiguous wording before stable Mission Data Contract declaration
+6. keep plugin execution out of scope
 ```
 
-Do not start plugin execution, plugin discovery or plugin loader work in v0.11.0.
+Do not start plugin execution, plugin discovery or plugin loader work in v0.12.0.
 
 Do not let plugins reconstruct contract semantics from raw YAML, generated files or human-oriented CLI output.
 
@@ -590,7 +406,7 @@ Do not let downstream tools become a second source of truth.
 
 ---
 
-## 18. Final Roadmap Statement
+## 17. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
@@ -612,9 +428,9 @@ The v0.10.0 roadmap step completed the first stability and compatibility classif
 
 The v0.10.1 roadmap step completed the documentation and published-site consistency pass.
 
-The v0.11.0 roadmap step should define the extensibility boundary without plugin execution.
+The v0.11.0 roadmap step completed the extensibility boundary contract without plugin execution.
 
-Only after the mission data chain, commandability, autonomy, end-to-end evidence, runtime-facing binding layer, ground-facing artifact layer, contract introspection, entity indexing, relationship semantics and compatibility boundaries are clear should OrbitFabric consider plugin execution.
+The v0.12.0 roadmap step must harden the path to v1.0.0 without broadening the Core.
 
 The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces and compatibility classification references in a single Mission Data Contract workflow.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classification references and extensibility boundary contracts in a single Mission Data Contract workflow.
 
 From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic integration and inspection artifacts.
 
@@ -11,12 +11,12 @@ From that contract, OrbitFabric validates consistency, generates documentation, 
 OrbitFabric is currently at:
 
 ```text
-v0.10.1 - Documentation and Published Site Consistency
+v0.11.0 - Extensibility Boundary Contract, no execution
 ```
 
-v0.10.1 closes the documentation and published-site consistency pass after the first **stability and compatibility classification baseline** introduced in v0.10.0.
+v0.11.0 defines the extensibility boundary without introducing plugin execution.
 
-It introduces no Mission Model semantics, CLI behavior, generated surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin execution or Studio-specific APIs.
+It introduces no Mission Model semantics, CLI behavior beyond version reporting, generated Core surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, plugin discovery, plugin loading, plugin execution, metadata schema, metadata parser, metadata loader, metadata validator or Studio-specific APIs.
 
 It builds on:
 
@@ -26,6 +26,7 @@ v0.8.2  -> entity_index.json
 v0.9.0  -> relationship_manifest.json
 v0.10.0 -> stability and compatibility classification
 v0.10.1 -> documentation and published-site consistency
+v0.11.0 -> extensibility boundary contract, no execution
 ```
 
 The current public preview includes:
@@ -63,6 +64,8 @@ The current public preview includes:
 - `orbitfabric export relationship-manifest`;
 - generated `relationship_manifest.json` candidate relationship report;
 - stability and compatibility classification references;
+- Extensibility Boundary Contract reference documentation;
+- ADR-0015 for the extensibility boundary;
 - release compatibility policy;
 - a clean-room synthetic `demo-3u` mission.
 
@@ -86,6 +89,7 @@ Mission Model
   -> Core-owned entity index surfaces
   -> Core-owned relationship manifest surfaces
   -> stability and compatibility classification
+  -> extensibility boundary contract
 ```
 
 The current Core-owned structured surface chain is:
@@ -96,9 +100,20 @@ entity_index.json           -> entity navigation
 relationship_manifest.json  -> relationship navigation
 ```
 
+The extensibility boundary rule is:
+
+```text
+Mission Model remains the source of truth.
+Core owns Mission Data Contract semantics.
+Extensions consume Core-owned structured surfaces.
+Extension-owned outputs remain distinguishable from Core-owned outputs.
+Extensions must not override Core semantics.
+Execution is out of scope.
+```
+
 OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
 
-It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing bindings, ground-facing integration artifacts and downstream inspection tools.
+It is the contract layer between mission design, onboard software, simulation, testing, documentation, runtime-facing bindings, ground-facing integration artifacts, downstream inspection tools and future extension-owned outputs.
 
 Generated runtime-facing contract bindings are not flight software.
 
@@ -106,4 +121,4 @@ Generated ground integration artifacts are not ground software.
 
 Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.
 
-Compatibility classification references are not schema migration tooling, plugin execution, runtime behavior or a v1.0 stability guarantee.
+Compatibility classification references and the Extensibility Boundary Contract are not schema migration tooling, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or a v1.0 stability guarantee.

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -11,9 +11,10 @@ OrbitFabric currently distinguishes between:
 - the generated ground contract manifest context;
 - the generated contract introspection report context;
 - the generated entity index report context;
-- the generated relationship manifest report context.
+- the generated relationship manifest report context;
+- the extensibility boundary documentation context.
 
-These versions are related, but they are not the same thing.
+These versions and contexts are related, but they are not the same thing.
 
 ---
 
@@ -37,7 +38,7 @@ orbitfabric --version
 Current example:
 
 ```text
-orbitfabric 0.10.1
+orbitfabric 0.11.0
 ```
 
 This version answers the question:
@@ -90,7 +91,7 @@ Current lint report example:
 ```json
 {
   "tool": "orbitfabric-lint",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "mission": "demo-3u",
   "model_version": "0.1.0"
 }
@@ -279,11 +280,29 @@ They do not introduce new version fields, schema migration tooling, JSON Schema 
 
 ---
 
-## Documentation consistency context
+## Extensibility boundary context
 
-v0.10.1 closes the documentation and published-site consistency pass after v0.10.0.
+v0.11.0 introduces the Extensibility Boundary Contract before any plugin execution exists.
 
-It updates the OrbitFabric tool/package version and release documentation, but it does not introduce new Mission Model semantics, generated surface formats, JSON report fields, CLI behavior beyond version reporting, plugin execution, runtime behavior or ground behavior.
+This boundary is documented through:
+
+```text
+ADR-0015 - Extensibility Boundary Contract, No Execution
+Extensibility Boundary Contract reference documentation
+```
+
+The extensibility boundary records expectations such as:
+
+```text
+Core remains semantic owner
+Mission Model remains source of truth
+extensions consume Core-owned surfaces
+extension-owned outputs remain distinguishable from Core-owned outputs
+semantic override remains forbidden
+execution remains out of scope
+```
+
+This boundary does not introduce a metadata schema, JSON shape, metadata manifest format, parser, loader, validator, registry, CLI command, plugin discovery, plugin loading or plugin execution.
 
 ---
 
@@ -294,7 +313,7 @@ During development previews, OrbitFabric may evolve faster than the Mission Mode
 For example:
 
 ```text
-OrbitFabric tool/package version: 0.10.1
+OrbitFabric tool/package version: 0.11.0
 Mission Model version:           0.1.0
 ```
 
@@ -302,13 +321,13 @@ This is valid.
 
 It means:
 
-- the tool has gained capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces and Stability/Compatibility Classification references;
+- the tool has gained capabilities such as Payload Contracts, Data Product Contracts, Contact/Downlink Contracts, Commandability/Autonomy Contracts, Data Flow Evidence, Runtime Contract Bindings, Ground Integration Artifacts, Contract Introspection Surfaces, Entity Index Surfaces, Relationship Manifest Surfaces, Stability/Compatibility Classification references and the Extensibility Boundary Contract;
 - the demo mission still declares the v0.1 Mission Model contract;
 - generated artifacts record the relevant tool and model context.
 
 ---
 
-## Current v0.10.1 rule
+## Current v0.11.0 rule
 
 For the current development preview:
 
@@ -329,6 +348,7 @@ For the current development preview:
 | Entity index `kind` | Entity index report kind, currently `orbitfabric.entity_index`. |
 | Relationship manifest `manifest_version` | Relationship manifest report format version, currently `0.1-candidate`. |
 | Relationship manifest `kind` | Relationship manifest report kind, currently `orbitfabric.relationship_manifest`. |
+| Extensibility Boundary Contract | Documentation boundary for future extension-owned outputs, not an execution version. |
 
 ---
 
@@ -345,7 +365,8 @@ Do not assume that:
 - model summary reports imply entity-level indexing, relationship graphs or plugin APIs;
 - entity index reports imply relationship graphs, dependency graphs or plugin APIs;
 - relationship manifest reports imply graph engines, runtime behavior, ground behavior, plugin APIs or Studio-specific APIs;
-- stability and compatibility references imply schema migration tooling, JSON Schema publication, plugin execution or a stable v1.0 compatibility guarantee.
+- stability and compatibility references imply schema migration tooling, JSON Schema publication, plugin execution or a stable v1.0 compatibility guarantee;
+- Extensibility Boundary Contract implies metadata schema, plugin discovery, plugin loading, plugin execution or a plugin runtime.
 
 ---
 
@@ -363,6 +384,7 @@ Possible future additions include:
 - schema migration helpers;
 - compatibility checks between tool version and Mission Model version;
 - JSON Schema export for Mission Model validation;
-- compatibility checks for generated artifact profiles.
+- compatibility checks for generated artifact profiles;
+- a separately reviewed metadata format for future extension-owned outputs.
 
-These are not part of the current v0.10.1 development preview.
+These are not part of the current v0.11.0 development preview.

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -1,0 +1,156 @@
+# v0.11.0 - Extensibility Boundary Contract, no execution
+
+OrbitFabric v0.11.0 defines the extensibility boundary without introducing plugin execution.
+
+This release is intentionally narrow.
+
+It makes future extensibility explicit as a boundary contract around Core-owned Mission Data Contract semantics, not as a plugin runtime, loader, registry or execution mechanism.
+
+---
+
+## Purpose
+
+The purpose of v0.11.0 is to define how future extensions may relate to OrbitFabric Core without becoming a second source of truth.
+
+The accepted posture is:
+
+```text
+extensibility is descriptive before it is executable
+```
+
+OrbitFabric Core remains responsible for:
+
+```text
+Mission Model loading
+structural validation
+semantic linting
+scenario validation
+scenario evidence semantics
+runtime-facing contract binding semantics
+ground-facing artifact semantics
+model_summary.json semantics
+entity_index.json semantics
+relationship_manifest.json semantics
+stability and compatibility classification
+release compatibility policy
+```
+
+Future extensions may add value at the edges, but they must consume Core-owned structured surfaces and must not redefine Core Mission Data Contract semantics.
+
+---
+
+## Added
+
+v0.11.0 adds:
+
+```text
+ADR-0015 - Extensibility Boundary Contract, No Execution
+Extensibility Boundary Contract reference documentation
+non-normative guidance for future descriptive extension metadata
+explicit Core ownership rules
+explicit extension ownership rules
+provenance expectations for future extension-owned artifacts
+semantic override ban
+explicit downstream consumer rules
+compatibility-sensitive extensibility boundary expectations before v1.0.0
+```
+
+The new reference page is:
+
+```text
+docs/reference/extensibility-boundary-contract.md
+```
+
+The new ADR is:
+
+```text
+docs/adr/ADR-0015-extensibility-boundary-contract-no-execution.md
+```
+
+---
+
+## Changed
+
+v0.11.0 updates the public documentation baseline from:
+
+```text
+v0.10.1 - Documentation and Published Site Consistency
+```
+
+to:
+
+```text
+v0.11.0 - Extensibility Boundary Contract, no execution
+```
+
+It also marks `v0.12.0 - v1.0 Release Candidate Hardening` as the next roadmap milestone.
+
+---
+
+## Boundary
+
+v0.11.0 intentionally does not introduce:
+
+```text
+new Mission Model semantics
+new YAML fields
+new model domains
+new CLI behavior beyond version reporting
+new JSON report fields
+new generated Core surfaces
+new lint diagnostics
+new scenario behavior
+metadata schema
+JSON metadata shape
+metadata manifest format
+metadata parser
+metadata loader
+metadata validator
+new extension command
+plugin discovery
+plugin loading
+plugin execution
+custom lint plugin execution
+custom generator plugin execution
+dynamic extension runtime
+third-party code execution
+remote plugin registry
+plugin marketplace
+extension installation
+extension dependency resolution
+relationship graph
+dependency graph
+runtime behavior
+ground behavior
+Studio-specific API
+schema migration tooling
+JSON Schema publication
+stable v1.0 compatibility guarantee
+```
+
+v0.11.0 is an extensibility boundary and release-alignment milestone only.
+
+---
+
+## Result
+
+After v0.11.0, OrbitFabric has a documented boundary for future extensibility.
+
+The stable rule is:
+
+```text
+Mission Model remains the source of truth.
+Core owns Mission Data Contract semantics.
+Extensions consume Core-owned structured surfaces.
+Extension-owned outputs remain distinguishable from Core-owned outputs.
+Extensions must not override Core semantics.
+Execution is out of scope.
+```
+
+The next milestone is:
+
+```text
+v0.12.0 - v1.0 Release Candidate Hardening
+```
+
+That next milestone should focus on consistency, release hardening, validation coverage and removal of ambiguity before declaring a stable Mission Data Contract.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - v0.9.0 Relationship Manifest Surface and Extensibility Boundary: releases/v0.9.0.md
       - v0.10.0 Stability and Compatibility Contract: releases/v0.10.0.md
       - v0.10.1 Documentation and Published Site Consistency: releases/v0.10.1.md
+      - v0.11.0 Extensibility Boundary Contract, no execution: releases/v0.11.0.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "0.10.1"
+version = "0.11.0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"


### PR DESCRIPTION
## Summary

Release-align OrbitFabric Core for:

`v0.11.0 - Extensibility Boundary Contract, no execution`

This PR aligns package version, release notes, README, public documentation, roadmap, changelog and contributor/development references after the v0.11.0 extensibility boundary work.

This PR does **not** create a tag and does **not** publish a GitHub Release.

## Changes

- Bump package and CLI version to `0.11.0`.
- Add `docs/releases/v0.11.0.md`.
- Add v0.11.0 release notes to MkDocs navigation.
- Align README with v0.11.0 current status and boundary.
- Align documentation homepage with v0.11.0 current status and boundary.
- Align ROADMAP so v0.11.0 is completed and v0.12.0 is next.
- Align CHANGELOG with the v0.11.0 release section.
- Align Versioning Model with the v0.11.0 package/version context.
- Align Quickstart, Development Guide and Contributing Guide with v0.11.0.
- Align Architecture and Project Charter with the v0.11.0 extensibility boundary baseline.

## Affected Area

Select all that apply:

- [ ] Mission Model
- [ ] Model loading / validation
- [ ] Semantic lint rules
- [ ] Scenario loading / validation
- [ ] Scenario simulation
- [ ] JSON reports
- [ ] Documentation generation
- [ ] Generated artifacts
- [ ] Example missions
- [ ] CI / tooling
- [x] Public documentation
- [x] Release alignment
- [x] Other

## Mission Data Contract Impact

Does this PR change Mission Data Contract semantics?

- [x] No
- [ ] Yes

This PR is release alignment only.

It does not add a model field, reference rule, lint diagnostic, generated artifact, JSON report structure or scenario expectation semantics.

## Architectural Boundary

This PR intentionally does **not** implement:

- new Mission Model semantics
- new YAML fields
- new model domains
- new CLI behavior beyond version reporting
- new JSON report fields
- new generated Core surfaces
- new lint diagnostics
- new scenario behavior
- metadata schema
- JSON metadata shape
- metadata manifest format
- metadata parser
- metadata loader
- metadata validator
- new extension command
- plugin discovery
- plugin loading
- plugin execution
- custom lint plugin execution
- custom generator plugin execution
- dynamic extension runtime
- third-party code execution
- remote plugin registry
- plugin marketplace
- extension installation
- extension dependency resolution
- relationship graph
- dependency graph
- runtime behavior
- ground behavior
- Studio-specific API
- schema migration tooling
- JSON Schema publication
- stable v1.0 compatibility guarantee
- Git tag creation
- GitHub Release publication

## Clean-Room Confirmation

By opening this PR, I confirm that this contribution does not include:

- [x] proprietary mission data
- [x] private spacecraft architecture
- [x] private packet formats
- [x] real operational logs
- [x] non-public payload details
- [x] real bus maps or pinouts
- [x] employer-owned or customer-owned code
- [x] export-controlled or NDA-protected material

All examples are synthetic or derived only from public information.

## Validation

Select the checks that were run.

- [ ] `ruff check .`
- [ ] `pytest`
- [ ] `mkdocs build --strict`
- [ ] `orbitfabric lint examples/demo-3u/mission/ --json generated/reports/lint_report.json`
- [ ] `orbitfabric gen docs examples/demo-3u/mission/`
- [ ] `orbitfabric gen data-flow examples/demo-3u/mission/ --output-file generated/docs/data_flow.md`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml --json generated/reports/battery_low_during_payload_report.json --log generated/logs/battery_low_during_payload.log`
- [ ] `orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml --json generated/reports/payload_data_flow_evidence_report.json --log generated/logs/payload_data_flow_evidence.log`

Not run locally in this environment. The PR should be validated by CI before merge.

## Generated Artifacts

- [x] This PR does not commit generated artifacts.
- [ ] This PR intentionally updates generated artifacts.

## Notes for Review

Review should focus on release-alignment consistency across:

- package version and `__version__`
- README current status
- public docs homepage
- ROADMAP completed/next milestones
- CHANGELOG v0.11.0 section
- v0.11.0 release notes
- MkDocs navigation
- Versioning, Quickstart, Development and Contributing references
- Architecture and Project Charter baseline statements

Also verify that the v0.11.0 boundary remains documentation-only and does not introduce plugin execution, discovery, loading, metadata schema or new Core surfaces.