### PR TITLE
test: add v1 golden signatures for Core-owned surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 - Added the v1.0 Stable Surface Decision page to the MkDocs Reference navigation.
 - Added explicit v1.0 classification for stable surfaces, public preview surfaces, generated disposable artifacts, internal implementation details and out-of-scope topics.
 - Added the selected v1.0 demonstration use-case boundary for Mission Data Contract continuity.
+- Added contract-significant golden signatures for the demo-3u Core-owned structured surfaces: `model_summary.json`, `entity_index.json` and `relationship_manifest.json`.
+- Added regression tests comparing generated Core-owned structured surfaces against those golden signatures.
 
 ### Compatibility impact
 
@@ -22,6 +24,10 @@ This change has no Mission Data Contract semantic impact.
 It does not add, remove or rename Mission Model fields, model domains, controlled values, reference rules, lint diagnostics, scenario expectations, JSON report fields, generated surfaces or CLI behavior.
 
 It documents the proposed narrow v1.0 stable surface selected from existing OrbitFabric Core behavior and surfaces.
+
+The golden signatures protect selected contract-significant fields for existing Core-owned structured surfaces.
+
+They do not introduce new generated surfaces or new report fields.
 
 ### Boundaries
 
@@ -35,8 +41,6 @@ This change intentionally does not introduce:
 - new generated Core surfaces;
 - new lint diagnostics;
 - new scenario behavior;
-- new golden files;
-- new snapshot tests;
 - schema migration tooling;
 - JSON Schema publication;
 - XTCE export;
@@ -56,6 +60,8 @@ This change intentionally does not introduce:
 - runtime behavior;
 - ground behavior;
 - Studio-specific API.
+
+The new golden signatures do not freeze full generated JSON files, absolute paths, human-oriented output, Markdown wording, generated runtime bindings, generated ground dictionaries or disposable artifact formatting.
 
 ---
 

--- a/tests/golden/demo_3u_core_surfaces/entity_index_contract_signature.json
+++ b/tests/golden/demo_3u_core_surfaces/entity_index_contract_signature.json
@@ -1,0 +1,253 @@
+{
+  "surface": "entity_index.json",
+  "fixture": "examples/demo-3u/mission",
+  "comparison_scope": [
+    "surface kind",
+    "surface schema version",
+    "mission identity",
+    "boundary flags",
+    "domain entity counts",
+    "entity identifiers"
+  ],
+  "expected": {
+    "index_version": "0.1",
+    "kind": "orbitfabric.entity_index",
+    "mission": {
+      "id": "demo-3u",
+      "name": "Demo 3U Spacecraft",
+      "model_version": "0.1.0"
+    },
+    "boundaries": {
+      "source_of_truth": "mission_model",
+      "core_derived_report": true,
+      "read_only": true,
+      "contains_entity_index": true,
+      "contains_entity_records": true,
+      "contains_relationship_manifest": false,
+      "contains_relationship_graph": false,
+      "contains_dependency_graph": false,
+      "contains_yaml_ast": false,
+      "contains_source_locations": false,
+      "contains_plugin_api": false,
+      "contains_studio_api": false,
+      "contains_runtime_behavior": false,
+      "contains_ground_behavior": false
+    },
+    "counts": {
+      "domains": {
+        "spacecraft": 1,
+        "subsystems": 4,
+        "modes": 6,
+        "mode_transitions": 0,
+        "telemetry": 5,
+        "commands": 4,
+        "events": 8,
+        "faults": 3,
+        "packets": 3,
+        "policies": 0,
+        "payloads": 1,
+        "data_products": 1,
+        "contact_profiles": 1,
+        "link_profiles": 1,
+        "contact_windows": 1,
+        "downlink_flows": 1,
+        "command_sources": 2,
+        "commandability_rules": 1,
+        "autonomous_actions": 2,
+        "recovery_intents": 2
+      },
+      "total_entities": 47
+    },
+    "domains": [
+      {
+        "id": "autonomous_actions",
+        "source_file": "commandability.yaml",
+        "indexed": true,
+        "model_count": 2,
+        "entity_count": 2
+      },
+      {
+        "id": "command_sources",
+        "source_file": "commandability.yaml",
+        "indexed": true,
+        "model_count": 2,
+        "entity_count": 2
+      },
+      {
+        "id": "commandability_rules",
+        "source_file": "commandability.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "commands",
+        "source_file": "commands.yaml",
+        "indexed": true,
+        "model_count": 4,
+        "entity_count": 4
+      },
+      {
+        "id": "contact_profiles",
+        "source_file": "contacts.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "contact_windows",
+        "source_file": "contacts.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "data_products",
+        "source_file": "data_products.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "downlink_flows",
+        "source_file": "contacts.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "events",
+        "source_file": "events.yaml",
+        "indexed": true,
+        "model_count": 8,
+        "entity_count": 8
+      },
+      {
+        "id": "faults",
+        "source_file": "faults.yaml",
+        "indexed": true,
+        "model_count": 3,
+        "entity_count": 3
+      },
+      {
+        "id": "link_profiles",
+        "source_file": "contacts.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "mode_transitions",
+        "source_file": "modes.yaml",
+        "indexed": false,
+        "model_count": 6,
+        "entity_count": 0
+      },
+      {
+        "id": "modes",
+        "source_file": "modes.yaml",
+        "indexed": true,
+        "model_count": 6,
+        "entity_count": 6
+      },
+      {
+        "id": "packets",
+        "source_file": "packets.yaml",
+        "indexed": true,
+        "model_count": 3,
+        "entity_count": 3
+      },
+      {
+        "id": "payloads",
+        "source_file": "payloads.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "policies",
+        "source_file": "policies.yaml",
+        "indexed": false,
+        "model_count": 1,
+        "entity_count": 0
+      },
+      {
+        "id": "recovery_intents",
+        "source_file": "commandability.yaml",
+        "indexed": true,
+        "model_count": 2,
+        "entity_count": 2
+      },
+      {
+        "id": "spacecraft",
+        "source_file": "spacecraft.yaml",
+        "indexed": true,
+        "model_count": 1,
+        "entity_count": 1
+      },
+      {
+        "id": "subsystems",
+        "source_file": "subsystems.yaml",
+        "indexed": true,
+        "model_count": 4,
+        "entity_count": 4
+      },
+      {
+        "id": "telemetry",
+        "source_file": "telemetry.yaml",
+        "indexed": true,
+        "model_count": 5,
+        "entity_count": 5
+      }
+    ],
+    "entities": [
+      {"domain": "autonomous_actions", "id": "stop_payload_on_battery_critical", "entity_type": "autonomous_action", "source_file": "commandability.yaml"},
+      {"domain": "autonomous_actions", "id": "stop_payload_on_battery_low", "entity_type": "autonomous_action", "source_file": "commandability.yaml"},
+      {"domain": "command_sources", "id": "ground_operator", "entity_type": "command_source", "source_file": "commandability.yaml"},
+      {"domain": "command_sources", "id": "onboard_autonomy", "entity_type": "command_source", "source_file": "commandability.yaml"},
+      {"domain": "commandability_rules", "id": "payload_start_ground_rule", "entity_type": "commandability_rule", "source_file": "commandability.yaml"},
+      {"domain": "commands", "id": "eps.get_status", "entity_type": "command", "source_file": "commands.yaml"},
+      {"domain": "commands", "id": "payload.start_acquisition", "entity_type": "command", "source_file": "commands.yaml"},
+      {"domain": "commands", "id": "payload.stop_acquisition", "entity_type": "command", "source_file": "commands.yaml"},
+      {"domain": "commands", "id": "radio.downlink_housekeeping", "entity_type": "command", "source_file": "commands.yaml"},
+      {"domain": "contact_profiles", "id": "primary_ground_contact", "entity_type": "contact_profile", "source_file": "contacts.yaml"},
+      {"domain": "contact_windows", "id": "demo_contact_001", "entity_type": "contact_window", "source_file": "contacts.yaml"},
+      {"domain": "data_products", "id": "payload.radiation_histogram", "entity_type": "data_product", "source_file": "data_products.yaml"},
+      {"domain": "downlink_flows", "id": "science_next_available_contact", "entity_type": "downlink_flow", "source_file": "contacts.yaml"},
+      {"domain": "events", "id": "eps.battery_critical", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "eps.battery_low", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "eps.status_requested", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "obc.mode_changed", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "payload.acquisition_started", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "payload.acquisition_stopped", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "payload.command_timeout", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "events", "id": "radio.housekeeping_downlink_requested", "entity_type": "event", "source_file": "events.yaml"},
+      {"domain": "faults", "id": "eps.battery_critical_fault", "entity_type": "fault", "source_file": "faults.yaml"},
+      {"domain": "faults", "id": "eps.battery_low_fault", "entity_type": "fault", "source_file": "faults.yaml"},
+      {"domain": "faults", "id": "payload.command_timeout_fault", "entity_type": "fault", "source_file": "faults.yaml"},
+      {"domain": "link_profiles", "id": "uhf_downlink_nominal", "entity_type": "link_profile", "source_file": "contacts.yaml"},
+      {"domain": "modes", "id": "BOOT", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "modes", "id": "DEGRADED", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "modes", "id": "MAINTENANCE", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "modes", "id": "NOMINAL", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "modes", "id": "PAYLOAD_ACTIVE", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "modes", "id": "SAFE", "entity_type": "mode", "source_file": "modes.yaml"},
+      {"domain": "packets", "id": "comm_status", "entity_type": "packet", "source_file": "packets.yaml"},
+      {"domain": "packets", "id": "hk_fast", "entity_type": "packet", "source_file": "packets.yaml"},
+      {"domain": "packets", "id": "payload_status", "entity_type": "packet", "source_file": "packets.yaml"},
+      {"domain": "payloads", "id": "demo_iod_payload", "entity_type": "payload", "source_file": "payloads.yaml"},
+      {"domain": "recovery_intents", "id": "payload_battery_critical_recovery", "entity_type": "recovery_intent", "source_file": "commandability.yaml"},
+      {"domain": "recovery_intents", "id": "payload_battery_low_recovery", "entity_type": "recovery_intent", "source_file": "commandability.yaml"},
+      {"domain": "spacecraft", "id": "demo-3u", "entity_type": "spacecraft", "source_file": "spacecraft.yaml"},
+      {"domain": "subsystems", "id": "eps", "entity_type": "subsystem", "source_file": "subsystems.yaml"},
+      {"domain": "subsystems", "id": "obc", "entity_type": "subsystem", "source_file": "subsystems.yaml"},
+      {"domain": "subsystems", "id": "payload", "entity_type": "subsystem", "source_file": "subsystems.yaml"},
+      {"domain": "subsystems", "id": "radio", "entity_type": "subsystem", "source_file": "subsystems.yaml"},
+      {"domain": "telemetry", "id": "eps.battery.current", "entity_type": "telemetry", "source_file": "telemetry.yaml"},
+      {"domain": "telemetry", "id": "eps.battery.voltage", "entity_type": "telemetry", "source_file": "telemetry.yaml"},
+      {"domain": "telemetry", "id": "obc.mode", "entity_type": "telemetry", "source_file": "telemetry.yaml"},
+      {"domain": "telemetry", "id": "payload.acquisition.active", "entity_type": "telemetry", "source_file": "telemetry.yaml"},
+      {"domain": "telemetry", "id": "radio.downlink.available", "entity_type": "telemetry", "source_file": "telemetry.yaml"}
+    ]
+  }
+}

--- a/tests/golden/demo_3u_core_surfaces/model_summary_contract_signature.json
+++ b/tests/golden/demo_3u_core_surfaces/model_summary_contract_signature.json
@@ -1,0 +1,194 @@
+{
+  "surface": "model_summary.json",
+  "fixture": "examples/demo-3u/mission",
+  "comparison_scope": [
+    "surface kind",
+    "surface schema version",
+    "mission identity",
+    "boundary flags",
+    "domain counts",
+    "domain source files"
+  ],
+  "expected": {
+    "summary_version": "0.1",
+    "kind": "orbitfabric.model_summary",
+    "mission": {
+      "id": "demo-3u",
+      "name": "Demo 3U Spacecraft",
+      "model_version": "0.1.0"
+    },
+    "boundaries": {
+      "source_of_truth": "mission_model",
+      "core_derived_report": true,
+      "contains_entity_index": false,
+      "contains_relationship_manifest": false,
+      "contains_plugin_api": false,
+      "contains_runtime_behavior": false,
+      "contains_ground_behavior": false
+    },
+    "counts": {
+      "spacecraft": 1,
+      "subsystems": 4,
+      "modes": 6,
+      "mode_transitions": 6,
+      "telemetry": 5,
+      "commands": 4,
+      "events": 8,
+      "faults": 3,
+      "packets": 3,
+      "policies": 1,
+      "payloads": 1,
+      "data_products": 1,
+      "contact_profiles": 1,
+      "link_profiles": 1,
+      "contact_windows": 1,
+      "downlink_flows": 1,
+      "command_sources": 2,
+      "commandability_rules": 1,
+      "autonomous_actions": 2,
+      "recovery_intents": 2
+    },
+    "domains": [
+      {
+        "id": "autonomous_actions",
+        "required": false,
+        "present": true,
+        "source_file": "commandability.yaml",
+        "count": 2
+      },
+      {
+        "id": "command_sources",
+        "required": false,
+        "present": true,
+        "source_file": "commandability.yaml",
+        "count": 2
+      },
+      {
+        "id": "commandability_rules",
+        "required": false,
+        "present": true,
+        "source_file": "commandability.yaml",
+        "count": 1
+      },
+      {
+        "id": "commands",
+        "required": true,
+        "present": true,
+        "source_file": "commands.yaml",
+        "count": 4
+      },
+      {
+        "id": "contact_profiles",
+        "required": false,
+        "present": true,
+        "source_file": "contacts.yaml",
+        "count": 1
+      },
+      {
+        "id": "contact_windows",
+        "required": false,
+        "present": true,
+        "source_file": "contacts.yaml",
+        "count": 1
+      },
+      {
+        "id": "data_products",
+        "required": false,
+        "present": true,
+        "source_file": "data_products.yaml",
+        "count": 1
+      },
+      {
+        "id": "downlink_flows",
+        "required": false,
+        "present": true,
+        "source_file": "contacts.yaml",
+        "count": 1
+      },
+      {
+        "id": "events",
+        "required": true,
+        "present": true,
+        "source_file": "events.yaml",
+        "count": 8
+      },
+      {
+        "id": "faults",
+        "required": true,
+        "present": true,
+        "source_file": "faults.yaml",
+        "count": 3
+      },
+      {
+        "id": "link_profiles",
+        "required": false,
+        "present": true,
+        "source_file": "contacts.yaml",
+        "count": 1
+      },
+      {
+        "id": "mode_transitions",
+        "required": false,
+        "present": true,
+        "source_file": "modes.yaml",
+        "count": 6
+      },
+      {
+        "id": "modes",
+        "required": true,
+        "present": true,
+        "source_file": "modes.yaml",
+        "count": 6
+      },
+      {
+        "id": "packets",
+        "required": true,
+        "present": true,
+        "source_file": "packets.yaml",
+        "count": 3
+      },
+      {
+        "id": "payloads",
+        "required": false,
+        "present": true,
+        "source_file": "payloads.yaml",
+        "count": 1
+      },
+      {
+        "id": "policies",
+        "required": true,
+        "present": true,
+        "source_file": "policies.yaml",
+        "count": 1
+      },
+      {
+        "id": "recovery_intents",
+        "required": false,
+        "present": true,
+        "source_file": "commandability.yaml",
+        "count": 2
+      },
+      {
+        "id": "spacecraft",
+        "required": true,
+        "present": true,
+        "source_file": "spacecraft.yaml",
+        "count": 1
+      },
+      {
+        "id": "subsystems",
+        "required": true,
+        "present": true,
+        "source_file": "subsystems.yaml",
+        "count": 4
+      },
+      {
+        "id": "telemetry",
+        "required": true,
+        "present": true,
+        "source_file": "telemetry.yaml",
+        "count": 5
+      }
+    ]
+  }
+}

--- a/tests/golden/demo_3u_core_surfaces/model_summary_contract_signature.json
+++ b/tests/golden/demo_3u_core_surfaces/model_summary_contract_signature.json
@@ -128,7 +128,7 @@
       },
       {
         "id": "mode_transitions",
-        "required": false,
+        "required": true,
         "present": true,
         "source_file": "modes.yaml",
         "count": 6

--- a/tests/golden/demo_3u_core_surfaces/relationship_manifest_contract_signature.json
+++ b/tests/golden/demo_3u_core_surfaces/relationship_manifest_contract_signature.json
@@ -1,0 +1,100 @@
+{
+  "surface": "relationship_manifest.json",
+  "fixture": "examples/demo-3u/mission",
+  "comparison_scope": [
+    "surface kind",
+    "surface schema version",
+    "mission identity",
+    "boundary flags",
+    "derivation policy",
+    "relationship family counts",
+    "selected end-to-end relationship records"
+  ],
+  "expected": {
+    "manifest_version": "0.1-candidate",
+    "kind": "orbitfabric.relationship_manifest",
+    "status": "candidate",
+    "mission": {
+      "id": "demo-3u",
+      "name": "Demo 3U Spacecraft",
+      "model_version": "0.1.0"
+    },
+    "boundaries": {
+      "source_of_truth": "mission_model",
+      "core_derived_report": true,
+      "read_only": true,
+      "contains_entity_index": false,
+      "contains_entity_records": false,
+      "contains_relationship_manifest": true,
+      "contains_relationship_records": true,
+      "contains_relationship_graph": false,
+      "contains_dependency_graph": false,
+      "contains_yaml_ast": false,
+      "contains_source_locations": false,
+      "contains_plugin_api": false,
+      "contains_studio_api": false,
+      "contains_runtime_behavior": false,
+      "contains_ground_behavior": false
+    },
+    "derivation_policy": {
+      "requires_explicit_loaded_mission_model_fields": true,
+      "references_entity_index_entities": true,
+      "forbids_naming_heuristics": true,
+      "forbids_raw_yaml_scanning": true,
+      "forbids_downstream_assumptions": true
+    },
+    "counts": {
+      "total_relationships": 46,
+      "relationship_types": {
+        "autonomous_action_dispatches_command": 2,
+        "command_emits_event": 4,
+        "command_targets_subsystem": 4,
+        "commandability_rule_constrains_command": 1,
+        "data_product_produced_by_payload": 1,
+        "downlink_flow_includes_data_product": 1,
+        "event_sourced_from_subsystem": 8,
+        "fault_emits_event": 3,
+        "fault_sourced_from_subsystem": 3,
+        "packet_includes_telemetry": 5,
+        "payload_accepts_command": 2,
+        "payload_belongs_to_subsystem": 1,
+        "payload_generates_event": 2,
+        "payload_may_raise_fault": 1,
+        "payload_produces_telemetry": 1,
+        "recovery_intent_reacts_to_fault": 2,
+        "telemetry_sourced_from_subsystem": 5
+      }
+    },
+    "relationship_types": [
+      {"relationship_type": "autonomous_action_dispatches_command", "display_name": "Autonomous action dispatches command", "from_domain": "autonomous_actions", "to_domain": "commands", "derived_from": {"model_field": "commandability.autonomous_actions[].dispatches.command"}, "relationship_count": 2},
+      {"relationship_type": "command_emits_event", "display_name": "Command emits event", "from_domain": "commands", "to_domain": "events", "derived_from": {"model_field": "commands[].emits"}, "relationship_count": 4},
+      {"relationship_type": "command_targets_subsystem", "display_name": "Command targets subsystem", "from_domain": "commands", "to_domain": "subsystems", "derived_from": {"model_field": "commands[].target"}, "relationship_count": 4},
+      {"relationship_type": "commandability_rule_constrains_command", "display_name": "Commandability rule constrains command", "from_domain": "commandability_rules", "to_domain": "commands", "derived_from": {"model_field": "commandability.rules[].command"}, "relationship_count": 1},
+      {"relationship_type": "data_product_produced_by_payload", "display_name": "Data product produced by payload", "from_domain": "data_products", "to_domain": "payloads", "derived_from": {"model_field": "data_products[].producer"}, "relationship_count": 1},
+      {"relationship_type": "downlink_flow_includes_data_product", "display_name": "Downlink flow includes data product", "from_domain": "downlink_flows", "to_domain": "data_products", "derived_from": {"model_field": "downlink_flows[].eligible_data_products"}, "relationship_count": 1},
+      {"relationship_type": "event_sourced_from_subsystem", "display_name": "Event sourced from subsystem", "from_domain": "events", "to_domain": "subsystems", "derived_from": {"model_field": "events[].source"}, "relationship_count": 8},
+      {"relationship_type": "fault_emits_event", "display_name": "Fault emits event", "from_domain": "faults", "to_domain": "events", "derived_from": {"model_field": "faults[].emits"}, "relationship_count": 3},
+      {"relationship_type": "fault_sourced_from_subsystem", "display_name": "Fault sourced from subsystem", "from_domain": "faults", "to_domain": "subsystems", "derived_from": {"model_field": "faults[].source"}, "relationship_count": 3},
+      {"relationship_type": "packet_includes_telemetry", "display_name": "Packet includes telemetry", "from_domain": "packets", "to_domain": "telemetry", "derived_from": {"model_field": "packets[].telemetry"}, "relationship_count": 5},
+      {"relationship_type": "payload_accepts_command", "display_name": "Payload accepts command", "from_domain": "payloads", "to_domain": "commands", "derived_from": {"model_field": "payloads[].commands.accepted"}, "relationship_count": 2},
+      {"relationship_type": "payload_belongs_to_subsystem", "display_name": "Payload belongs to subsystem", "from_domain": "payloads", "to_domain": "subsystems", "derived_from": {"model_field": "payloads[].subsystem"}, "relationship_count": 1},
+      {"relationship_type": "payload_generates_event", "display_name": "Payload generates event", "from_domain": "payloads", "to_domain": "events", "derived_from": {"model_field": "payloads[].events.generated"}, "relationship_count": 2},
+      {"relationship_type": "payload_may_raise_fault", "display_name": "Payload may raise fault", "from_domain": "payloads", "to_domain": "faults", "derived_from": {"model_field": "payloads[].faults.possible"}, "relationship_count": 1},
+      {"relationship_type": "payload_produces_telemetry", "display_name": "Payload produces telemetry", "from_domain": "payloads", "to_domain": "telemetry", "derived_from": {"model_field": "payloads[].telemetry.produced"}, "relationship_count": 1},
+      {"relationship_type": "recovery_intent_reacts_to_fault", "display_name": "Recovery intent reacts to fault", "from_domain": "recovery_intents", "to_domain": "faults", "derived_from": {"model_field": "commandability.recovery_intents[].fault"}, "relationship_count": 2},
+      {"relationship_type": "telemetry_sourced_from_subsystem", "display_name": "Telemetry sourced from subsystem", "from_domain": "telemetry", "to_domain": "subsystems", "derived_from": {"model_field": "telemetry[].source"}, "relationship_count": 5}
+    ],
+    "selected_relationship_ids": [
+      "commands:payload.start_acquisition->command_emits_event:events:payload.acquisition_started",
+      "commands:payload.start_acquisition->command_targets_subsystem:subsystems:payload",
+      "data_products:payload.radiation_histogram->data_product_produced_by_payload:payloads:demo_iod_payload",
+      "downlink_flows:science_next_available_contact->downlink_flow_includes_data_product:data_products:payload.radiation_histogram",
+      "payloads:demo_iod_payload->payload_accepts_command:commands:payload.start_acquisition",
+      "payloads:demo_iod_payload->payload_belongs_to_subsystem:subsystems:payload",
+      "payloads:demo_iod_payload->payload_generates_event:events:payload.acquisition_started",
+      "payloads:demo_iod_payload->payload_produces_telemetry:telemetry:payload.acquisition.active",
+      "recovery_intents:payload_battery_low_recovery->recovery_intent_reacts_to_fault:faults:eps.battery_low_fault",
+      "telemetry:payload.acquisition.active->telemetry_sourced_from_subsystem:subsystems:payload"
+    ]
+  }
+}

--- a/tests/test_v1_golden_core_surfaces.py
+++ b/tests/test_v1_golden_core_surfaces.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orbitfabric.export.entity_index import entity_index_to_dict
+from orbitfabric.export.model_summary import model_summary_to_dict
+from orbitfabric.export.relationship_manifest import relationship_manifest_to_dict
+from orbitfabric.model.loader import MissionModelLoader
+
+DEMO_MISSION = Path("examples/demo-3u/mission")
+GOLDEN_DIR = Path("tests/golden/demo_3u_core_surfaces")
+
+
+def _load_expected(file_name: str) -> dict[str, Any]:
+    golden = json.loads((GOLDEN_DIR / file_name).read_text(encoding="utf-8"))
+    return golden["expected"]
+
+
+def _select_model_summary_contract_fields(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "summary_version": summary["summary_version"],
+        "kind": summary["kind"],
+        "mission": summary["mission"],
+        "boundaries": summary["boundaries"],
+        "counts": summary["counts"],
+        "domains": sorted(
+            [
+                {
+                    "id": domain["id"],
+                    "required": domain["required"],
+                    "present": domain["present"],
+                    "source_file": domain["source_file"],
+                    "count": domain["count"],
+                }
+                for domain in summary["domains"]
+            ],
+            key=lambda item: item["id"],
+        ),
+    }
+
+
+def _select_entity_index_contract_fields(index: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "index_version": index["index_version"],
+        "kind": index["kind"],
+        "mission": index["mission"],
+        "boundaries": index["boundaries"],
+        "counts": index["counts"],
+        "domains": sorted(
+            [
+                {
+                    "id": domain["id"],
+                    "source_file": domain["source_file"],
+                    "indexed": domain["indexed"],
+                    "model_count": domain["model_count"],
+                    "entity_count": domain["entity_count"],
+                }
+                for domain in index["domains"]
+            ],
+            key=lambda item: item["id"],
+        ),
+        "entities": sorted(
+            [
+                {
+                    "domain": entity["domain"],
+                    "id": entity["id"],
+                    "entity_type": entity["entity_type"],
+                    "source_file": entity["source_file"],
+                }
+                for entity in index["entities"]
+            ],
+            key=lambda item: (item["domain"], item["id"]),
+        ),
+    }
+
+
+def _select_relationship_manifest_contract_fields(
+    manifest: dict[str, Any],
+    selected_relationship_ids: list[str],
+) -> dict[str, Any]:
+    emitted_relationship_ids = {
+        relationship["relationship_id"] for relationship in manifest["relationships"]
+    }
+
+    return {
+        "manifest_version": manifest["manifest_version"],
+        "kind": manifest["kind"],
+        "status": manifest["status"],
+        "mission": manifest["mission"],
+        "boundaries": manifest["boundaries"],
+        "derivation_policy": manifest["derivation_policy"],
+        "counts": manifest["counts"],
+        "relationship_types": manifest["relationship_types"],
+        "selected_relationship_ids": [
+            relationship_id
+            for relationship_id in selected_relationship_ids
+            if relationship_id in emitted_relationship_ids
+        ],
+    }
+
+
+def test_demo_3u_model_summary_matches_golden_contract_signature() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    summary = model_summary_to_dict(model, DEMO_MISSION)
+
+    actual = _select_model_summary_contract_fields(summary)
+
+    assert actual == _load_expected("model_summary_contract_signature.json")
+
+
+def test_demo_3u_entity_index_matches_golden_contract_signature() -> None:
+    model = MissionModelLoader().load(DEMO_MISSION)
+    index = entity_index_to_dict(model, DEMO_MISSION)
+
+    actual = _select_entity_index_contract_fields(index)
+
+    assert actual == _load_expected("entity_index_contract_signature.json")
+
+
+def test_demo_3u_relationship_manifest_matches_golden_contract_signature() -> None:
+    expected = _load_expected("relationship_manifest_contract_signature.json")
+    model = MissionModelLoader().load(DEMO_MISSION)
+    manifest = relationship_manifest_to_dict(model, DEMO_MISSION)
+
+    actual = _select_relationship_manifest_contract_fields(
+        manifest,
+        selected_relationship_ids=expected["selected_relationship_ids"],
+    )
+
+    assert actual == expected


### PR DESCRIPTION
## Summary

Adds contract-significant golden signatures for the three selected v1.0 Core-owned structured surfaces generated from `examples/demo-3u/mission`:

- `model_summary.json`;
- `entity_index.json`;
- `relationship_manifest.json`.

Adds regression tests that compare generated surfaces against those golden signatures while intentionally selecting only contract-significant fields.

## Mission Data Contract impact

No Mission Data Contract semantic impact.

This PR does not add, remove or rename Mission Model fields, model domains, controlled values, reference rules, lint diagnostics, scenario expectations, JSON report fields, generated Core surfaces or CLI behavior.

It protects existing Core-owned structured surface meaning from accidental drift.

## Architectural Boundary

This PR introduces golden test baselines only for selected contract-significant fields of existing Core-owned structured surfaces.

It does not freeze:

- full generated JSON files;
- absolute paths;
- human-oriented terminal output;
- Markdown wording;
- generated runtime bindings;
- generated ground dictionaries;
- disposable artifact formatting.

It does not introduce runtime behavior, ground behavior, plugin discovery/loading/execution, schema migration tooling, JSON Schema publication, security semantics, XTCE/Yamcs/OpenC3/F Prime/cFS/CCSDS/PUS integration or relationship graph behavior.

## Validation

Not run locally in this environment.

Expected checks:

```text
ruff check .
pytest
mkdocs build --strict
```

Primary expected coverage is the new `tests/test_v1_golden_core_surfaces.py` regression suite.