### PR TITLE
docs: align v1 candidate public documentation claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project follows a lightweight pre-1.0 changelog style while the Mission Mod
 
 - Aligned the v1.0 Compatibility and Migration Notes reference with the current v1.0 candidate posture after the stable surface decision, golden signatures and demo evidence chain.
 - Documented that no migration is required from the v0.12.0 release candidate hardening baseline to the current v1.0 candidate documentation and regression-test state.
+- Aligned the public documentation homepage with the current v1.0 candidate posture.
+- Aligned the roadmap with the current v1.0 candidate alignment path before final v1.0.0 release preparation.
 
 ### Compatibility impact
 
@@ -41,6 +43,8 @@ The v1.0 Demo Evidence Chain reference is documentation-only and maps existing d
 It does not introduce new Mission Model semantics, new scenarios, new generated artifacts, new report fields or new compatibility guarantees.
 
 The v1.0 Compatibility and Migration Notes alignment is documentation-only and does not introduce migration tooling, compatibility scanners, JSON Schema publication, schema version negotiation or new compatibility guarantees beyond the proposed v1.0 posture.
+
+The homepage and roadmap alignment is documentation-only and does not change the package version, release status, Mission Model semantics, generated artifacts, CI behavior or v1.0 release state.
 
 ### Boundaries
 
@@ -79,6 +83,8 @@ The new golden signatures do not freeze full generated JSON files, absolute path
 The v1.0 Demo Evidence Chain reference does not claim flight readiness, ground readiness, protocol compliance, tool-specific integration, security enforcement or operational completeness.
 
 The v1.0 Compatibility and Migration Notes reference does not claim that preview, disposable, internal or out-of-scope surfaces become stable.
+
+The public documentation claim alignment does not claim that v1.0.0 has been released.
 
 ---
 
@@ -388,7 +394,7 @@ Relationship Manifest Surface in v0.9.0 is a Core-owned read-only candidate rela
 ### Added
 
 - Added `entity_index_to_dict(model, mission_dir)`.
-- Added `write_entity_index(model, mission_dir, output_file)`.
+- Added `write_entity_index(model, mission_dir)`.
 - Added deterministic `entity_index.json` generation.
 - Added the `orbitfabric export entity-index` command.
 - Added `index_version 0.1` for the entity index surface.
@@ -438,7 +444,7 @@ The Entity Index Surface intentionally does not introduce:
 
 - Added the `orbitfabric.export` package.
 - Added `model_summary_to_dict(model, mission_dir)`.
-- Added `write_model_summary(model, mission_dir, output_file)`.
+- Added `write_model_summary(model, mission_dir)`.
 - Added the `orbitfabric export model-summary` command.
 - Added deterministic `model_summary.json` generation.
 - Added the first Core-owned read-only Contract Introspection Surface.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # OrbitFabric - Roadmap
 
 Version: v0.12.0 to v1.0 stability path  
-Status: Development preview  
+Status: v1.0 candidate alignment  
 Scope: v0.3 to v1.0 planning
 
 ---
@@ -43,6 +43,10 @@ Mission Model
         -> documentation and published site consistency
         -> extensibility boundary contract
         -> release candidate hardening
+        -> stable surface decision
+        -> golden signatures for selected Core-owned surfaces
+        -> demo evidence chain
+        -> compatibility and migration posture
         -> stable Mission Data Contract
 ```
 
@@ -78,11 +82,22 @@ v0.12.0 v1.0 Release Candidate Hardening                         completed
 v1.0.0  Stable Mission Data Contract                             next
 ```
 
-The current completed milestone is `v0.12.0 - v1.0 Release Candidate Hardening`.
+The current completed released milestone is `v0.12.0 - v1.0 Release Candidate Hardening`.
 
-The immediate target after v0.12.0 is `v1.0.0 - Stable Mission Data Contract`.
+The active unreleased alignment work is the v1.0 candidate stabilization path.
 
-This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified compatibility expectations around public and preview surfaces before v1.0. v0.10.1 verified documentation and published-site consistency. v0.11.0 defined the extensibility boundary without plugin execution. v0.12.0 hardened the release candidate path toward a stable Mission Data Contract.
+That path now includes:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+The immediate target remains `v1.0.0 - Stable Mission Data Contract`.
+
+This sequence is intentional. v0.8.1 exposed the first Core-owned domain-level introspection surface. v0.8.2 exposed the first Core-owned entity-level index surface. v0.9.0 introduced the first Core-owned relationship-level surface. v0.10.0 classified compatibility expectations around public and preview surfaces before v1.0. v0.10.1 verified documentation and published-site consistency. v0.11.0 defined the extensibility boundary without plugin execution. v0.12.0 hardened the release candidate path toward a stable Mission Data Contract. The v1.0 candidate alignment work now selects, protects, demonstrates and documents the narrow v1.0 posture before release.
 
 The next step is not plugin execution. The next step is the stable Mission Data Contract release.
 
@@ -254,7 +269,7 @@ v0.11.0 intentionally does not introduce new Mission Model semantics, new YAML f
 
 v0.12.0 hardens the release candidate path toward v1.0.0.
 
-It introduces these hardening references:
+It introduced these hardening references:
 
 ```text
 v1.0 Candidate Surface Inventory
@@ -262,13 +277,13 @@ Golden Output and Regression Confidence Policy
 v1.0 Compatibility and Migration Notes
 ```
 
-Their role is to make the v1.0 path explicit before the final stable release.
+Their role was to make the v1.0 path explicit before final stable release work.
 
-They do not themselves decide the final v1.0 stable surface.
+They did not themselves decide the final v1.0 stable surface.
 
-They do not add golden baselines, migration tooling, JSON Schema publication, generated Core surfaces or new Mission Model semantics.
+They did not add golden baselines, migration tooling, JSON Schema publication, generated Core surfaces or new Mission Model semantics.
 
-v0.12.0 answers or explicitly defers central stabilization questions before the project moves to v1.0.0.
+v0.12.0 answered or explicitly deferred central stabilization questions before the project moved to v1.0.0 candidate alignment.
 
 Security assumptions and command criticality contracts remain valid future explorations, but they are deferred beyond v1.0.0 unless separately scoped in a post-v1.0 milestone.
 
@@ -276,40 +291,59 @@ v0.12.0 intentionally does not broaden OrbitFabric into flight software, ground 
 
 ---
 
-## 13. Next Milestone - v1.0.0 Stable Mission Data Contract
+## 13. Active v1.0 Candidate Alignment
+
+The active v1.0 candidate alignment work prepares the final stable Mission Data Contract release.
+
+It has already added:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+This work does not change the package version and does not introduce new Mission Model semantics, YAML fields, CLI behavior, JSON report fields, generated artifact families, runtime behavior, ground behavior, plugin execution, schema migration tooling or JSON Schema publication.
+
+It selects, protects, demonstrates and documents the narrow stable surface before the final v1.0.0 release alignment.
+
+---
+
+## 14. Next Milestone - v1.0.0 Stable Mission Data Contract
 
 v1.0.0 should be the first version where the Mission Data Contract is stable enough for external users and downstream consumers to build around.
 
-Possible requirements:
+Selected stable surface candidates:
 
 ```text
-stable Mission Model schema
-stable Payload Contract Model schema
-stable Data Product Contract schema
-stable Contact/Downlink Contract schema
-stable Commandability Contract schema
-stable data-flow evidence semantics
-stable RuntimeContract semantics
-stable GroundContract semantics
-stable contract introspection surface
-stable entity index surface
-stable relationship manifest surface
-stable extensibility boundary semantics
-stable runtime-facing contract binding surface
-stable ground-facing artifact package
-stable CLI commands
-stable lint rule code policy
-stable generated documentation format
-stable JSON report format
-migration guide from earlier model versions
-complete demo mission
-multiple example missions
-published documentation site
-CI-tested release artifacts
-clear contribution process
+Mission Model documented contract semantics
+Core structural validation
+Core semantic lint diagnostic policy
+scenario YAML evidence inputs
+lint JSON report
+simulation JSON report
+model_summary.json
+entity_index.json
+relationship_manifest.json for admitted families
+CLI command interface for documented workflows
+release compatibility policy
+extensibility boundary contract
 ```
 
-The final v1.0.0 stable surface must be selected explicitly.
+Surfaces that must remain preview or disposable unless explicitly promoted later:
+
+```text
+CLI textual output
+generated Markdown mission documentation
+plain-text simulation logs
+generated C++17 runtime-facing bindings
+generated ground-facing dictionaries
+runtime_contract_manifest.json
+ground_contract_manifest.json
+```
+
+The final v1.0.0 stable surface must remain narrow.
 
 A surface listed as a candidate, preview or generated artifact before v1.0.0 does not become stable automatically.
 
@@ -317,7 +351,7 @@ v1.0.0 should mean stable Mission Data Contract framework, not a complete space 
 
 ---
 
-## 14. Backlog Parking Lot
+## 15. Backlog Parking Lot
 
 These ideas are valid but must not distract from the active milestone.
 
@@ -365,7 +399,7 @@ plugin execution
 
 ---
 
-## 15. Priority Rules
+## 16. Priority Rules
 
 When deciding what to implement next, use these rules.
 
@@ -387,12 +421,14 @@ When deciding what to implement next, use these rules.
 16. Relationship Semantics Before Relationship Visualization.
 17. Boundary Before Execution.
 18. Hardening Before Stability.
+19. Stable Surface Decision Before v1.0 Release.
+20. Golden Signatures Before Compatibility Claims.
 
 ---
 
-## 16. Immediate Work Plan
+## 17. Immediate Work Plan
 
-The immediate work package after v0.12.0 is:
+The immediate work package is:
 
 ```text
 v1.0.0 - Stable Mission Data Contract
@@ -401,13 +437,13 @@ v1.0.0 - Stable Mission Data Contract
 Required next-step discipline:
 
 ```text
-1. select the final narrow v1.0 stable surface
-2. confirm which candidate surfaces become stable
-3. explicitly defer or mark preview surfaces that do not become stable
-4. confirm golden-output and regression expectations for stable surfaces
-5. confirm compatibility and migration notes
-6. align release documentation without broadening scope
-7. keep plugin execution out of scope
+1. keep the final v1.0 stable surface narrow
+2. keep generated runtime-facing and ground-facing artifacts preview/disposable unless explicitly promoted
+3. keep plugin execution out of scope
+4. keep security enforcement out of scope
+5. keep JSON Schema publication and migration tooling out of scope
+6. align documentation claims without broadening scope
+7. prepare final v1.0.0 release alignment only after documentation and CI are clean
 ```
 
 Do not start plugin execution, plugin discovery or plugin loader work in v1.0.0.
@@ -420,7 +456,7 @@ Do not let downstream tools become a second source of truth.
 
 ---
 
-## 17. Final Roadmap Statement
+## 18. Final Roadmap Statement
 
 OrbitFabric must first become excellent at one thing:
 
@@ -445,6 +481,8 @@ The v0.10.1 roadmap step completed the documentation and published-site consiste
 The v0.11.0 roadmap step completed the extensibility boundary contract without plugin execution.
 
 The v0.12.0 roadmap step completed the release candidate hardening path to v1.0.0 without broadening the Core.
+
+The v1.0 candidate alignment path selected, protected, demonstrated and documented the narrow stable Mission Data Contract posture before the final v1.0.0 release.
 
 The narrowness of the roadmap is intentional.
 That narrowness is a strength, not a limitation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,11 @@
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classification references, extensibility boundary contracts and v1.0 release candidate hardening references in a single Mission Data Contract workflow.
+It defines telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, contact/downlink assumptions, commandability/autonomy contracts, scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classification references, extensibility boundary contracts and v1.0 candidate hardening references in a single Mission Data Contract workflow.
 
 From that contract, OrbitFabric validates consistency, generates documentation, executes host-side operational scenarios and generates deterministic integration and inspection artifacts.
 
-## Current development preview
+## Current status
 
 OrbitFabric is currently at:
 
@@ -14,68 +14,26 @@ OrbitFabric is currently at:
 v0.12.0 - v1.0 Release Candidate Hardening
 ```
 
-v0.12.0 hardens the path toward `v1.0.0 - Stable Mission Data Contract`.
-
-It introduces release candidate hardening references, not new Mission Model behavior.
-
-It introduces no Mission Model semantics, CLI behavior beyond version reporting, generated Core surfaces, JSON report fields, lint diagnostics, scenario behavior, runtime behavior, ground behavior, golden files, snapshot tests, schema migration tooling, JSON Schema publication, security enforcement semantics, plugin discovery, plugin loading, plugin execution, metadata schema, metadata parser, metadata loader, metadata validator or Studio-specific APIs.
-
-It builds on:
+The immediate target is:
 
 ```text
-v0.8.1  -> model_summary.json
-v0.8.2  -> entity_index.json
-v0.9.0  -> relationship_manifest.json
-v0.10.0 -> stability and compatibility classification
-v0.10.1 -> documentation and published-site consistency
-v0.11.0 -> extensibility boundary contract, no execution
-v0.12.0 -> v1.0 release candidate hardening references
+v1.0.0 - Stable Mission Data Contract
 ```
 
-The current public preview includes:
+The repository now contains the v1.0 candidate documentation and regression-confidence material needed before the final v1.0.0 release alignment:
 
-- Mission Model YAML loading;
-- structural validation;
-- semantic linting;
-- generated Markdown documentation;
-- deterministic scenario execution;
-- optional Payload / IOD Payload Contracts;
-- optional Data Product and Storage Contracts;
-- optional Contact Windows and Downlink Flow Contracts;
-- optional Commandability and Autonomy Contracts;
-- command-declared data product effects;
-- generated payload documentation;
-- generated data product documentation;
-- generated contact/downlink documentation;
-- generated commandability/autonomy documentation;
-- generated data-flow evidence documentation;
-- JSON lint reports;
-- JSON simulation reports with contract-level data-flow evidence;
-- data-flow scenario assertions;
-- RuntimeContract generation;
-- generated C++17 runtime-facing contract bindings;
-- generated C++17 host-build smoke files;
-- GroundContract generation;
-- generated ground contract manifest;
-- generated JSON ground dictionaries;
-- generated CSV ground dictionaries;
-- generated human-reviewable ground Markdown artifacts;
-- `orbitfabric export model-summary`;
-- generated `model_summary.json` contract introspection report;
-- `orbitfabric export entity-index`;
-- generated `entity_index.json` entity index report;
-- `orbitfabric export relationship-manifest`;
-- generated `relationship_manifest.json` candidate relationship report;
-- stability and compatibility classification references;
-- Extensibility Boundary Contract reference documentation;
-- ADR-0015 for the extensibility boundary;
-- release compatibility policy;
-- v1.0 candidate surface inventory;
-- golden output and regression confidence policy;
-- v1.0 compatibility and migration notes;
-- a clean-room synthetic `demo-3u` mission.
+```text
+v1.0 Stable Surface Decision
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes
+v1.0 golden signatures for selected Core-owned structured surfaces
+```
 
-## Core Idea
+These additions clarify the proposed v1.0 posture.
+
+They do not change the package version, add Mission Model behavior, add YAML fields, add CLI behavior, add JSON report fields, add generated Core surfaces, add runtime behavior, add ground behavior, introduce schema migration tooling, publish JSON Schema, add security enforcement semantics, add plugin discovery, add plugin loading, add plugin execution or create a tool-specific integration layer.
+
+## Core idea
 
 ```text
 Mission Model
@@ -96,7 +54,10 @@ Mission Model
   -> Core-owned relationship manifest surfaces
   -> stability and compatibility classification
   -> extensibility boundary contract
-  -> v1.0 release candidate hardening references
+  -> v1.0 stable surface decision
+  -> v1.0 demo evidence chain
+  -> v1.0 compatibility and migration posture
+  -> v1.0 golden signatures for selected Core-owned structured surfaces
 ```
 
 The current Core-owned structured surface chain is:
@@ -107,25 +68,15 @@ entity_index.json           -> entity navigation
 relationship_manifest.json  -> relationship navigation
 ```
 
-The extensibility boundary rule is:
+The current v1.0 candidate posture is:
 
 ```text
 Mission Model remains the source of truth.
 Core owns Mission Data Contract semantics.
-Extensions consume Core-owned structured surfaces.
-Extension-owned outputs remain distinguishable from Core-owned outputs.
-Extensions must not override Core semantics.
-Execution is out of scope.
-```
-
-The v0.12.0 hardening rule is:
-
-```text
-Review candidate v1.0 surfaces.
-Define confidence policy before adding golden baselines.
-Document compatibility and migration decisions before stabilization.
-Remove ambiguity before declaring a stable Mission Data Contract.
-Do not broaden OrbitFabric.
+Core-owned structured surfaces are derived from the validated Mission Model.
+Downstream tools consume Core-owned structured surfaces.
+Generated runtime-facing and ground-facing artifacts remain reproducible and disposable unless explicitly classified otherwise.
+Plugin execution remains out of scope.
 ```
 
 OrbitFabric is not a flight software framework, a ground segment or a spacecraft dynamics simulator.
@@ -138,4 +89,12 @@ Generated ground integration artifacts are not ground software.
 
 Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.
 
-Compatibility classification references, v0.12.0 hardening references and the Extensibility Boundary Contract are not schema migration tooling, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or a v1.0 stability guarantee.
+Compatibility references, v1.0 candidate references and the Extensibility Boundary Contract are not schema migration tooling, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or tool-specific integrations.
+
+The v1.0 golden signatures protect selected contract-significant fields of existing Core-owned structured surfaces.
+
+They do not freeze full generated JSON files, absolute paths, human-oriented output, Markdown wording, generated runtime bindings, generated ground dictionaries or disposable artifact formatting.
+
+The v1.0 demo evidence chain proves Mission Data Contract continuity from one validated Mission Model across scenario evidence, generated review artifacts and Core-owned structured surfaces.
+
+It does not prove flight readiness, ground readiness, protocol compliance, tool-specific integration, security enforcement or operational completeness.


### PR DESCRIPTION
## Summary

Aligns the high-visibility public documentation claims with the current v1.0 candidate posture.

This first focused pass updates:

- `docs/index.md`;
- `docs/ROADMAP.md`;
- `CHANGELOG.md`.

The change makes the public homepage and roadmap reflect that, after v0.12.0, the repository now contains:

- v1.0 Stable Surface Decision;
- v1.0 golden signatures for selected Core-owned structured surfaces;
- v1.0 Demo Evidence Chain;
- v1.0 Compatibility and Migration Notes aligned to the current candidate posture.

## Mission Data Contract impact

No Mission Data Contract semantic impact.

This PR does not add, remove or rename Mission Model fields, model domains, controlled values, reference rules, lint diagnostics, scenario expectations, JSON report fields, generated Core surfaces or CLI behavior.

## Architectural Boundary

Documentation-only claim alignment.

This PR does not introduce:

- new Mission Model semantics;
- new YAML fields;
- new CLI behavior;
- new JSON report fields;
- new generated artifacts;
- new tests;
- version bump;
- release notes;
- tag;
- GitHub release;
- schema migration tooling;
- JSON Schema publication;
- XTCE export;
- Yamcs integration;
- OpenC3 integration;
- F Prime mapping;
- cFS integration;
- CCSDS/PUS/CFDP implementation;
- security enforcement semantics;
- plugin discovery, loading or execution;
- relationship graph behavior;
- runtime behavior;
- ground behavior;
- Studio-specific API.

## Scope note

This is the first focused public-claim alignment pass.

It intentionally avoids editing every documentation page in one PR. README, Architecture, Project Charter, Quickstart and Development Guide can be aligned in follow-up PRs to keep review and CI risk controlled.

## Validation

Not run locally in this environment.

Expected checks:

```text
ruff check .
pytest
mkdocs build --strict
```

The primary relevant check is `mkdocs build --strict`.