### PR TITLE
docs: align quickstart and development with v1 candidate posture

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,31 @@
 
 This document explains how to work on OrbitFabric locally.
 
+OrbitFabric is currently released at:
+
+```text
+v0.12.0 - v1.0 Release Candidate Hardening
+```
+
+The immediate target is:
+
+```text
+v1.0.0 - Stable Mission Data Contract
+```
+
+After v0.12.0, the repository contains the v1.0 candidate alignment material needed before final release preparation:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+This does not mean v1.0.0 has already been released.
+
+Development work before v1.0.0 must preserve the narrow Mission Data Contract scope.
+
 ---
 
 ## Requirements
@@ -75,7 +100,7 @@ mkdocs build --strict -> passing
 
 ---
 
-## Verify the Current v0.12.0 Slice
+## Verify the Current Candidate State
 
 Run mission lint:
 
@@ -84,42 +109,29 @@ orbitfabric lint examples/demo-3u/mission/ \
   --json generated/reports/lint_report.json
 ```
 
-Export the Core-owned model summary report:
+Export the Core-owned structured surfaces:
 
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
-```
 
-Export the Core-owned entity index report:
-
-```bash
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
-```
 
-Export the Core-owned relationship manifest report:
-
-```bash
 orbitfabric export relationship-manifest examples/demo-3u/mission/ \
   --json generated/reports/relationship_manifest.json
 ```
 
-Review the compatibility, extensibility and v1.0 hardening references, which remain the current documentation foundation before v1.0.0:
+Review the v1.0 candidate references:
 
 ```text
-Stability and Compatibility Contract
-Mission Model Stability Contract
-CLI Contract v1 Preview
-Generated Surfaces Stability
-Extensibility Boundary Contract
 v1.0 Candidate Surface Inventory
+v1.0 Stable Surface Decision
+v1.0 Demo Evidence Chain
 Golden Output and Regression Confidence Policy
 v1.0 Compatibility and Migration Notes
-Lint Rule Code Stability
-JSON Report Compatibility
-Scenario Evidence Stability
 Release Compatibility Policy
+Extensibility Boundary Contract
 ```
 
 Generate documentation:
@@ -135,15 +147,10 @@ orbitfabric gen data-flow examples/demo-3u/mission/ \
   --output-file generated/docs/data_flow.md
 ```
 
-Generate runtime-facing contract bindings:
+Generate runtime-facing contract bindings and validate the host-build smoke target:
 
 ```bash
 orbitfabric gen runtime examples/demo-3u/mission/
-```
-
-Validate the generated C++17 host-build smoke target:
-
-```bash
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
 ```
@@ -154,17 +161,13 @@ Generate ground-facing integration artifacts:
 orbitfabric gen ground examples/demo-3u/mission/
 ```
 
-Run the battery-low recovery scenario:
+Run the demo scenarios:
 
 ```bash
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
   --json generated/reports/battery_low_during_payload_report.json \
   --log generated/logs/battery_low_during_payload.log
-```
 
-Run the data-flow evidence scenario:
-
-```bash
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
   --json generated/reports/payload_data_flow_evidence_report.json \
   --log generated/logs/payload_data_flow_evidence.log
@@ -183,63 +186,6 @@ gen runtime                  -> Result: PASSED
 cmake build                  -> passing
 gen ground                   -> Result: PASSED
 sim                          -> Result: PASSED
-```
-
-The generated Core-owned structured reports should include:
-
-```text
-generated/reports/model_summary.json
-generated/reports/entity_index.json
-generated/reports/relationship_manifest.json
-```
-
-The generated mission documentation should include:
-
-```text
-generated/docs/telemetry.md
-generated/docs/commands.md
-generated/docs/events.md
-generated/docs/faults.md
-generated/docs/modes.md
-generated/docs/packets.md
-generated/docs/payloads.md
-generated/docs/data_products.md
-generated/docs/contacts.md
-generated/docs/commandability.md
-generated/docs/data_flow.md
-```
-
-The generated runtime-facing contract bindings should include:
-
-```text
-generated/runtime/cpp17/runtime_contract_manifest.json
-generated/runtime/cpp17/include/orbitfabric/generated/mission_ids.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_enums.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_registries.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/command_args.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/adapter_interfaces.hpp
-generated/runtime/cpp17/CMakeLists.txt
-generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
-```
-
-The generated ground-facing integration artifacts should include:
-
-```text
-generated/ground/generic/ground_contract_manifest.json
-generated/ground/generic/README.md
-generated/ground/generic/dictionaries/telemetry_dictionary.json
-generated/ground/generic/dictionaries/command_dictionary.json
-generated/ground/generic/dictionaries/event_dictionary.json
-generated/ground/generic/dictionaries/fault_dictionary.json
-generated/ground/generic/dictionaries/data_product_dictionary.json
-generated/ground/generic/dictionaries/packet_dictionary.json
-generated/ground/generic/csv/telemetry_dictionary.csv
-generated/ground/generic/csv/command_dictionary.csv
-generated/ground/generic/csv/event_dictionary.csv
-generated/ground/generic/csv/fault_dictionary.csv
-generated/ground/generic/csv/data_product_dictionary.csv
-generated/ground/generic/csv/packet_dictionary.csv
-generated/ground/generic/ground_dictionaries.md
 ```
 
 ---
@@ -265,28 +211,69 @@ The source of truth is:
 
 ```text
 examples/demo-3u/mission/*.yaml
-examples/demo-3u/mission/payloads.yaml
-examples/demo-3u/mission/data_products.yaml
-examples/demo-3u/mission/contacts.yaml
-examples/demo-3u/mission/commandability.yaml
 examples/demo-3u/scenarios/*.yaml
 ```
 
-Generated runtime-facing contract bindings are disposable.
+Generated runtime-facing contract bindings are disposable unless explicitly classified otherwise.
 
-Generated ground-facing integration artifacts are disposable.
+Generated ground-facing integration artifacts are disposable unless explicitly classified otherwise.
 
-Generated contract introspection reports are disposable.
+Generated Markdown documentation is disposable.
 
-Generated entity index reports are disposable.
+Plain-text logs are human-oriented and non-contractual.
 
-Generated relationship manifest reports are disposable.
+Core-owned structured surfaces are derived from the validated Mission Model.
 
-Current v0.12.0 hardening references are documentation and review surfaces.
+The current selected Core-owned structured surfaces are:
 
-They are not generated artifacts, not new Mission Model semantics and not stable v1.0 guarantees.
+```text
+model_summary.json
+entity_index.json
+relationship_manifest.json
+```
+
+The v1.0 golden signatures protect selected contract-significant fields of these surfaces.
+
+They do not freeze full generated JSON files, absolute paths, human-oriented output, Markdown wording, generated runtime bindings, generated ground dictionaries or disposable artifact formatting.
 
 User implementation code and downstream integration code must live outside `generated/`.
+
+---
+
+## Development Order
+
+For new behavior, follow this order:
+
+```text
+1. update or define the Mission Model semantics
+2. add or update lint rules
+3. add tests
+4. update generated docs or reports if needed
+5. update runtime-facing, ground-facing, introspection, entity-index or relationship exporters if needed
+6. update user-facing documentation
+```
+
+Before v1.0.0, any change to a selected stable candidate surface must include explicit compatibility or migration notes.
+
+Do not add simulator behavior that is not represented in the Mission Model.
+
+Do not add generated artifacts that bypass validation.
+
+Do not add runtime or ground integration artifacts before the relevant contract layer exists.
+
+Do not add plugin execution mechanisms before Core-owned structured surfaces and plugin boundaries are explicitly defined.
+
+Do not turn the Extensibility Boundary Contract into metadata schema, plugin discovery, plugin loading or plugin execution without a separate architectural review.
+
+Do not introduce schema migration tooling, JSON Schema publication, security enforcement semantics or Mission Model security domains before v1.0.0.
+
+Do not put user code inside generated runtime bindings.
+
+Do not present generated ground artifacts as live ground behavior.
+
+Do not present Core-owned structured surfaces as relationship graphs, dependency graphs, plugin APIs, runtime behavior, ground behavior or Studio-specific APIs.
+
+Do not present v1.0 candidate governance references as released v1.0.0 compatibility guarantees.
 
 ---
 
@@ -305,47 +292,6 @@ mkdocs serve
 ```
 
 The public site is deployed by the GitHub Pages workflow after pushes to `main`.
-
----
-
-## Recommended Development Order
-
-For new behavior, follow this order:
-
-```text
-1. update or define the Mission Model semantics
-2. add or update lint rules
-3. add tests
-4. update generated docs or reports if needed
-5. update runtime-facing, ground-facing, introspection, entity-index or relationship exporters if needed
-6. update user-facing documentation
-```
-
-Do not add simulator behavior that is not represented in the Mission Model.
-
-Do not add generated artifacts that bypass validation.
-
-Do not add runtime or ground integration artifacts before the relevant contract layer exists.
-
-Do not add plugin execution mechanisms before Core-owned structured surfaces and plugin boundaries are explicitly defined.
-
-Do not turn the Extensibility Boundary Contract into metadata schema, plugin discovery, plugin loading or plugin execution without a separate architectural review.
-
-Do not introduce golden baselines without an explicit golden-output scope and acceptance criteria.
-
-Do not introduce schema migration tooling, JSON Schema publication, security enforcement semantics or Mission Model security domains during v0.12.0 release candidate hardening.
-
-Do not put user code inside generated runtime bindings.
-
-Do not present generated ground artifacts as live ground behavior.
-
-Do not present contract introspection reports as relationship graphs or Studio-specific APIs.
-
-Do not present entity index reports as relationship graphs, dependency graphs, plugin APIs or Studio-specific APIs.
-
-Do not present relationship manifest reports as graph engines, dependency graphs, runtime routing tables, ground routing tables, plugin APIs or Studio-specific APIs.
-
-Do not present compatibility classification references or v0.12.0 hardening references as implementation changes, schema migration tooling, runtime behavior, ground behavior, plugin execution or a stable v1.0 guarantee.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,43 +1,33 @@
 # Quickstart
 
-This guide shows how to run the current OrbitFabric development preview locally.
+This guide shows how to run OrbitFabric locally from the current repository baseline.
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-The current vertical slice demonstrates:
+The current released baseline is:
 
 ```text
-Mission Model YAML
-  -> structural validation
-  -> semantic lint
-  -> generated Markdown docs
-  -> mission inspection
-  -> scenario validation
-  -> deterministic scenario execution
-  -> Payload Contract documentation
-  -> Data Product Contract documentation
-  -> Contact and Downlink Contract documentation
-  -> Commandability and Autonomy Contract documentation
-  -> Data Flow Evidence documentation
-  -> RuntimeContract generation
-  -> C++17 runtime-facing contract bindings
-  -> C++17 host-build smoke validation
-  -> GroundContract generation
-  -> ground-facing JSON dictionaries
-  -> ground-facing CSV dictionaries
-  -> human-reviewable ground Markdown artifacts
-  -> model_summary.json contract introspection report
-  -> entity_index.json entity index report
-  -> relationship_manifest.json candidate relationship report
-  -> stability and compatibility classification references
-  -> Extensibility Boundary Contract reference
-  -> v1.0 candidate surface inventory
-  -> golden output and regression confidence policy
-  -> v1.0 compatibility and migration notes
-  -> JSON lint reports
-  -> JSON simulation reports with data-flow evidence
-  -> simulation logs
+v0.12.0 - v1.0 Release Candidate Hardening
 ```
+
+The immediate target is:
+
+```text
+v1.0.0 - Stable Mission Data Contract
+```
+
+After v0.12.0, the repository contains the v1.0 candidate alignment material needed before final release preparation:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+This does not mean v1.0.0 has already been released.
+
+It does not introduce new Mission Model semantics, YAML fields, CLI behavior, JSON report fields, generated Core surfaces, runtime behavior, ground behavior, schema migration tooling, JSON Schema publication, plugin discovery, plugin loading, plugin execution or tool-specific integrations.
 
 OrbitFabric is not a flight software framework, not a ground segment and not a spacecraft dynamics simulator.
 
@@ -45,9 +35,7 @@ Generated runtime-facing contract bindings are not flight software.
 
 Generated ground integration artifacts are not ground software.
 
-Contract introspection, entity index and relationship manifest surfaces are not plugin APIs, graph engines or Studio-specific APIs.
-
-Compatibility classification references, v0.12.0 hardening references and the Extensibility Boundary Contract are not runtime behavior, ground behavior, schema migration tooling, plugin discovery, plugin loading, plugin execution or a v1.0 stability guarantee.
+Core-owned structured surfaces are not plugin APIs, graph engines or Studio-specific APIs.
 
 ---
 
@@ -112,7 +100,7 @@ orbitfabric --version
 orbitfabric --help
 ```
 
-Expected version:
+Expected current package version:
 
 ```text
 orbitfabric 0.12.0
@@ -120,7 +108,7 @@ orbitfabric 0.12.0
 
 ---
 
-## 6. Run code quality checks
+## 6. Run core checks
 
 ```bash
 ruff check .
@@ -184,23 +172,13 @@ orbitfabric lint examples/demo-3u/mission/ \
 
 ## 10. Export Core-owned structured surfaces
 
-Generate the domain-level model summary:
-
 ```bash
 orbitfabric export model-summary examples/demo-3u/mission/ \
   --json generated/reports/model_summary.json
-```
 
-Generate the entity-level index:
-
-```bash
 orbitfabric export entity-index examples/demo-3u/mission/ \
   --json generated/reports/entity_index.json
-```
 
-Generate the relationship-level manifest:
-
-```bash
 orbitfabric export relationship-manifest examples/demo-3u/mission/ \
   --json generated/reports/relationship_manifest.json
 ```
@@ -213,37 +191,21 @@ generated/reports/entity_index.json
 generated/reports/relationship_manifest.json
 ```
 
-`model_summary.json` answers:
+These surfaces answer:
 
 ```text
-What contract domains are present in this mission?
+model_summary.json          -> What contract domains are present?
+entity_index.json           -> What contract entities are defined?
+relationship_manifest.json  -> How are indexed contract entities related?
 ```
 
-`entity_index.json` answers:
-
-```text
-What contract entities are defined in this mission?
-```
-
-`relationship_manifest.json` answers:
-
-```text
-How are indexed mission contract entities related?
-```
-
-These surfaces are Core-owned, read-only and derived from the loaded Mission Model.
+They are Core-owned, read-only and derived from the validated Mission Model.
 
 They do not expose plugin execution, graph engines, Studio-specific APIs, runtime behavior or ground behavior.
 
 ---
 
-## 11. Review stability, compatibility, extensibility and v1.0 hardening references
-
-v0.10.0 adds compatibility classification references for the path toward v1.0.0.
-
-v0.11.0 adds the Extensibility Boundary Contract before any plugin execution exists.
-
-v0.12.0 adds release candidate hardening references before the stable v1.0.0 decision.
+## 11. Review v1.0 candidate references
 
 Key references include:
 
@@ -254,6 +216,8 @@ CLI Contract v1 Preview
 Generated Surfaces Stability
 Extensibility Boundary Contract
 v1.0 Candidate Surface Inventory
+v1.0 Stable Surface Decision
+v1.0 Demo Evidence Chain
 Golden Output and Regression Confidence Policy
 v1.0 Compatibility and Migration Notes
 Lint Rule Code Stability
@@ -262,9 +226,9 @@ Scenario Evidence Stability
 Release Compatibility Policy
 ```
 
-These references classify existing public and preview surfaces, define how future extension-owned outputs must remain distinguishable from Core-owned outputs and document the v1.0 hardening path.
+These references classify existing surfaces, define the extensibility boundary, record the current v1.0 candidate posture and explain what is selected, preview, disposable, internal or out of scope.
 
-They do not introduce new Mission Model semantics, CLI behavior beyond version reporting, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, golden files, snapshot tests, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or a stable v1.0 compatibility guarantee.
+They do not introduce new Mission Model semantics, CLI behavior beyond version reporting, JSON report fields, generated surfaces, lint diagnostics, scenario behavior, migration tooling, runtime behavior, ground behavior, plugin discovery, plugin loading, plugin execution or tool-specific integrations.
 
 ---
 
@@ -303,8 +267,6 @@ They do not implement onboard behavior.
 
 ## 14. Validate the generated C++17 host-build smoke target
 
-After generating runtime bindings, run:
-
 ```bash
 cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
 cmake --build generated/runtime/cpp17/build
@@ -336,31 +298,10 @@ They do not implement a live ground segment, decoder, telemetry archive, databas
 
 ---
 
-## 16. Run the battery-low demo scenario
+## 16. Run demo scenarios
 
 ```bash
 orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
-```
-
-Expected result:
-
-```text
-Result: PASSED
-```
-
-Generate both JSON report and timeline log:
-
-```bash
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
-  --json generated/reports/battery_low_during_payload_report.json \
-  --log generated/logs/battery_low_during_payload.log
-```
-
----
-
-## 17. Run the data-flow evidence scenario
-
-```bash
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
 ```
 
@@ -370,15 +311,19 @@ Expected result:
 Result: PASSED
 ```
 
-Generate both JSON report and timeline log:
+Generate JSON reports and timeline logs:
 
 ```bash
+orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
+  --json generated/reports/battery_low_during_payload_report.json \
+  --log generated/logs/battery_low_during_payload.log
+
 orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
   --json generated/reports/payload_data_flow_evidence_report.json \
   --log generated/logs/payload_data_flow_evidence.log
 ```
 
-The JSON report includes a `data_flow_evidence` section tracing the declared contract path:
+The data-flow evidence report traces the declared contract path:
 
 ```text
 command -> data product -> storage intent -> downlink intent -> downlink flow -> contact window
@@ -386,37 +331,27 @@ command -> data product -> storage intent -> downlink intent -> downlink flow ->
 
 ---
 
-## 18. What this proves
+## 17. What this proves
 
 The current demo proves that OrbitFabric can:
 
 - load a multi-file YAML Mission Model;
-- load optional `payloads.yaml`, `data_products.yaml`, `contacts.yaml` and `commandability.yaml` domains;
 - validate Mission Model structure;
 - run semantic lint rules;
-- generate Markdown documentation;
+- generate documentation;
 - inspect a Mission Model summary;
-- export a model summary from the loaded Mission Model;
-- export an entity index from the loaded Mission Model;
-- export a relationship manifest from the loaded Mission Model;
-- classify public, preview, candidate, generated and internal compatibility surfaces;
-- document the extensibility boundary before plugin execution;
-- document the v1.0 release candidate hardening path;
+- export Core-owned structured surfaces;
 - validate scenarios without executing them;
-- execute deterministic operational sequences;
+- execute deterministic host-side scenario evidence;
 - record contract-level data-flow evidence;
-- assert command-to-data-product-to-contact evidence in a scenario;
-- produce JSON reports and logs;
-- build a RuntimeContract from the validated Mission Model;
-- generate deterministic C++17 runtime-facing contract bindings;
-- validate generated C++17 contract bindings with a host-build smoke target;
-- build a GroundContract from the validated Mission Model;
-- generate deterministic JSON, CSV and Markdown ground-facing contract artifacts;
-- export deterministic Core-owned structured surfaces for downstream inspection tools.
+- generate runtime-facing contract bindings;
+- validate generated C++17 bindings with a host-build smoke target;
+- generate ground-facing contract artifacts;
+- protect selected Core-owned structured surface fields with golden signatures.
 
 ---
 
-## 19. What this does not prove
+## 18. What this does not prove
 
 The current demo does not prove:
 
@@ -436,19 +371,16 @@ The current demo does not prove:
 - telemetry archive behavior;
 - database behavior;
 - operator console behavior;
-- orbital, attitude, power or thermal dynamics;
 - command dispatch runtime behavior;
 - telemetry polling runtime behavior;
 - HAL or RTOS integration;
 - relationship graph behavior;
 - dependency graph behavior;
-- security enforcement behavior;
 - plugin API behavior;
 - plugin discovery behavior;
 - plugin loading behavior;
 - plugin execution behavior;
-- metadata schema behavior;
-- v1.0 compatibility guarantee;
+- released v1.0.0 compatibility;
 - qualification for operational spacecraft use.
 
-Those are intentionally outside the current development preview scope.
+Those are intentionally outside the current scope.


### PR DESCRIPTION
## Summary

Aligns `docs/QUICKSTART.md` and `docs/DEVELOPMENT.md` with the current v1.0 candidate posture.

The updated docs now clarify that:

- `v0.12.0` remains the current released baseline;
- `v1.0.0` remains the immediate target;
- v1.0 candidate alignment material is present but does not mean v1.0.0 has already been released;
- Core-owned structured surfaces are derived from the validated Mission Model;
- selected Core-owned structured surface fields are protected by golden signatures;
- generated runtime-facing and ground-facing artifacts remain disposable unless explicitly classified otherwise;
- plugin execution remains out of scope.

The command flow is preserved and made less repetitive.

## Mission Data Contract impact

No Mission Data Contract semantic impact.

This PR does not add, remove or rename Mission Model fields, model domains, controlled values, reference rules, lint diagnostics, scenario expectations, JSON report fields, generated Core surfaces or CLI behavior.

## Architectural Boundary

Documentation-only guide alignment.

This PR does not introduce:

- new Mission Model semantics;
- new YAML fields;
- new CLI behavior;
- new JSON report fields;
- new generated artifacts;
- new tests;
- version bump;
- release notes;
- tag;
- GitHub release;
- schema migration tooling;
- JSON Schema publication;
- XTCE export;
- Yamcs integration;
- OpenC3 integration;
- F Prime mapping;
- cFS integration;
- CCSDS/PUS/CFDP implementation;
- security enforcement semantics;
- plugin discovery, loading or execution;
- relationship graph behavior;
- runtime behavior;
- ground behavior;
- Studio-specific API.

## Scope note

This PR intentionally updates only:

- `docs/QUICKSTART.md`;
- `docs/DEVELOPMENT.md`.

`ARCHITECTURE.md` and `PROJECT_CHARTER.md` should be aligned in a later dedicated PR.

## Validation

Not run locally in this environment.

Expected checks:

```text
ruff check .
pytest
mkdocs build --strict
```

The primary relevant check is `mkdocs build --strict`.