### PR TITLE
docs: align architecture and charter with v1 candidate posture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Architecture
 
-Version: 0.12.0  
-Status: Development preview  
-Scope: Mission Data Contract architecture through v1.0 Release Candidate Hardening
+Version: 0.12.0 to v1.0 candidate path  
+Status: v1.0 candidate alignment  
+Scope: Mission Data Contract architecture, Core-owned structured surfaces and v1.0 stable-surface preparation
 
 ---
 
@@ -16,7 +16,52 @@ Its architecture is centered on one primary artifact:
 
 The Mission Data Contract is expressed as a structured Mission Model.
 
-It defines mission data, operational behavior, payload contracts, data products, storage intent, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, stability and compatibility classifications, extensibility boundary rules, v1.0 release candidate hardening references, documentation and scenario evidence from one source of truth.
+The Mission Model remains the source of truth.
+
+OrbitFabric validates that model, executes deterministic host-side scenario evidence, generates documentation, generates runtime-facing and ground-facing contract artifacts and exports Core-owned structured surfaces for downstream inspection.
+
+The current released baseline is:
+
+```text
+v0.12.0 - v1.0 Release Candidate Hardening
+```
+
+The immediate target is:
+
+```text
+v1.0.0 - Stable Mission Data Contract
+```
+
+After v0.12.0, the repository contains v1.0 candidate alignment material:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+This does not mean v1.0.0 has already been released.
+
+It means the narrow stable surface has been selected, protected in part by golden signatures, demonstrated through the demo evidence chain and documented through compatibility and migration posture references.
+
+---
+
+## 2. Architectural Role
+
+OrbitFabric is the contract layer between:
+
+```text
+mission design
+onboard software
+simulation
+testing
+documentation
+runtime-facing integration
+ground integration
+downstream inspection tools
+future extension-owned outputs
+```
 
 OrbitFabric is not designed as:
 
@@ -36,155 +81,89 @@ plugin discovery mechanism
 plugin loading mechanism
 plugin execution platform
 security enforcement framework
+schema migration tooling
+JSON Schema publication layer
+tool-specific integration layer
+released v1.0.0 compatibility guarantee
 ```
 
 Its architectural role is:
 
-> define, validate, simulate, document, introspect, index, relate, classify, bound extensibility, harden release-candidate surfaces and generate contract-facing artifacts between mission design, onboard software, tests, documentation, simulation, runtime-facing bindings, ground-facing integration, downstream inspection tools and future extension-owned outputs.
-
-The current architectural baseline is `v0.12.0 - v1.0 Release Candidate Hardening`.
-
-v0.8.1 introduced the first Core-owned read-only model summary surface derived from the loaded Mission Model.
-
-v0.8.2 introduced the first Core-owned read-only entity index surface derived from the loaded Mission Model.
-
-v0.9.0 introduced the first Core-owned read-only relationship manifest surface derived from explicit loaded Mission Model fields.
-
-v0.10.0 introduced the first stability and compatibility classification baseline for public, preview, candidate, generated and internal surfaces before v1.0.0.
-
-v0.11.0 introduced the first extensibility boundary contract before any plugin execution exists.
-
-v0.12.0 introduces release candidate hardening references before the stable v1.0.0 Mission Data Contract decision.
+> define, validate, simulate, document, introspect, index, relate, classify, govern compatibility and generate contract-facing artifacts from one Mission Data Contract.
 
 ---
 
-## 2. Architectural Principles
+## 3. Architectural Principles
 
-### 2.1 Mission Model First
+### 3.1 Mission Model First
 
 The Mission Model is the source of truth.
 
-Runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulation behavior, generated documentation, compatibility classifications, extensibility boundary rules and v1.0 hardening references must derive from or describe the Mission Model and its Core-owned surfaces.
+Runtime-facing bindings, ground-facing artifacts, Core-owned structured surfaces, simulation evidence, generated documentation, compatibility classifications, extensibility rules and v1.0 candidate references must derive from or describe the Mission Model.
 
-No important mission behavior should live only in Python code, documentation, generated files, simulator internals, plugin outputs, extension-owned outputs or downstream tools.
+No important mission behavior should live only in Python code, generated files, documentation, simulator internals, extension-owned outputs, plugin outputs or downstream tools.
 
-### 2.2 Contract Before Runtime
+### 3.2 Contract Before Runtime
 
 OrbitFabric does not implement a flight runtime or a ground runtime.
 
 It implements a host-side toolchain that proves and hardens the Mission Data Contract.
 
-v0.7.0 introduced generated runtime-facing contract bindings, not onboard behavior.
+Generated runtime-facing artifacts are contract bindings, not onboard behavior.
 
-v0.8.0 introduced generated ground-facing contract exports, not ground behavior.
+Generated ground-facing artifacts are contract exports, not ground behavior.
 
-v0.8.1 introduced a Core-owned model summary report, not relationship graphs or plugins.
+Core-owned structured surfaces are inspection and integration surfaces, not runtime services.
 
-v0.8.2 introduced a Core-owned entity index report, not relationship graphs or plugins.
+### 3.3 Core Surfaces Before Plugins
 
-v0.9.0 introduced a Core-owned relationship manifest report, not graph execution, plugin execution or Studio-specific behavior.
+Downstream tools and future extensions must consume Core-owned structured surfaces.
 
-v0.10.0 introduced compatibility classification references, not schema migration tooling, plugin execution, runtime behavior, ground behavior or a stable v1.0 guarantee.
+They must not reconstruct Mission Data Contract semantics from raw YAML, generated files, terminal output, logs, UI state or private assumptions.
 
-v0.11.0 introduced an extensibility boundary contract, not metadata schema, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior or Studio-specific APIs.
-
-v0.12.0 introduces release candidate hardening references, not golden files, snapshot tests, schema migration tooling, JSON Schema publication, security enforcement, runtime behavior, ground behavior or a stable v1.0 guarantee.
-
-### 2.3 Chain Before Generated Artifacts
-
-OrbitFabric models the Mission Data Chain before generating downstream artifacts.
-
-The current chain is:
+The current Core-owned structured surface chain is:
 
 ```text
-Payload behavior
-        -> Data Product Contract
-        -> Storage Intent
-        -> Downlink Intent
-        -> Contact Windows and Downlink Flow Contracts
-        -> Commandability and Autonomy Contracts
-        -> End-to-End Mission Data Flow Evidence
-        -> Runtime-Facing Contract Bindings
-        -> Ground-Facing Integration Artifacts
-        -> Contract Introspection Surface
-        -> Entity Index Surface
-        -> Relationship Manifest Surface
-        -> Stability and Compatibility Classification
-        -> Extensibility Boundary Contract
-        -> v1.0 Release Candidate Hardening References
+model_summary.json          -> What contract domains are present?
+entity_index.json           -> What contract entities are defined?
+relationship_manifest.json  -> How are indexed contract entities related?
 ```
 
-### 2.4 Generated Bindings, Exports, Reports, Classifications, Boundaries and Hardening References Are Not Behavior
+These surfaces are derived from the validated Mission Model.
 
-Generated Runtime Skeletons are contract bindings.
+They are not a second source of truth.
 
-Generated Ground Integration Artifacts are contract exports.
+### 3.4 Generated Artifacts Are Disposable Unless Classified Otherwise
 
-Generated Contract Introspection reports are Core-owned read-only summaries.
+Generated files are reproducible outputs.
 
-Generated Entity Index reports are Core-owned read-only entity indexes.
+Users must not place handwritten implementation code inside generated output directories.
 
-Generated Relationship Manifest reports are Core-owned read-only relationship records.
+The following remain disposable unless explicitly classified otherwise:
 
-Stability and compatibility references classify public, preview, candidate, generated and internal surfaces.
+```text
+generated Markdown documentation
+generated runtime-facing bindings
+generated ground-facing dictionaries
+plain-text logs
+disposable generated formatting
+```
 
-The Extensibility Boundary Contract defines how future extension-owned outputs may relate to Core-owned semantics without becoming a second source of truth.
+The v1.0 golden signatures protect selected contract-significant fields of existing Core-owned structured surfaces.
 
-The v0.12.0 hardening references define how candidate v1.0 surfaces, golden-output decisions and compatibility or migration notes should be reviewed before v1.0.0.
+They do not freeze full generated JSON files, absolute paths, human-oriented output, Markdown wording, generated runtime bindings, generated ground dictionaries or disposable artifact formatting.
 
-These surfaces and references may expose identifiers, descriptors, typed command argument structures, static registries, abstract interfaces, manifests, dictionaries, review documents, domain-level model summaries, entity-level records, relationship records, compatibility expectations, extensibility boundary expectations and hardening expectations.
+### 3.5 Compatibility Must Be Explicit
 
-They must not implement command dispatch, queues, scheduling, hardware access, telemetry polling, fault handling runtime, storage runtime, downlink runtime, decoder runtime, database behavior, operator workflows, live ground operations, relationship graph behavior, plugin discovery, plugin loading, plugin execution, schema migration tooling, JSON Schema publication or security enforcement.
+Before v1.0.0, any change to a selected stable candidate surface must include explicit compatibility or migration notes.
 
-### 2.5 Lint as Engineering Judgment
+A surface is not stable only because it exists, is documented, appears in examples or is generated by CI.
 
-`orbitfabric lint` is a core architectural component.
-
-It must detect mission consistency issues, not merely invalid YAML.
-
-A concept that can become operationally ambiguous should have a lint rule before downstream runtime-facing, ground-facing, introspection, entity-index, relationship, compatibility, hardening or extension-owned artifacts depend on it.
-
-### 2.6 Docs from Model
-
-Documentation generated by OrbitFabric must derive from the validated Mission Model.
-
-Generated mission documentation is not the source of truth.
-
-The model is the source of truth.
-
-### 2.7 Scenario-First Operational Testing
-
-Scenarios are structured artifacts.
-
-They describe operational sequences and expected outcomes.
-
-The simulator executes scenarios to validate contract-level behavior.
-
-The simulator is deterministic and host-side.
-
-It is not a real-time onboard runtime.
-
-### 2.8 Downstream Tools Consume, Not Infer
-
-Downstream tools should consume Core-generated structured surfaces.
-
-They must not reconstruct Mission Model semantics from raw YAML, generated files or human-oriented CLI output.
-
-v0.8.1 establishes this principle with `model_summary.json`.
-
-v0.8.2 extends it with `entity_index.json`.
-
-v0.9.0 extends it with `relationship_manifest.json`.
-
-v0.10.0 classifies these and other public surfaces as compatibility-sensitive before v1.0.0.
-
-v0.11.0 extends the same rule to future extension-owned outputs: extensions consume Core-owned surfaces and must not redefine Core semantics.
-
-v0.12.0 reinforces the same rule before v1.0.0: candidate, preview and generated surfaces require explicit stabilization decisions and do not become stable automatically.
+A surface becomes stable only when the v1.0 decision or a later reviewed decision says so.
 
 ---
 
-## 3. High-Level System View
+## 4. High-Level System View
 
 ```text
 OrbitFabric
@@ -197,21 +176,12 @@ OrbitFabric
 │   ├── events
 │   ├── faults
 │   ├── packets
-│   ├── policies
 │   ├── payload contracts
 │   ├── data product contracts
 │   ├── contact/downlink contracts
 │   ├── commandability/autonomy contracts
-│   ├── data-flow evidence contracts
-│   ├── runtime-facing contract binding inputs
-│   ├── ground-facing contract export inputs
-│   ├── contract introspection inputs
-│   ├── entity index inputs
-│   ├── relationship manifest inputs
-│   ├── stability and compatibility classifications
-│   ├── extensibility boundary rules
-│   ├── v1.0 hardening references
-│   └── scenarios
+│   ├── scenario evidence contracts
+│   └── Core-owned structured-surface inputs
 │
 ├── Toolchain
 │   ├── orbitfabric inspect mission
@@ -228,930 +198,156 @@ OrbitFabric
 │
 ├── Model Layer
 ├── Lint Layer
-├── Simulation Layer
+├── Scenario Evidence Layer
 ├── RuntimeContract Layer
 ├── GroundContract Layer
 ├── Export Layer
 ├── Generation Layer
-├── Compatibility Classification Layer
-├── Extensibility Boundary Layer
-└── Release Candidate Hardening Layer
+├── Compatibility Governance Layer
+└── Extensibility Boundary Layer
 ```
 
 ---
 
-## 4. Current Capability Boundary - v0.12.0
+## 5. Current Capability Boundary
 
 OrbitFabric currently includes:
 
 ```text
-Mission Model YAML
+Mission Model YAML loading
 canonical multi-file mission directory
-optional payloads.yaml domain
-optional data_products.yaml domain
-optional contacts.yaml domain
-optional commandability.yaml domain
-Pydantic typed validation
 structural validation
 semantic lint
 scenario loading and reference validation
 host-side deterministic scenario execution
 contract-level data-flow evidence recording
-generated Markdown docs
-JSON lint reports
-JSON scenario reports with data_flow_evidence
-RuntimeContract intermediate model
-orbitfabric gen runtime command
-C++17 runtime-facing contract bindings
-C++17 host-build smoke CMake target
-GroundContract intermediate model
-orbitfabric gen ground command
-generic ground contract manifest
-JSON ground dictionaries
-CSV ground dictionaries
-human-reviewable ground Markdown artifacts
-orbitfabric export model-summary command
-model_summary.json contract introspection report
-orbitfabric export entity-index command
-entity_index.json entity index report
-orbitfabric export relationship-manifest command
-relationship_manifest.json candidate relationship report
-stability and compatibility classification references
-Extensibility Boundary Contract reference
-ADR-0015 extensibility boundary decision
-v1.0 Candidate Surface Inventory
-Golden Output and Regression Confidence Policy
-v1.0 Compatibility and Migration Notes
-release compatibility policy
-synthetic demo mission
+generated Markdown documentation
+generated runtime-facing C++17 contract bindings
+generated runtime host-build smoke target
+generated ground-facing JSON, CSV and Markdown artifacts
+model_summary.json export
+entity_index.json export
+relationship_manifest.json export
+v1.0 stable surface decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 demo evidence chain
+v1.0 compatibility and migration posture
 ```
 
-OrbitFabric currently excludes:
+OrbitFabric currently does not include:
 
 ```text
-flight runtime
-embedded deployment
-hardware drivers
-real onboard storage runtime
-real downlink execution
-downlink runtime
-ground segment
-mission control system
-operator console
-telemetry archive
-telemetry database
-command uplink service
-telecommand transport
-network/session/routing behavior
-binary packet decoder
+flight runtime behavior
+ground runtime behavior
+telemetry polling runtime
+command dispatcher
+scheduler
+HAL
+drivers
+binary telemetry decoder
 binary telecommand encoder
+CCSDS/PUS/CFDP implementation
+XTCE export
 Yamcs integration
 OpenC3 integration
-XTCE compliance
-CCSDS/PUS/CFDP implementation
-flight autonomy runtime
-real recovery runtime
-relationship graph
-dependency graph
-schema migration tooling
-JSON Schema publication
-Mission Model security domain
-security YAML fields
-security enforcement semantics
-metadata schema
-metadata parser
-metadata loader
-metadata validator
-plugin API
+F Prime mapping
+cFS mapping
+relationship graph engine
+dependency graph engine
 plugin discovery
-plugin loader
+plugin loading
 plugin execution
 Studio-specific API
-stable v1.0 compatibility guarantee
+security enforcement semantics
+schema migration tooling
+JSON Schema publication
+released v1.0.0 compatibility status
 ```
-
-These are intentional architectural boundaries.
 
 ---
 
-## 5. Canonical Data Flow
+## 6. v1.0 Candidate Stable Surface
 
-The canonical OrbitFabric flow is:
+The selected v1.0 candidate stable surface is intentionally narrow.
 
-```text
-Mission YAML files
-      │
-      ▼
-Model Loader
-      │
-      ▼
-Typed Mission Model
-      │
-      ├──────────────► Lint Engine ─────────────► Lint Report
-      │
-      ├──────────────► Documentation Generator ─► Markdown Docs
-      │
-      ├──────────────► Scenario Runner ─────────► Simulation Log + Scenario Report
-      │
-      ├──────────────► RuntimeContract Builder ─► Runtime-Facing Contract Bindings
-      │
-      ├──────────────► GroundContract Builder ──► Ground-Facing Integration Artifacts
-      │
-      └──────────────► Export Layer ────────────► Core-Owned Structured Surfaces
-```
-
-The model is loaded once and consumed by multiple downstream layers.
-
-No generator, simulator, exporter, plugin, extension-owned output or downstream tool should independently reinterpret raw YAML.
-
----
-
-## 6. Mission Data Chain View
-
-The current Mission Data Chain view is:
+It includes:
 
 ```text
-Subsystems and payloads
-      │
-      ▼
-Telemetry, commands, events, faults and modes
-      │
-      ▼
-Payload Contracts
-      │
-      ▼
-Data Product Contracts
-      │
-      ▼
-Storage Intent and Downlink Intent
-      │
-      ▼
-Contact Windows and Downlink Flow Contracts
-      │
-      ▼
-Commandability and Autonomy Contracts
-      │
-      ▼
-End-to-End Mission Data Flow Evidence
-      │
-      ▼
-Runtime-Facing Contract Bindings
-      │
-      ▼
-Ground-Facing Integration Artifacts
-      │
-      ▼
-Contract Introspection Surface
-      │
-      ▼
-Entity Index Surface
-      │
-      ▼
-Relationship Manifest Surface
-      │
-      ▼
-Stability and Compatibility Classification
-      │
-      ▼
-Extensibility Boundary Contract
-      │
-      ▼
-v1.0 Release Candidate Hardening References
-```
-
-This is the architectural reason OrbitFabric did not jump directly from payload contracts to plugins.
-
-Plugins, extension-owned outputs and downstream tools are useful only after the mission data chain, Core-owned structured surfaces, compatibility boundaries, extensibility boundaries and release candidate hardening references are explicit enough to consume safely.
-
----
-
-## 7. Command-Line Architecture
-
-The current CLI exposes these primary commands:
-
-```bash
-orbitfabric --version
-orbitfabric lint examples/demo-3u/mission/
-orbitfabric gen docs examples/demo-3u/mission/
-orbitfabric gen data-flow examples/demo-3u/mission/
-orbitfabric gen runtime examples/demo-3u/mission/
-orbitfabric gen ground examples/demo-3u/mission/
-orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
-orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
-orbitfabric export relationship-manifest examples/demo-3u/mission/ --json generated/reports/relationship_manifest.json
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
-orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
-orbitfabric inspect mission examples/demo-3u/mission/
-orbitfabric validate scenario examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
-```
-
-Conceptual CLI structure:
-
-```text
-orbitfabric
-├── lint <mission-dir>
-├── gen
-│   ├── docs <mission-dir>
-│   ├── data-flow <mission-dir>
-│   ├── runtime <mission-dir>
-│   └── ground <mission-dir>
-├── export
-│   ├── model-summary <mission-dir>
-│   ├── entity-index <mission-dir>
-│   └── relationship-manifest <mission-dir>
-├── sim <scenario-file>
-├── inspect
-│   └── mission <mission-dir>
-└── validate
-    └── scenario <scenario-file>
-```
-
-Future commands may include tool-specific exporters and plugin-related commands only after their semantics, trust model and boundaries are implemented and tested explicitly.
-
-v0.12.0 does not add extension commands.
-
----
-
-## 8. RuntimeContract Architecture
-
-RuntimeContract is the intermediate model for runtime-facing generation.
-
-The required dependency direction is:
-
-```text
-Mission Model
-        -> validation and linting
-        -> RuntimeContract builder
-        -> profile-specific generator
-        -> generated runtime-facing files
-```
-
-RuntimeContract contains the software-facing subset of the Mission Data Contract.
-
-It is not flight software and it is not the source of truth.
-
----
-
-## 9. GroundContract Architecture
-
-GroundContract is the intermediate model for ground-facing generation.
-
-The required dependency direction is:
-
-```text
-Mission Model
-        -> validation and linting
-        -> GroundContract builder
-        -> generic ground exporter
-        -> generated ground-facing package
-```
-
-GroundContract contains the ground-facing subset of the Mission Data Contract.
-
-It is not a mission database runtime.
-
-It is not a ground segment configuration format.
-
-It is not the source of truth.
-
----
-
-## 10. Export Layer Architecture
-
-v0.8.1 introduced the first export layer surface:
-
-```text
+Mission Model documented contract semantics
+Core structural validation
+Core semantic lint diagnostic policy
+scenario YAML evidence inputs
+lint JSON report
+simulation JSON report
 model_summary.json
-```
-
-v0.8.2 introduced the second export layer surface:
-
-```text
 entity_index.json
+relationship_manifest.json for admitted families
+CLI command interface for documented workflows
+release compatibility policy
+extensibility boundary contract
 ```
 
-v0.9.0 introduced the third export layer surface:
+The following remain preview, disposable or out of scope unless explicitly promoted later:
 
 ```text
-relationship_manifest.json
+CLI textual output
+generated Markdown mission documentation
+plain-text simulation logs
+generated C++17 runtime-facing bindings
+generated ground-facing dictionaries
+runtime_contract_manifest.json
+ground_contract_manifest.json
+plugin execution
+relationship graph behavior
+schema migration tooling
+JSON Schema publication
+security enforcement semantics
+Studio-specific API
 ```
 
-v0.10.0 classifies these Core-owned structured surfaces as compatibility-sensitive candidate or preview surfaces before v1.0.0.
+---
 
-v0.11.0 defines how future extension-owned outputs may consume these surfaces without redefining them.
+## 7. Demo Evidence Chain
 
-v0.12.0 identifies these surfaces as strong v1.0 review candidates and requires explicit stabilization decisions before v1.0.0.
-
-The required dependency direction is:
+The selected v1.0 demonstration chain is:
 
 ```text
-Mission Model
-        -> canonical loader
-        -> validated MissionModel
-        -> export layer
+payload.start_acquisition
+        -> payload.acquisition_started
+        -> payload.radiation_histogram data product evidence
+        -> storage intent declared
+        -> downlink intent declared
+        -> science_next_available_contact downlink flow
+        -> demo_contact_001 contact window
+        -> scenario JSON evidence
+        -> runtime-facing contract bindings
+        -> ground-facing dictionaries
         -> model_summary.json
         -> entity_index.json
         -> relationship_manifest.json
-        -> downstream tools and future extensions consume Core-owned structured surfaces
+        -> golden signatures protecting selected Core-owned surface fields
 ```
 
-The disallowed direction is:
+This demonstrates Mission Data Contract continuity.
 
-```text
-export layer
-        -> raw YAML files
-        -> generated docs
-        -> generated runtime files
-        -> generated ground files
-        -> human-oriented CLI output
-        -> downstream UI state
-        -> plugin assumptions
-        -> extension-owned assumptions
-```
-
-The model summary report contains domain-level information only.
-
-The entity index report contains entity-level records only.
-
-The relationship manifest report contains admitted Core-owned relationship records only.
-
-None of these surfaces contains source locations, YAML AST data, plugin definitions, extension definitions, Studio-specific formatting, runtime behavior or ground behavior.
+It does not demonstrate flight readiness, ground readiness, protocol compliance, tool-specific integration, security enforcement or operational completeness.
 
 ---
 
-## 11. Relationship Manifest Architecture
+## 8. Final Architecture Boundary
 
-The Relationship Manifest Surface is a Core-owned read-only candidate report.
+OrbitFabric Core must remain a Mission Data Contract framework.
 
-It references entities already exposed by the Entity Index Surface.
-
-It does not create independent synthetic downstream nodes.
-
-Every emitted relationship record must be derived from explicit loaded Mission Model fields.
-
-It must not derive records from:
+The correct architectural statement is:
 
 ```text
-naming conventions
-string similarity
-ID prefixes
-source file names
-YAML file ordering
-generated Markdown
-generated runtime files
-generated ground files
-human-oriented CLI output
-Studio UI state
-React component state
-private downstream assumptions
-extension-owned assumptions
+Define the contract once.
+Validate it.
+Exercise scenario evidence.
+Generate review artifacts.
+Export Core-owned structured surfaces.
+Protect selected stable surface fields with golden signatures.
+Keep the Mission Model as the source of truth.
 ```
 
-For `examples/demo-3u/mission`, the current manifest emits 46 relationship records across 17 emitted relationship families.
-
-The candidate surface currently admits 19 relationship families documented in `docs/reference/relationship-manifest-surface.md`.
-
-The relationship manifest is not:
-
-```text
-a graph engine
-a dependency graph
-a visualization format
-a Studio API
-a layout format
-a runtime routing table
-a ground routing table
-a scheduler input
-a command dispatcher input
-a plugin API
-an extension API
-```
-
-A downstream tool may render a graph from relationship records, but the engineering meaning of every edge must still come from Core.
-
----
-
-## 12. Stability, Compatibility, Extensibility and Hardening Architecture
-
-v0.10.0 classifies OrbitFabric's public and preview surfaces before v1.0.0.
-
-The classification references cover:
-
-```text
-Mission Model stability expectations
-CLI command stability
-JSON report compatibility expectations
-lint rule code evolution
-generated and exported surface stability
-scenario evidence stability
-release compatibility policy
-```
-
-v0.11.0 adds the Extensibility Boundary Contract, which states:
-
-```text
-Mission Model remains the source of truth.
-Core owns Mission Data Contract semantics.
-Extensions consume Core-owned structured surfaces.
-Extension-owned outputs remain distinguishable from Core-owned outputs.
-Extensions must not override Core semantics.
-Execution is out of scope.
-```
-
-v0.12.0 adds release candidate hardening references:
-
-```text
-v1.0 Candidate Surface Inventory
-Golden Output and Regression Confidence Policy
-v1.0 Compatibility and Migration Notes
-```
-
-These references are documentation contracts and governance references.
-
-They define how existing surfaces should evolve, how future extension-owned outputs may relate to Core-owned semantics, how candidate v1.0 surfaces should be reviewed and how compatibility or migration notes should be written.
-
-They do not add new Mission Model semantics, YAML fields, report fields, generated surfaces, CLI behavior beyond version reporting, lint diagnostics or scenario behavior.
-
-They also do not introduce golden files, snapshot tests, schema migration tooling, JSON Schema publication, security enforcement semantics, metadata schema, plugin discovery, plugin loading, plugin execution, runtime behavior, ground behavior, graph behavior, Studio-specific APIs or a stable v1.0 compatibility guarantee.
-
----
-
-## 13. Ground-Facing Generation Layer
-
-The generic ground profile generates:
-
-```text
-generated/ground/generic/
-├── ground_contract_manifest.json
-├── README.md
-├── dictionaries/*.json
-├── csv/*.csv
-└── ground_dictionaries.md
-```
-
-These artifacts expose telemetry, command, event, fault, data product and packet contract metadata.
-
-They do not expose binary packet decoders, ground runtime, telemetry archive, database implementation, operator console, command uplink service, Yamcs compatibility, OpenC3 compatibility, XTCE compliance or CCSDS/PUS/CFDP behavior.
-
-Generated ground artifacts are disposable.
-
-Downstream ground integration code must live outside generated OrbitFabric output unless explicitly generated by a future tool-specific profile.
-
----
-
-## 14. Runtime-Facing Generation Layer
-
-The C++17 runtime profile generates:
-
-```text
-generated/runtime/cpp17/runtime_contract_manifest.json
-generated/runtime/cpp17/include/orbitfabric/generated/mission_ids.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_enums.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/mission_registries.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/command_args.hpp
-generated/runtime/cpp17/include/orbitfabric/generated/adapter_interfaces.hpp
-generated/runtime/cpp17/CMakeLists.txt
-generated/runtime/cpp17/src/orbitfabric_runtime_contract_smoke.cpp
-```
-
-These artifacts expose stable generated identifiers, typed command argument structs, static metadata registries, abstract adapter interfaces and host-build smoke validation.
-
-They do not implement flight behavior.
-
-Generated runtime-facing artifacts are disposable.
-
-User implementation code must live outside `generated/`.
-
----
-
-## 15. Host-Build, Ground Export and Structured Surface Validation
-
-Runtime-facing bindings can be validated with:
-
-```bash
-orbitfabric gen runtime examples/demo-3u/mission/
-cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
-cmake --build generated/runtime/cpp17/build
-```
-
-Ground-facing artifacts can be validated with:
-
-```bash
-orbitfabric gen ground examples/demo-3u/mission/
-```
-
-The model summary surface can be validated with:
-
-```bash
-orbitfabric export model-summary examples/demo-3u/mission/ \
-  --json generated/reports/model_summary.json
-```
-
-The entity index surface can be validated with:
-
-```bash
-orbitfabric export entity-index examples/demo-3u/mission/ \
-  --json generated/reports/entity_index.json
-```
-
-The relationship manifest surface can be validated with:
-
-```bash
-orbitfabric export relationship-manifest examples/demo-3u/mission/ \
-  --json generated/reports/relationship_manifest.json
-```
-
-These commands confirm that the generated contract surfaces are syntactically valid and reproducible on the host.
-
-They do not validate flight behavior, live ground behavior, relationship graph behavior or plugin behavior.
-
----
-
-## 16. Documentation Generation Layer
-
-The Generation Layer derives human-readable and machine-readable artifacts from the Mission Model.
-
-Current generated mission documentation includes:
-
-```text
-generated/docs/telemetry.md
-generated/docs/commands.md
-generated/docs/events.md
-generated/docs/faults.md
-generated/docs/modes.md
-generated/docs/packets.md
-generated/docs/payloads.md
-generated/docs/data_products.md
-generated/docs/contacts.md
-generated/docs/commandability.md
-generated/docs/data_flow.md
-```
-
-Ground-facing review artifacts are generated under:
-
-```text
-generated/ground/generic/
-```
-
-Core-owned structured reports are generated under:
-
-```text
-generated/reports/
-```
-
-Generated documentation and reports are not the source of truth.
-
----
-
-## 17. Demo Mission Architecture
-
-The canonical demo is `demo-3u`.
-
-Canonical structure:
-
-```text
-examples/demo-3u/
-├── mission/
-│   ├── spacecraft.yaml
-│   ├── subsystems.yaml
-│   ├── modes.yaml
-│   ├── telemetry.yaml
-│   ├── commands.yaml
-│   ├── events.yaml
-│   ├── faults.yaml
-│   ├── packets.yaml
-│   ├── policies.yaml
-│   ├── payloads.yaml
-│   ├── data_products.yaml
-│   ├── contacts.yaml
-│   └── commandability.yaml
-└── scenarios/
-    ├── battery_low_during_payload.yaml
-    ├── nominal_payload_acquisition.yaml
-    └── payload_data_flow_evidence.yaml
-```
-
-The demo must stay synthetic and clean-room.
-
----
-
-## 18. Reports and Generated Artifact Architecture
-
-Reports are JSON where machine-readable output is required.
-
-Generated artifact manifests are also JSON where deterministic downstream inspection is required.
-
-Current generated JSON families include:
-
-```text
-lint reports
-simulation reports
-runtime contract manifest
-ground contract manifest
-ground dictionaries
-model summary report
-entity index report
-relationship manifest report
-```
-
-Reports and manifests must remain stable enough for tests and CI, but they are still development-preview artifacts before v1.0.
-
-v0.10.0 classifies JSON report compatibility expectations without changing report structure or introducing JSON Schema publication.
-
-v0.11.0 does not introduce new JSON report fields or extension metadata schemas.
-
-v0.12.0 does not introduce new JSON report fields, golden files, snapshot tests or committed golden-output baselines.
-
----
-
-## 19. Layer Dependency Rules
-
-Allowed dependencies:
-
-```text
-cli -> model
-cli -> lint
-cli -> sim
-cli -> gen
-cli -> export
-cli -> reports
-
-lint -> model
-sim -> model
-sim -> reports
-gen -> model
-gen -> RuntimeContract builder
-gen -> GroundContract builder
-export -> model
-RuntimeContract builder -> model
-GroundContract builder -> model
-reports -> lint report data
-reports -> simulation report data
-```
-
-Forbidden dependencies:
-
-```text
-model -> cli
-model -> sim
-model -> gen
-model -> export
-model -> lint policy
-lint -> sim
-sim -> gen
-gen -> sim
-RuntimeContract builder -> raw YAML files
-GroundContract builder -> raw YAML files
-profile-specific generator -> raw YAML files
-exporter -> raw YAML files
-relationship exporter -> raw YAML files
-relationship exporter -> generated Markdown
-relationship exporter -> downstream UI state
-plugin output -> Core-owned relationship manifest
-extension output -> Core-owned semantics
-```
-
-The Model Layer must remain the lowest stable layer.
-
----
-
-## 20. Testing Architecture
-
-Current test strategy covers:
-
-```text
-model loader tests
-structural validation tests
-duplicate identifier tests
-cross-reference lint tests
-engineering lint rules
-payload contract lint rules
-data product contract lint rules
-contact/downlink contract lint rules
-commandability/autonomy lint rules
-command data-product effect lint rules
-scenario validation tests
-scenario data-flow expectation tests
-scenario execution tests
-data-flow evidence JSON report tests
-documentation generator tests
-RuntimeContract builder tests
-C++17 runtime generator tests
-GroundContract builder tests
-ground manifest tests
-ground JSON export tests
-ground CSV export tests
-ground Markdown export tests
-model summary export tests
-entity index export tests
-relationship manifest export tests
-relationship manifest CLI tests
-CLI smoke tests
-```
-
-CI runs:
-
-```text
-ruff check .
-pytest
-orbitfabric lint examples/demo-3u/mission/
-orbitfabric gen docs examples/demo-3u/mission/
-orbitfabric gen data-flow examples/demo-3u/mission/
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
-orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
-mkdocs build --strict
-```
-
-Release validation additionally includes:
-
-```bash
-orbitfabric export model-summary examples/demo-3u/mission/ \
-  --json generated/reports/model_summary.json
-orbitfabric export entity-index examples/demo-3u/mission/ \
-  --json generated/reports/entity_index.json
-orbitfabric export relationship-manifest examples/demo-3u/mission/ \
-  --json generated/reports/relationship_manifest.json
-orbitfabric gen runtime examples/demo-3u/mission/
-cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
-cmake --build generated/runtime/cpp17/build
-orbitfabric gen ground examples/demo-3u/mission/
-```
-
----
-
-## 21. Future Extension Architecture
-
-Future extensions should be added as generators, plugins or adapters only after their semantics, trust model and boundary rules are reviewed explicitly.
-
-Possible future layers:
-
-```text
-Custom Ground Exporters
-Custom Lint Rule Plugins
-Custom Mission Model Extensions
-Runtime Adapter SDK
-Plugin Metadata Manifests
-Yamcs Export Generator
-OpenC3 Export Generator
-XTCE Export Generator
-Basilisk Bridge
-cFS/F Prime Integration Bridges
-```
-
-These must remain downstream of the Mission Model and Core-owned structured surfaces.
-
-They must not redefine the mission contract.
-
-v0.11.0 defines the boundary but does not introduce discovery, loading or execution.
-
-v0.12.0 hardens the v1.0 path but does not introduce discovery, loading or execution.
-
-Plugin execution requires explicit trust and boundary design before arbitrary plugin code is supported.
-
----
-
-## 22. Anti-Patterns
-
-The following patterns are architecturally wrong:
-
-```text
-runtime-first drift
-ground-first drift
-demo-driven special cases
-hidden mission logic
-premature standard compliance
-ground segment creep
-flight framework creep
-simulation creep
-storage runtime creep
-downlink runtime creep
-plugin-before-core-surface creep
-relationship-graph-before-relationship-semantics creep
-compatibility-claim-before-classification creep
-execution-before-boundary creep
-stability-claim-before-hardening creep
-proprietary example contamination
-```
-
----
-
-## 23. v0.12.0 Acceptance Architecture
-
-OrbitFabric v0.12.0 is architecturally acceptable when this flow works end-to-end:
-
-```bash
-ruff check .
-pytest
-mkdocs build --strict
-
-orbitfabric lint examples/demo-3u/mission/ \
-  --json generated/reports/lint_report.json
-
-orbitfabric export model-summary examples/demo-3u/mission/ \
-  --json generated/reports/model_summary.json
-
-orbitfabric export entity-index examples/demo-3u/mission/ \
-  --json generated/reports/entity_index.json
-
-orbitfabric export relationship-manifest examples/demo-3u/mission/ \
-  --json generated/reports/relationship_manifest.json
-
-orbitfabric gen docs examples/demo-3u/mission/
-
-orbitfabric gen data-flow examples/demo-3u/mission/ \
-  --output-file generated/docs/data_flow.md
-
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml \
-  --json generated/reports/battery_low_during_payload_report.json \
-  --log generated/logs/battery_low_during_payload.log
-
-orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
-  --json generated/reports/payload_data_flow_evidence_report.json \
-  --log generated/logs/payload_data_flow_evidence.log
-
-orbitfabric gen runtime examples/demo-3u/mission/
-
-cmake -S generated/runtime/cpp17 -B generated/runtime/cpp17/build
-cmake --build generated/runtime/cpp17/build
-
-orbitfabric gen ground examples/demo-3u/mission/
-```
-
-And exposes:
-
-```text
-valid lint output
-model_summary.json
-entity_index.json
-relationship_manifest.json
-Markdown mission documentation
-scenario execution logs
-scenario JSON reports
-data_flow_evidence JSON records
-RuntimeContract manifest
-C++17 runtime-facing contract headers
-host-build smoke validation
-GroundContract manifest
-JSON ground dictionaries
-CSV ground dictionaries
-human-reviewable ground Markdown artifacts
-stability and compatibility classification references
-Extensibility Boundary Contract reference
-ADR-0015
-v1.0 Candidate Surface Inventory
-Golden Output and Regression Confidence Policy
-v1.0 Compatibility and Migration Notes
-release compatibility policy
-```
-
-No flight runtime, live ground segment, orbital propagation, RF simulation, storage/downlink runtime, live uplink, decoder runtime, telemetry archive, operator console, autonomy runtime, relationship graph, metadata schema, plugin discovery, plugin loading, plugin execution, schema migration tooling, JSON Schema publication, security enforcement semantics or stable v1.0 guarantee is required for v0.12.0.
-
----
-
-## 24. Next Architectural Step After v0.12.0
-
-The next architectural step after v0.12.0 is v1.0.0 Stable Mission Data Contract.
-
-That work should select the final narrow stable surface from the existing Mission Data Contract core.
-
-It should not introduce model, runtime, ground, graph, security-enforcement, Studio-specific, plugin discovery, plugin loading or plugin execution behavior.
-
----
-
-## 25. Final Architectural Statement
-
-OrbitFabric is architecturally centered on the Mission Data Contract.
-
-The Mission Model expresses the contract.
-
-The lint engine validates the contract.
-
-The simulator executes deterministic scenarios against the contract.
-
-The documentation generator explains the contract.
-
-The v0.6 data-flow evidence layer proves the first end-to-end Mission Data Chain at contract level.
-
-The v0.7 runtime-facing binding layer exposes that contract to implementation code without generating flight behavior.
-
-The v0.8.0 ground-facing artifact layer exposes that contract to ground integration work without generating ground behavior.
-
-The v0.8.1 contract introspection surface exposes a Core-owned model summary for downstream tools without introducing relationship graphs or plugins.
-
-The v0.8.2 entity index surface exposes Core-owned entity records for downstream tools without introducing relationship graphs or plugins.
-
-The v0.9.0 relationship manifest surface exposes Core-owned relationship records for downstream tools without introducing graph behavior, plugin execution or Studio-specific APIs.
-
-The v0.10.0 stability and compatibility contract classifies public, preview, candidate, generated and internal surfaces before v1.0.0 without introducing implementation behavior or a stable v1.0 guarantee.
-
-The v0.11.0 extensibility boundary contract defines how future extension-owned outputs may relate to Core-owned semantics without introducing plugin discovery, plugin loading or plugin execution.
-
-The v0.12.0 release candidate hardening references define how OrbitFabric should select, protect, document or defer candidate surfaces before v1.0.0 without broadening the Core.
-
-Future plugins must consume the contract.
-
-Nothing should bypass the contract.
-
-That narrowness is intentional.
-
-It is the architecture.
+The architecture must not drift into flight software, a ground segment, a simulator platform, a plugin execution framework, a graph engine or a Studio backend.

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Project Charter
 
-Version: 0.12.0
-Status: Draft
-Scope: Mission Data Contract foundation, Mission Data Chain, generated contract-facing artifacts, stability classification, extensibility boundary contract and v1.0 release candidate hardening references
+Version: 0.12.0 to v1.0 candidate path  
+Status: v1.0 candidate alignment  
+Scope: Mission Data Contract foundation, Core-owned structured surfaces, extensibility boundary and v1.0 stable-surface preparation
 
 ---
 
@@ -10,7 +10,7 @@ Scope: Mission Data Contract foundation, Mission Data Chain, generated contract-
 
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 
-Its purpose is to let small spacecraft teams define telemetry, commands, events, faults, operational modes, packets, payload contracts, data products, storage intent, downlink assumptions, commandability/autonomy assumptions, operational scenarios, runtime-facing contract bindings, ground-facing integration artifacts, Core-owned introspection surfaces, entity index surfaces, relationship manifest surfaces, compatibility classifications, extensibility boundary rules and v1.0 release candidate hardening references once, in a single mission contract, and then use that contract to validate consistency, generate documentation, run simulations, support tests and prepare integration and inspection artifacts for onboard, ground, downstream tooling and future extension-owned outputs.
+Its purpose is to let small spacecraft teams define mission data once, in a structured Mission Model, and then reuse that contract across validation, documentation, testing, scenario evidence, runtime-facing bindings, ground-facing artifacts, Core-owned structured surfaces and downstream inspection workflows.
 
 OrbitFabric is not intended to be another flight software framework, another CubeSat tutorial, another ground segment tool, a payload runtime framework, a plugin execution platform, a plugin loader, a plugin discovery mechanism or a visual modeling backend.
 
@@ -22,7 +22,36 @@ The guiding principle is:
 
 ---
 
-## 2. Core Definition
+## 2. Current Status
+
+OrbitFabric is currently released at:
+
+```text
+v0.12.0 - v1.0 Release Candidate Hardening
+```
+
+The immediate target is:
+
+```text
+v1.0.0 - Stable Mission Data Contract
+```
+
+After v0.12.0, the repository contains the v1.0 candidate alignment material needed before final release preparation:
+
+```text
+v1.0 Stable Surface Decision
+v1.0 golden signatures for selected Core-owned structured surfaces
+v1.0 Demo Evidence Chain
+v1.0 Compatibility and Migration Notes aligned to the current candidate posture
+```
+
+This does not mean v1.0.0 has already been released.
+
+It means the project has selected, protected, demonstrated and documented the proposed narrow v1.0 posture.
+
+---
+
+## 3. Core Definition
 
 OrbitFabric is a framework for defining and using a Mission Data Contract.
 
@@ -35,11 +64,10 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - events;
 - faults;
 - operational modes;
-- mode transitions;
 - packets;
 - payload contracts;
 - data products;
-- persistence, storage and retention policies;
+- storage and retention intent;
 - downlink priorities and contact assumptions;
 - commandability constraints;
 - autonomy and recovery expectations;
@@ -47,18 +75,16 @@ A Mission Data Contract describes, in a structured and machine-readable way:
 - validation and linting rules;
 - runtime-facing generated contract bindings;
 - ground-facing generated integration artifacts;
-- Core-owned contract introspection surfaces;
-- Core-owned entity index surfaces;
-- Core-owned relationship manifest surfaces;
+- Core-owned structured surfaces;
 - stability and compatibility classifications;
 - extensibility boundary rules;
-- v1.0 release candidate hardening references.
+- v1.0 candidate governance references.
 
 The Mission Data Contract is the single source of truth for all derived artifacts.
 
 ---
 
-## 3. Problem Statement
+## 4. Problem Statement
 
 Small spacecraft projects often suffer from mission data fragmentation.
 
@@ -81,13 +107,13 @@ The same information is commonly duplicated and reinterpreted across multiple pl
 
 This creates drift.
 
-A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A packet may exceed its expected size without being detected early. A mode may forbid an operation in principle, while the command router still accepts it in practice. A payload may produce data products that have no storage policy, retention rule or downlink path. A ground dictionary may describe data that the onboard design does not actually preserve or prioritize. A generated software boundary may diverge from the mission model it was supposed to represent. A downstream tool may infer contract semantics differently from the Core. A future extension may accidentally become a second semantic source if the ownership boundary is not explicit.
+A command may be accepted by a simulator but rejected onboard. A telemetry field may exist in flight software but be missing in documentation. A fault may be described in a document but implemented differently in code. A payload may produce data products that have no storage policy, retention rule or downlink path. A downstream tool may infer contract semantics differently from the Core. A future extension may accidentally become a second semantic source if the ownership boundary is not explicit.
 
-OrbitFabric addresses this by making the mission data model explicit, validated, executable, documented, reusable, introspectable, indexable, relatable, compatibility-classified, extensibility-bounded and hardened toward v1.0 through Core-owned structured surfaces and references.
+OrbitFabric addresses this by making the Mission Data Contract explicit, validated, executable as host-side scenario evidence, documented, reusable, introspectable, indexable, relatable, compatibility-classified, extensibility-bounded and protected through selected golden signatures.
 
 ---
 
-## 4. Target Users
+## 5. Target Users
 
 The initial target users are:
 
@@ -108,7 +134,7 @@ OrbitFabric must be accessible to students and power makers, but designed with t
 
 ---
 
-## 5. Positioning
+## 6. Positioning
 
 OrbitFabric does not compete directly with mature space software frameworks and tools.
 
@@ -130,495 +156,199 @@ The correct long-term role is:
 
 ---
 
-## 6. Core Principles
+## 7. Core Principles
 
-### 6.1 Mission Model First
+### 7.1 Mission Model First
 
 OrbitFabric starts from the Mission Model, not from the onboard runtime, the ground system, a plugin, an extension-owned output or a visual tool.
 
-The runtime-facing bindings, ground-facing artifacts, contract introspection reports, entity index reports, relationship manifest reports, simulator, documentation, compatibility classifications, extensibility boundary rules and v1.0 hardening references must derive from or describe the model, not the other way around.
+The Mission Model remains the source of truth.
 
-### 6.2 Contract Before Code
+### 7.2 Contract Before Code
 
 The first valuable artifact is the contract.
 
-Code generation, runtime execution, ground integration, inspection surfaces, relationship surfaces, entity surfaces, compatibility references, extension-owned outputs and integration bridges are secondary and must not redefine the model.
+Code generation, runtime-facing bindings, ground-facing artifacts, inspection surfaces, relationship surfaces, compatibility references, extension-owned outputs and integration bridges are secondary.
 
-### 6.3 Mission Data Chain Before Generated Artifacts
+They must not redefine the model.
 
-OrbitFabric must make the mission data chain explicit before generating software-facing, ground-facing, introspection, entity-index, relationship or extension-facing artifacts.
+### 7.3 Core Surfaces Before Plugins
 
-The current chain is:
+Downstream tools and future extensions must consume Core-owned structured surfaces.
+
+They must not reconstruct Mission Data Contract semantics from raw YAML, generated files, terminal output, logs, UI state or private assumptions.
+
+The current selected Core-owned structured surfaces are:
 
 ```text
-payload behavior
-        -> data products
-        -> onboard storage and retention intent
-        -> downlink queue intent
-        -> contact window assumptions
-        -> commandability constraints
-        -> autonomy and recovery expectations
-        -> end-to-end scenario evidence
-        -> runtime-facing contract bindings
-        -> ground-facing integration artifacts
-        -> contract introspection surface
-        -> entity index surface
-        -> relationship manifest surface
-        -> stability and compatibility classification
-        -> extensibility boundary contract
-        -> v1.0 release candidate hardening references
+model_summary.json
+entity_index.json
+relationship_manifest.json
 ```
 
-Only after these concepts are sufficiently clear should OrbitFabric derive plugin, tool-specific or external integration layers from them.
+### 7.4 Generated Artifacts Are Disposable Unless Classified Otherwise
 
-### 6.4 Generated Artifacts Are Disposable
-
-Generated runtime-facing contract bindings, ground-facing integration artifacts, contract introspection reports, entity index reports and relationship manifest reports are reproducible outputs.
+Generated runtime-facing bindings, generated ground-facing artifacts, generated Markdown documentation and plain-text logs are reproducible outputs.
 
 They are not the source of truth.
 
 Users must not place handwritten implementation code inside generated files.
 
-User implementation code and downstream integration code must live outside `generated/` and integrate through generated identifiers, descriptors, typed structures, abstract interfaces, manifests, dictionaries or Core-owned reports.
+### 7.5 Compatibility Must Be Explicit
 
-### 6.5 Linting as Engineering Judgment
+Before v1.0.0, any change to a selected stable candidate surface must include explicit compatibility or migration notes.
 
-OrbitFabric linting must not be limited to YAML syntax validation.
+A surface does not become stable only because it exists.
 
-It must perform mission consistency analysis.
-
-The lint system is a core feature, not a utility.
-
-### 6.6 Scenario-First Testing
+### 7.6 Scenario Evidence Is Host-Side Contract Evidence
 
 Operational scenarios must be first-class artifacts.
 
-A mission scenario should be expressible as structured data and executable by the simulator.
+The simulator validates deterministic host-side contract behavior.
 
-The simulator must be able to answer a practical engineering question:
-
-> Given this mission model and this scenario, does the system behave as expected?
-
-Scenarios provide evidence for mode transitions, command behavior, payload data production, storage intent, downlink assumptions, contact windows and recovery expectations.
-
-### 6.7 Ground by Construction
-
-OrbitFabric must not become a full ground segment.
-
-However, it must generate artifacts useful for ground integration:
-
-- generated review documentation;
-- JSON ground dictionaries;
-- CSV review dictionaries;
-- packet membership dictionaries;
-- data product dictionaries;
-- downlink policy descriptions;
-- future Yamcs/OpenC3/XTCE exports when explicitly implemented and tested.
-
-### 6.8 Core Surfaces Before Plugins
-
-Downstream tools and future extensions must consume Core-owned structured surfaces.
-
-They must not reconstruct Mission Model semantics from raw YAML, generated artifacts or human-oriented CLI output.
-
-v0.8.1 introduces `model_summary.json` as the first such surface.
-
-v0.8.2 introduces `entity_index.json` as the second such surface.
-
-v0.9.0 introduces `relationship_manifest.json` as the third such surface.
-
-v0.10.0 classifies public, preview, candidate, generated and internal surfaces before v1.0.0.
-
-v0.11.0 defines the extensibility boundary before any plugin execution exists.
-
-v0.12.0 hardens the release candidate path before the final v1.0 stable-surface decision.
-
-Future plugin extensibility must build on these surfaces without silently redefining Core semantics.
-
-### 6.9 Clean-Room Development
-
-OrbitFabric must be developed from scratch using public knowledge, synthetic examples and generic engineering concepts.
-
-It must not contain proprietary mission details, real non-public architectures, private protocols, real bus maps, real pinouts, real logs, real payload data or any information under NDA.
-
-### 6.10 Small Core, Extensible Edges
-
-The core must stay small.
-
-Extensibility should come through plugins, generators, custom lint rules and adapters only after the ownership, provenance, trust and execution boundaries are explicit.
-
-Plugin execution requires explicit trust, metadata and boundary design before arbitrary or untrusted plugin code is supported.
-
-v0.11.0 does not introduce plugin discovery, plugin loading or plugin execution.
-
-v0.12.0 does not introduce plugin discovery, plugin loading or plugin execution.
-
-### 6.11 Practical Before Perfect
-
-OrbitFabric must favor useful, testable, well-documented behavior over broad but shallow standard compliance.
-
-CCSDS, PUS, CFDP, XTCE, Yamcs, OpenC3, cFS, F Prime and Basilisk integrations are future extensions, not early-version requirements.
+It is not a real-time onboard runtime or a spacecraft dynamics simulator.
 
 ---
 
-## 7. Current Baseline
+## 8. v1.0 Candidate Stable Surface
 
-The current v0.12.0 baseline includes:
+The selected v1.0 candidate stable surface is intentionally narrow.
 
-- Mission Model YAML files;
-- model loading;
-- structural validation;
-- semantic linting;
-- generated Markdown documentation;
-- deterministic host-side scenario simulation;
-- scenario runner;
-- payload contract model;
-- data product contract model;
-- contact/downlink contract model;
-- commandability/autonomy contract model;
-- end-to-end mission data flow evidence;
-- RuntimeContract intermediate model;
-- generated C++17 runtime-facing contract bindings;
-- C++17 host-build smoke validation;
-- GroundContract intermediate model;
-- generated generic ground-facing dictionaries;
-- generated JSON ground dictionaries;
-- generated CSV ground dictionaries;
-- generated ground Markdown review artifacts;
-- Core-owned model summary export;
-- Core-owned entity index export;
-- Core-owned relationship manifest export;
-- stability and compatibility classification references;
-- Extensibility Boundary Contract reference;
-- ADR-0015 extensibility boundary decision;
-- v1.0 Candidate Surface Inventory;
-- Golden Output and Regression Confidence Policy;
-- v1.0 Compatibility and Migration Notes;
-- release compatibility policy;
-- readable logs;
-- JSON reports;
-- one complete demo mission named `demo-3u`.
-
-The current baseline supports these commands:
-
-```bash
-orbitfabric lint examples/demo-3u/mission/
-orbitfabric export model-summary examples/demo-3u/mission/ --json generated/reports/model_summary.json
-orbitfabric export entity-index examples/demo-3u/mission/ --json generated/reports/entity_index.json
-orbitfabric export relationship-manifest examples/demo-3u/mission/ --json generated/reports/relationship_manifest.json
-orbitfabric gen docs examples/demo-3u/mission/
-orbitfabric gen data-flow examples/demo-3u/mission/
-orbitfabric gen runtime examples/demo-3u/mission/
-orbitfabric gen ground examples/demo-3u/mission/
-orbitfabric sim examples/demo-3u/scenarios/battery_low_during_payload.yaml
-orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml
-```
-
-There are no extension commands in v0.12.0.
-
----
-
-## 8. Ground Integration Artifact Direction
-
-The Ground Integration Artifacts slice makes mission data visible to ground-side engineering workflows without turning OrbitFabric into ground software.
-
-A ground artifact may describe telemetry identity and metadata, command identity, arguments and allowed modes, event identity and severity, fault identity and recovery intent metadata, data product identity, storage intent and downlink intent, packet membership, manifest boundary flags and human-reviewable dictionary documentation.
-
-A ground artifact must not describe or implement live telemetry transport, binary packet decoding, command uplink, authentication or authorization, telemetry archive storage, operator displays, ground station scheduling, Yamcs/OpenC3/XTCE compatibility unless explicitly implemented and tested.
-
-Ground artifacts are part of the Mission Data Contract output chain.
-
-They are the foundation for later tool-specific exporters and plugin extensibility.
-
----
-
-## 9. Contract Introspection, Entity Index, Relationship Manifest, Compatibility, Extensibility and Hardening Direction
-
-Core-owned structured surfaces make the loaded Mission Model visible to downstream tools without letting those tools infer Core semantics privately.
-
-The v0.8.1 model summary report describes mission identity, source mission directory, contract domains, domain counts, required or optional domain status, source file metadata and explicit boundary flags.
-
-The v0.8.2 entity index report describes mission identity, source mission directory, contract entities, entity IDs, entity domains, entity types, display names, source file metadata and explicit boundary flags.
-
-The v0.9.0 relationship manifest report describes mission identity, source mission directory, relationship records, relationship IDs, relationship types, source and target indexed entities, relationship type counts, derivation policy and explicit boundary flags.
-
-The v0.10.0 compatibility references classify how public, preview, candidate, generated and internal surfaces should evolve before v1.0.0.
-
-The v0.11.0 extensibility boundary defines how future extension-owned outputs may relate to Core-owned semantics without becoming a second source of truth.
-
-The v0.12.0 hardening references define how v1.0 candidate surfaces, golden-output decisions and compatibility or migration notes should be reviewed before a stable Mission Data Contract release.
-
-These surfaces and references must not describe or implement:
-
-- relationship graph execution;
-- dependency graph execution;
-- source line or column tracking;
-- YAML AST export;
-- metadata schema;
-- metadata parser;
-- metadata loader;
-- metadata validator;
-- plugin API;
-- plugin discovery;
-- plugin loading;
-- plugin execution;
-- schema migration tooling;
-- JSON Schema publication;
-- security enforcement semantics;
-- Studio-specific API;
-- runtime behavior;
-- ground behavior;
-- stable v1.0 compatibility guarantee.
-
----
-
-## 10. Mission Data Chain Direction
-
-After the Payload Contract Model, OrbitFabric evolved toward explicit Mission Data Chain modeling.
-
-The current chain is:
+It includes:
 
 ```text
-Payload or subsystem activity
-        -> generated telemetry and data products
-        -> onboard storage and retention intent
-        -> downlink queue and priority intent
-        -> contact window assumptions
-        -> commandability and autonomy constraints
-        -> end-to-end scenario evidence
+Mission Model documented contract semantics
+Core structural validation
+Core semantic lint diagnostic policy
+scenario YAML evidence inputs
+lint JSON report
+simulation JSON report
+model_summary.json
+entity_index.json
+relationship_manifest.json for admitted families
+CLI command interface for documented workflows
+release compatibility policy
+extensibility boundary contract
+```
+
+The following remain preview, disposable, internal or out of scope unless explicitly promoted later:
+
+```text
+CLI textual output
+generated Markdown mission documentation
+plain-text simulation logs
+generated C++17 runtime-facing bindings
+generated ground-facing dictionaries
+runtime_contract_manifest.json
+ground_contract_manifest.json
+plugin discovery
+plugin loading
+plugin execution
+relationship graph behavior
+schema migration tooling
+JSON Schema publication
+security enforcement semantics
+Studio-specific API
+```
+
+---
+
+## 9. Non-Goals
+
+OrbitFabric must not become:
+
+- a flight software framework;
+- a ground segment;
+- a mission control system;
+- an operator console;
+- a telemetry archive;
+- a command uplink service;
+- a spacecraft dynamics simulator;
+- a hardware abstraction layer;
+- a CCSDS/PUS/CFDP implementation;
+- an XTCE mission database;
+- a Yamcs integration;
+- an OpenC3 integration;
+- an F Prime or cFS mapping layer;
+- a relationship graph engine;
+- a dependency graph engine;
+- a plugin execution framework;
+- a Studio-specific backend API;
+- a schema migration tool;
+- a JSON Schema publication layer;
+- a security enforcement framework;
+- a released v1.0.0 compatibility guarantee before v1.0.0 is actually released.
+
+These may be valid future directions only after separate design, implementation and tests.
+
+They are not part of the current Core charter.
+
+---
+
+## 10. Golden Signature Boundary
+
+The v1.0 golden signatures protect selected contract-significant fields of existing Core-owned structured surfaces.
+
+They protect:
+
+```text
+surface kind
+surface version
+mission identity
+boundary flags
+domain counts
+entity identifiers
+relationship family counts
+selected relationship records
+```
+
+They do not freeze:
+
+```text
+full generated JSON files
+absolute paths
+human-oriented terminal output
+Markdown wording
+generated runtime bindings
+generated ground dictionaries
+disposable artifact formatting
+```
+
+---
+
+## 11. Demo Evidence Chain
+
+The selected v1.0 demo evidence chain is:
+
+```text
+payload.start_acquisition
+        -> payload.acquisition_started
+        -> payload.radiation_histogram data product evidence
+        -> storage intent declared
+        -> downlink intent declared
+        -> science_next_available_contact downlink flow
+        -> demo_contact_001 contact window
+        -> scenario JSON evidence
         -> runtime-facing contract bindings
-        -> ground-facing integration artifacts
-        -> contract introspection surface
-        -> entity index surface
-        -> relationship manifest surface
-        -> stability and compatibility classification
-        -> extensibility boundary contract
-        -> v1.0 release candidate hardening references
-        -> future extensions
+        -> ground-facing dictionaries
+        -> model_summary.json
+        -> entity_index.json
+        -> relationship_manifest.json
+        -> golden signatures protecting selected Core-owned surface fields
 ```
 
-This direction is essential for small spacecraft and CubeSat missions because the value of mission data depends on the full path from onboard generation to ground consumption and downstream inspection.
+This demonstrates Mission Data Contract continuity.
 
-OrbitFabric must model the contract of that path.
-
-It must not implement the physical, flight or operational stack behind that path.
+It does not demonstrate flight readiness, ground readiness, protocol compliance, tool-specific integration, security enforcement or operational completeness.
 
 ---
 
-## 11. Early Non-Goals
+## 12. Final Charter Statement
 
-Early OrbitFabric versions must not include:
+OrbitFabric must remain excellent at one thing:
 
-- real spacecraft hardware support;
-- real SPI/I2C/UART drivers;
-- a complete onboard runtime;
-- a flight-ready C++ runtime;
-- RTOS integration;
-- Linux onboard integration;
-- CCSDS packet implementation;
-- PUS implementation;
-- CFDP implementation;
-- CSP integration;
-- SpaceWire integration;
-- CANopen integration;
-- cFS integration;
-- F Prime integration;
-- Yamcs integration as a live service;
-- OpenC3 integration as a live service;
-- XTCE compliance;
-- telemetry archive implementation;
-- operator console implementation;
-- command uplink implementation;
-- Basilisk integration as a dynamics simulator;
-- formal verification;
-- advanced security;
-- real mission operations procedures;
-- proprietary mission examples;
-- payload firmware support;
-- payload driver support;
-- physical payload simulation;
-- live ground operations;
-- schema migration tooling before versioning semantics are stable;
-- JSON Schema publication before schema semantics are stable;
-- metadata schema before the extension boundary is stable;
-- plugin APIs before Core-owned surfaces and plugin boundaries are stable;
-- plugin discovery before trust and boundary design are stable;
-- plugin loading before trust and boundary design are stable;
-- plugin execution before trust and boundary design are stable;
-- relationship graphs before entity indexing and relationship semantics are stable;
-- Mission Model security domain before v1.0.0;
-- security YAML fields before v1.0.0;
-- security enforcement semantics.
+> defining, validating, simulating, documenting, introspecting, indexing, relating and generating contract-facing artifacts from a Mission Data Contract for a small spacecraft.
 
-These items may become future integration targets, generated artifacts or external consumers only after the Mission Model, lint engine, scenario runner, mission data chain contracts, generated contract-facing artifacts, Core-owned surfaces, extensibility boundary and v1.0 release candidate hardening references prove valuable.
+The narrowness of the charter is intentional.
 
----
-
-## 12. Demo Mission
-
-The initial demo mission is `demo-3u`.
-
-It is a synthetic 3U CubeSat-like mission used only to demonstrate OrbitFabric concepts.
-
-It contains the full current Mission Data Chain from telemetry, commands, events, faults and modes through payload contracts, data products, contact/downlink assumptions, commandability/autonomy assumptions, data-flow evidence, runtime-facing contract bindings, ground-facing integration artifacts, contract introspection surface, entity index surface, relationship manifest surface, stability/compatibility classification, extensibility boundary documentation and v1.0 release candidate hardening references.
-
-The demo assumptions remain generic and do not encode private mission details, real ground station data, real orbit data or real RF behavior.
-
----
-
-## 13. Initial Technical Direction
-
-The recommended technical baseline is:
-
-- Python 3.11 or newer;
-- YAML for the Mission Model;
-- Pydantic v2 for typed model validation;
-- Typer for the command-line interface;
-- PyYAML for YAML loading;
-- pytest for tests;
-- ruff for formatting and linting;
-- MkDocs Material for documentation;
-- C++17 for the first generated runtime-facing binding profile;
-- CMake for host-build smoke validation;
-- JSON, CSV and Markdown for the first generated ground-facing artifact package;
-- JSON for Core-owned introspection, entity index and relationship manifest reports;
-- Markdown for stability, compatibility, extensibility boundary and v1.0 hardening references;
-- GitHub Actions for CI;
-- Apache-2.0 license.
-
-The generated C++17 surface is intentionally contract-facing and host-buildable.
-
-It is not a flight runtime.
-
-The generated ground-facing package is intentionally tool-neutral and reviewable.
-
-The generated model summary report is intentionally Core-owned and read-only.
-
-The generated entity index report is intentionally Core-owned and read-only.
-
-The generated relationship manifest report is intentionally Core-owned, read-only and candidate.
-
-The stability and compatibility references are intentionally classification documents, not implementation behavior or a stable v1.0 guarantee.
-
-The extensibility boundary is intentionally a documentation contract, not metadata schema, plugin discovery, plugin loading or plugin execution.
-
-The v0.12.0 hardening references are intentionally review and governance documents, not golden baselines, migration tooling, JSON Schema publication, security enforcement, generated Core surfaces or a stable v1.0 guarantee.
-
-None is a relationship graph engine, plugin execution mechanism or Studio-specific API.
-
----
-
-## 14. Repository Philosophy
-
-OrbitFabric should use a monorepo at the beginning.
-
-The repository should contain:
-
-- framework source code;
-- documentation;
-- examples;
-- tests;
-- generated artifact examples only when explicitly required;
-- architectural decision records.
-
-Initial repository structure:
-
-```text
-orbitfabric/
-├── README.md
-├── LICENSE
-├── pyproject.toml
-├── mkdocs.yml
-├── docs/
-├── examples/
-├── src/
-├── tests/
-└── generated/
-```
-
-Splitting into multiple repositories too early would add complexity without architectural benefit.
-
----
-
-## 15. Success Criteria for the Early Public Preview
-
-OrbitFabric is successful in the early public preview if a user can:
-
-1. inspect the `demo-3u` Mission Model;
-2. run mission linting;
-3. receive meaningful semantic errors and warnings;
-4. run the battery degradation scenario;
-5. see events, faults, mode transitions and auto-dispatched commands in the log;
-6. generate Markdown documentation from the same Mission Model;
-7. generate runtime-facing C++17 contract bindings from the same Mission Model;
-8. validate those generated bindings through a host-side C++17 smoke build;
-9. generate ground-facing JSON, CSV and Markdown artifacts from the same Mission Model;
-10. export a Core-owned model summary report from the same Mission Model;
-11. export a Core-owned entity index report from the same Mission Model;
-12. export a Core-owned relationship manifest report from the same Mission Model;
-13. understand the project positioning from the README in less than one minute;
-14. extend the demo mission with one telemetry item, one command or one event without modifying the simulator internals;
-15. understand how payload contracts fit into the Mission Data Contract;
-16. understand how data products, storage intent, downlink intent, contact assumptions, commandability constraints, recovery expectations, runtime-facing bindings, ground-facing artifacts, Core-owned surfaces, compatibility references, extensibility boundaries and v1.0 hardening references fit into the roadmap before plugin execution;
-17. understand which surfaces are public preview, candidate, internal or disposable before v1.0.0;
-18. understand that candidate, preview and generated surfaces do not become stable v1.0 automatically.
-
-A minimal but strong preview is better than a broad, fragile and unfinished feature set.
-
----
-
-## 16. Clean-Room Policy Summary
-
-OrbitFabric must not use or encode non-public mission information.
-
-Forbidden content includes:
-
-- real non-public mission names;
-- real proprietary subsystem architectures;
-- real payload interfaces;
-- real bus maps;
-- real pinouts;
-- real packet formats from private programs;
-- real logs;
-- real failure cases;
-- real operational procedures;
-- real data rates from private systems;
-- proprietary code;
-- proprietary documentation.
-
-Allowed content includes:
-
-- synthetic mission examples;
-- public standards and public documentation;
-- generic CubeSat concepts;
-- abstract subsystem models;
-- invented telemetry;
-- invented commands;
-- invented scenarios;
-- invented data products;
-- invented contact windows;
-- clean-room code written from scratch.
-
-If a design choice risks being too close to a private mission, it must be generalized or removed.
-
----
-
-## 17. Governance Principles
-
-Technical decisions should optimize for clarity, minimalism and architectural coherence.
-
-The project should prefer:
-
-- explicit models over implicit behavior;
-- small examples over large fake missions;
-- readable YAML over clever DSLs;
-- deterministic simulation over realism;
-- semantic lint rules over superficial validation;
-- generated documentation over manually duplicated references;
-- generated contract-facing artifacts over hidden implementation assumptions;
-- Core-owned structured surfaces over downstream semantic inference;
-- compatibility classifications over implicit stability assumptions;
-- extensibility boundary contracts over premature plugin execution;
-- v1.0 hardening references over implicit release stability assumptions;
-- clean interfaces over premature integrations;
-- mission data chain modeling before runtime-facing, ground-facing, introspection, entity indexing, relationship manifests, stability guarantees and plugin execution.
+That narrowness is a strength, not a limitation.


### PR DESCRIPTION
## Summary

Aligns the two highest-level architectural documents with the current v1.0 candidate posture:

- `docs/ARCHITECTURE.md`;
- `docs/PROJECT_CHARTER.md`.

The update clarifies that:

- `v0.12.0` remains the current released baseline;
- `v1.0.0` remains the immediate target;
- v1.0 candidate alignment material is present but does not mean v1.0.0 has already been released;
- the Mission Model remains the source of truth;
- the v1.0 stable surface is intentionally narrow;
- Core-owned structured surfaces are derived from the validated Mission Model;
- selected Core-owned structured surface fields are protected by golden signatures;
- generated runtime-facing and ground-facing artifacts remain disposable unless explicitly classified otherwise;
- plugin execution, graph engines, schema migration tooling, JSON Schema publication, security enforcement and Studio-specific APIs remain out of scope.

The documents are also made substantially shorter and less repetitive.

## Mission Data Contract impact

No Mission Data Contract semantic impact.

This PR does not add, remove or rename Mission Model fields, model domains, controlled values, reference rules, lint diagnostics, scenario expectations, JSON report fields, generated Core surfaces or CLI behavior.

## Architectural Boundary

Documentation-only architecture and charter alignment.

This PR does not introduce:

- new Mission Model semantics;
- new YAML fields;
- new CLI behavior;
- new JSON report fields;
- new generated artifacts;
- new tests;
- version bump;
- release notes;
- tag;
- GitHub release;
- schema migration tooling;
- JSON Schema publication;
- XTCE export;
- Yamcs integration;
- OpenC3 integration;
- F Prime mapping;
- cFS integration;
- CCSDS/PUS/CFDP implementation;
- security enforcement semantics;
- plugin discovery, loading or execution;
- relationship graph behavior;
- runtime behavior;
- ground behavior;
- Studio-specific API.

## Scope note

This PR intentionally updates only:

- `docs/ARCHITECTURE.md`;
- `docs/PROJECT_CHARTER.md`.

The large diff is mostly deliberate removal of repeated historical milestone prose already captured in roadmap, release notes and references.

## Validation

Not run locally in this environment.

Expected checks:

```text
ruff check .
pytest
mkdocs build --strict
```

The primary relevant check is `mkdocs build --strict`.