### PR TITLE
feat: add structured expectation accounting to simulation reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project follows a lightweight changelog style for the Mission Model, contra
 - Added `orbitfabric export scenario-run-index --simulation-reports <dir> --json <path>`.
 - Added the Scenario Run Index Surface reference page and MkDocs navigation entry.
 - Added tests for scenario run index identity, boundaries, filtering of non-simulation JSON reports, deterministic JSON writing and CLI export.
+- Added additive structured expectation accounting to simulation JSON reports.
+- Added `summary.expectations`, `summary.passed_expectations` and the structured top-level `expectations` object to simulation JSON reports.
+- Added tests covering passed expectation accounting, failed expectation accounting and legacy `failed_expectations` compatibility.
 
 ### Compatibility impact
 
@@ -30,6 +33,10 @@ The new dashboard summary and scenario run index are additive candidate post-v1 
 The dashboard summary does not introduce coverage metrics, model completeness scoring, mission health scoring, runtime behavior, ground behavior, relationship graph behavior, plugin execution or Studio-specific APIs.
 
 The scenario run index is derived from simulation JSON reports only. It does not parse plain-text logs and does not introduce coverage metrics, structured expectation accounting, runtime behavior, ground behavior, relationship graph behavior, plugin execution or Studio-specific APIs.
+
+The structured expectation accounting fields are additive simulation JSON report fields. They preserve the legacy top-level `failed_expectations` array for compatibility.
+
+The structured expectation accounting fields do not introduce formal verification, coverage metrics, runtime behavior, ground behavior, relationship graph behavior, plugin execution or Studio-specific APIs.
 
 ---
 

--- a/docs/reference/json-reports-v0.1.md
+++ b/docs/reference/json-reports-v0.1.md
@@ -47,6 +47,8 @@ runtime_contract_manifest.json
 ground_contract_manifest.json
 ```
 
+Post-v1 additive extensions may introduce new fields into existing stable report families when they preserve existing fields and include compatibility notes.
+
 Future versions may introduce:
 
 - JSON Schema definitions;
@@ -177,8 +179,11 @@ orbitfabric-sim
 | `commands` | array | Executed commands. |
 | `mode_transitions` | array | Mode transitions. |
 | `data_flow_evidence` | array | Contract-level data-flow evidence records. |
+| `expectations` | object | Structured scenario expectation accounting. |
 | `final_state` | object | Final simulator state. |
-| `failed_expectations` | array | Failed scenario expectations. |
+| `failed_expectations` | array | Legacy compatibility list of failed expectation messages. |
+
+The `expectations` object is additive. The legacy `failed_expectations` array remains present for compatibility.
 
 ---
 
@@ -203,7 +208,106 @@ Current fields:
 | `commands` | Number of executed or auto-dispatched commands. |
 | `mode_transitions` | Number of mode transitions. |
 | `data_flow_evidence` | Number of data-flow evidence records. |
-| `failed_expectations` | Number of failed expectations. |
+| `expectations` | Number of structured expectation records. |
+| `passed_expectations` | Number of structured expectation records with result `passed`. |
+| `failed_expectations` | Number of failed expectations. Preserved from the legacy failed expectation list. |
+
+---
+
+## Structured expectation accounting
+
+The simulation report includes structured expectation accounting in the additive `expectations` object.
+
+Shape:
+
+```json
+{
+  "expectations": {
+    "total": 12,
+    "passed": 12,
+    "failed": 0,
+    "records": []
+  }
+}
+```
+
+Each expectation record includes:
+
+```text
+t
+expectation_type
+target
+expected
+actual
+result
+message
+```
+
+Record example:
+
+```json
+{
+  "t": 9,
+  "expectation_type": "data_flow",
+  "target": "payload.radiation_histogram",
+  "expected": {
+    "data_product": "payload.radiation_histogram",
+    "triggered_by_command": "payload.start_acquisition",
+    "storage_intent_declared": true,
+    "downlink_intent_declared": true,
+    "eligible_downlink_flow": "science_next_available_contact",
+    "contact_window": "demo_contact_001"
+  },
+  "actual": {
+    "data_product": "payload.radiation_histogram",
+    "triggered_by_command": "payload.start_acquisition",
+    "storage_intent_declared": true,
+    "downlink_intent_declared": true,
+    "eligible_downlink_flows": [
+      "science_next_available_contact"
+    ],
+    "contact_windows": [
+      "demo_contact_001"
+    ]
+  },
+  "result": "passed",
+  "message": "expectation passed"
+}
+```
+
+Current expectation record result values:
+
+| Value | Meaning |
+|---|---|
+| `passed` | The expectation was evaluated and passed. |
+| `failed` | The expectation was evaluated and failed. |
+
+Current expectation types may include:
+
+```text
+mode
+event
+command
+command_status
+telemetry
+payload_lifecycle
+data_flow
+scenario_status
+```
+
+Structured expectation accounting is scenario evidence metadata. It does not imply formal verification, proof coverage, runtime telemetry validation, live command execution or ground operations.
+
+---
+
+## Legacy failed expectations compatibility
+
+The top-level `failed_expectations` array remains present.
+
+It contains the same human-readable failed expectation messages as before.
+
+This field is retained for compatibility with existing consumers.
+
+New consumers that need passed and failed accounting should read the structured `expectations` object.
 
 ---
 
@@ -484,6 +588,8 @@ Compact example:
     "commands": 2,
     "mode_transitions": 1,
     "data_flow_evidence": 1,
+    "expectations": 12,
+    "passed_expectations": 12,
     "failed_expectations": 0
   },
   "timeline": [],
@@ -491,6 +597,12 @@ Compact example:
   "commands": [],
   "mode_transitions": [],
   "data_flow_evidence": [],
+  "expectations": {
+    "total": 12,
+    "passed": 12,
+    "failed": 0,
+    "records": []
+  },
   "final_state": {
     "mode": "PAYLOAD_ACTIVE",
     "telemetry": {}

--- a/src/orbitfabric/sim/json_report.py
+++ b/src/orbitfabric/sim/json_report.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from typing import Any
 
 from orbitfabric import __version__
-from orbitfabric.sim.state import SimDataFlowEvidenceRecord, SimulationResult
+from orbitfabric.sim.state import (
+    SimDataFlowEvidenceRecord,
+    SimExpectationRecord,
+    SimulationResult,
+)
 
 
 def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
@@ -21,6 +25,8 @@ def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
             "commands": len(result.state.commands),
             "mode_transitions": len(result.state.mode_transitions),
             "data_flow_evidence": len(result.state.data_flow_evidence),
+            "expectations": len(result.state.expectations),
+            "passed_expectations": _expectation_count(result, "passed"),
             "failed_expectations": len(result.state.failed_expectations),
         },
         "timeline": [
@@ -62,6 +68,15 @@ def simulation_result_to_dict(result: SimulationResult) -> dict[str, Any]:
             _data_flow_evidence_to_dict(evidence)
             for evidence in result.state.data_flow_evidence
         ],
+        "expectations": {
+            "total": len(result.state.expectations),
+            "passed": _expectation_count(result, "passed"),
+            "failed": _expectation_count(result, "failed"),
+            "records": [
+                _expectation_to_dict(expectation)
+                for expectation in result.state.expectations
+            ],
+        },
         "final_state": {
             "mode": result.state.current_mode,
             "telemetry": result.state.telemetry,
@@ -97,6 +112,22 @@ def _data_flow_evidence_to_dict(
         "eligible_downlink_flows": evidence.eligible_downlink_flows,
         "contact_windows": evidence.contact_windows,
     }
+
+
+def _expectation_to_dict(expectation: SimExpectationRecord) -> dict[str, Any]:
+    return {
+        "t": expectation.t,
+        "expectation_type": expectation.expectation_type,
+        "target": expectation.target,
+        "expected": expectation.expected,
+        "actual": expectation.actual,
+        "result": expectation.result,
+        "message": expectation.message,
+    }
+
+
+def _expectation_count(result: SimulationResult, label: str) -> int:
+    return sum(1 for item in result.state.expectations if item.result == label)
 
 
 def _json_result_label(result: SimulationResult) -> str:

--- a/src/orbitfabric/sim/runner.py
+++ b/src/orbitfabric/sim/runner.py
@@ -14,6 +14,7 @@ from orbitfabric.sim.event_bus import EventBus
 from orbitfabric.sim.fault_monitor import FaultMonitor, FaultTrigger
 from orbitfabric.sim.mode_manager import ModeManager
 from orbitfabric.sim.state import (
+    ExpectationResult,
     SimDataFlowEvidenceRecord,
     SimulationResult,
     SimulationState,
@@ -259,11 +260,20 @@ class ScenarioRunner:
         if expected_status is None:
             return
 
-        if result.status != expected_status:
-            state.fail_expectation(
-                step.t,
-                f"expected command status {expected_status} but got {result.status}",
-            )
+        actual_status = result.status
+        message = (
+            f"expected command status {expected_status} but got {actual_status}"
+        )
+        self._record_expectation_result(
+            state=state,
+            t=step.t,
+            expectation_type="command_status",
+            target=step.command or "<unknown>",
+            expected=expected_status,
+            actual=actual_status,
+            passed=actual_status == expected_status,
+            failure_message=message,
+        )
 
     def _check_expectations(
         self,
@@ -274,23 +284,53 @@ class ScenarioRunner:
         mode_manager: ModeManager,
         command_router: CommandRouter,
     ) -> None:
-        if step.expect_event is not None and not event_bus.has_event(step.expect_event):
-            state.fail_expectation(step.t, f"missing event {step.expect_event}")
+        if step.expect_event is not None:
+            has_event = event_bus.has_event(step.expect_event)
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="event",
+                target=step.expect_event,
+                expected=True,
+                actual=has_event,
+                passed=has_event,
+                failure_message=f"missing event {step.expect_event}",
+            )
 
-        if step.expect_mode is not None and mode_manager.current_mode != step.expect_mode:
-            state.fail_expectation(
-                step.t,
-                f"expected mode {step.expect_mode} but got {mode_manager.current_mode}",
+        if step.expect_mode is not None:
+            actual_mode = mode_manager.current_mode
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="mode",
+                target="current_mode",
+                expected=step.expect_mode,
+                actual=actual_mode,
+                passed=actual_mode == step.expect_mode,
+                failure_message=(
+                    f"expected mode {step.expect_mode} but got {actual_mode}"
+                ),
             )
 
         if step.expect_command is not None:
             expected_dispatch = step.expect_command.dispatch
-            if not command_router.has_command(step.expect_command.id, expected_dispatch):
-                state.fail_expectation(
-                    step.t,
+            has_command = command_router.has_command(
+                step.expect_command.id,
+                expected_dispatch,
+            )
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="command",
+                target=step.expect_command.id,
+                expected={"dispatch": expected_dispatch, "present": True},
+                actual={"dispatch": expected_dispatch, "present": has_command},
+                passed=has_command,
+                failure_message=(
                     "missing command "
-                    f"{step.expect_command.id} with dispatch {expected_dispatch}",
-                )
+                    f"{step.expect_command.id} with dispatch {expected_dispatch}"
+                ),
+            )
 
         if step.expect_telemetry is not None:
             self._check_telemetry_expectations(step, telemetry, state)
@@ -311,13 +351,21 @@ class ScenarioRunner:
 
         for telemetry_id, expected_value in step.expect_telemetry.items():
             actual_value = telemetry.get(telemetry_id)
-            if actual_value != expected_value:
-                state.fail_expectation(
-                    step.t,
+            passed = actual_value == expected_value
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="telemetry",
+                target=telemetry_id,
+                expected=expected_value,
+                actual=actual_value,
+                passed=passed,
+                failure_message=(
                     f"expected telemetry {telemetry_id}={_format_value(expected_value)} "
-                    f"but got {_format_value(actual_value)}",
-                )
-            else:
+                    f"but got {_format_value(actual_value)}"
+                ),
+            )
+            if passed:
                 state.log(
                     step.t,
                     f"TELEMETRY {telemetry_id}={_format_value(actual_value)}",
@@ -339,17 +387,34 @@ class ScenarioRunner:
         expected_state = expected_lifecycle.get("state")
 
         if not isinstance(payload_id, str) or not isinstance(expected_state, str):
-            state.fail_expectation(step.t, "invalid payload lifecycle expectation")
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="payload_lifecycle",
+                target="<invalid>",
+                expected=expected_lifecycle,
+                actual=None,
+                passed=False,
+                failure_message="invalid payload lifecycle expectation",
+            )
             return
 
         actual_state = state.payload_lifecycle.get(payload_id)
-        if actual_state != expected_state:
-            state.fail_expectation(
-                step.t,
+        passed = actual_state == expected_state
+        self._record_expectation_result(
+            state=state,
+            t=step.t,
+            expectation_type="payload_lifecycle",
+            target=payload_id,
+            expected=expected_state,
+            actual=actual_state,
+            passed=passed,
+            failure_message=(
                 f"expected payload {payload_id} lifecycle {expected_state} "
-                f"but got {actual_state}",
-            )
-        else:
+                f"but got {actual_state}"
+            ),
+        )
+        if passed:
             state.log(step.t, f"PAYLOAD {payload_id} LIFECYCLE={actual_state}")
 
     def _check_data_flow_expectation(
@@ -366,21 +431,46 @@ class ScenarioRunner:
 
         data_product_id = expected_data_flow.get("data_product")
         if not isinstance(data_product_id, str):
-            state.fail_expectation(step.t, "invalid data flow expectation")
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="data_flow",
+                target="<invalid>",
+                expected=expected_data_flow,
+                actual=None,
+                passed=False,
+                failure_message="invalid data flow expectation",
+            )
             return
 
         evidence = _find_data_flow_evidence(state, data_product_id)
         if evidence is None:
-            state.fail_expectation(
-                step.t,
-                f"missing data flow evidence for {data_product_id}",
+            self._record_expectation_result(
+                state=state,
+                t=step.t,
+                expectation_type="data_flow",
+                target=data_product_id,
+                expected=expected_data_flow,
+                actual=None,
+                passed=False,
+                failure_message=f"missing data flow evidence for {data_product_id}",
             )
             return
 
+        actual = _data_flow_evidence_expectation_view(evidence)
         mismatches = _data_flow_expectation_mismatches(expected_data_flow, evidence)
-        if mismatches:
-            state.fail_expectation(step.t, "; ".join(mismatches))
-        else:
+        passed = not mismatches
+        self._record_expectation_result(
+            state=state,
+            t=step.t,
+            expectation_type="data_flow",
+            target=data_product_id,
+            expected=expected_data_flow,
+            actual=actual,
+            passed=passed,
+            failure_message="; ".join(mismatches),
+        )
+        if passed:
             state.log(step.t, f"DATA_FLOW {data_product_id} EXPECTATION_MET")
 
     def _check_scenario_status_expectation(
@@ -396,11 +486,43 @@ class ScenarioRunner:
             return
 
         actual_status = "PASSED" if state.passed else "FAILED"
-        if actual_status != expected_status:
-            state.fail_expectation(
-                step.t,
-                f"expected scenario status {expected_status} but got {actual_status}",
-            )
+        self._record_expectation_result(
+            state=state,
+            t=step.t,
+            expectation_type="scenario_status",
+            target="scenario",
+            expected=expected_status,
+            actual=actual_status,
+            passed=actual_status == expected_status,
+            failure_message=(
+                f"expected scenario status {expected_status} but got {actual_status}"
+            ),
+        )
+
+    def _record_expectation_result(
+        self,
+        state: SimulationState,
+        t: float,
+        expectation_type: str,
+        target: str,
+        expected: Any,
+        actual: Any,
+        passed: bool,
+        failure_message: str,
+    ) -> None:
+        result: ExpectationResult = "passed" if passed else "failed"
+        message = "expectation passed" if passed else failure_message
+        state.record_expectation(
+            t=t,
+            expectation_type=expectation_type,
+            target=target,
+            expected=expected,
+            actual=actual,
+            result=result,
+            message=message,
+        )
+        if not passed:
+            state.fail_expectation(t, failure_message)
 
 
 def _build_data_flow_evidence(
@@ -482,6 +604,19 @@ def _find_data_flow_evidence(
             return evidence
 
     return None
+
+
+def _data_flow_evidence_expectation_view(
+    evidence: SimDataFlowEvidenceRecord,
+) -> dict[str, Any]:
+    return {
+        "data_product": evidence.data_product_id,
+        "triggered_by_command": evidence.command_id,
+        "storage_intent_declared": evidence.storage_intent.get("declared"),
+        "downlink_intent_declared": evidence.downlink_intent.get("declared"),
+        "eligible_downlink_flows": evidence.eligible_downlink_flows,
+        "contact_windows": evidence.contact_windows,
+    }
 
 
 def _data_flow_expectation_mismatches(

--- a/src/orbitfabric/sim/state.py
+++ b/src/orbitfabric/sim/state.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 CommandDispatchKind = Literal["GROUND", "AUTO"]
 CommandStatus = Literal["ACCEPTED", "REJECTED", "AUTO_DISPATCHED", "FAILED"]
+ExpectationResult = Literal["passed", "failed"]
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,17 @@ class SimDataFlowEvidenceRecord:
     contact_windows: list[str]
 
 
+@dataclass(frozen=True)
+class SimExpectationRecord:
+    t: float
+    expectation_type: str
+    target: str
+    expected: Any
+    actual: Any
+    result: ExpectationResult
+    message: str
+
+
 @dataclass
 class SimulationState:
     current_time: float
@@ -63,10 +75,33 @@ class SimulationState:
     commands: list[SimCommandRecord] = field(default_factory=list)
     mode_transitions: list[SimModeTransitionRecord] = field(default_factory=list)
     data_flow_evidence: list[SimDataFlowEvidenceRecord] = field(default_factory=list)
+    expectations: list[SimExpectationRecord] = field(default_factory=list)
     failed_expectations: list[str] = field(default_factory=list)
 
     def log(self, t: float, message: str) -> None:
         self.logs.append(SimLogEntry(t=t, message=message))
+
+    def record_expectation(
+        self,
+        t: float,
+        expectation_type: str,
+        target: str,
+        expected: Any,
+        actual: Any,
+        result: ExpectationResult,
+        message: str,
+    ) -> None:
+        self.expectations.append(
+            SimExpectationRecord(
+                t=t,
+                expectation_type=expectation_type,
+                target=target,
+                expected=expected,
+                actual=actual,
+                result=result,
+                message=message,
+            )
+        )
 
     def fail_expectation(self, t: float, message: str) -> None:
         self.failed_expectations.append(message)

--- a/tests/test_sim_json_report.py
+++ b/tests/test_sim_json_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -85,6 +86,89 @@ def test_simulation_result_to_dict_for_data_flow_evidence_scenario() -> None:
     )
 
 
+def test_simulation_result_to_dict_contains_structured_expectation_accounting() -> None:
+    loaded = ScenarioLoader().load(DATA_FLOW_SCENARIO)
+    result = ScenarioRunner().run(loaded)
+
+    payload = simulation_result_to_dict(result)
+
+    assert payload["summary"]["expectations"] == 12
+    assert payload["summary"]["passed_expectations"] == 12
+    assert payload["summary"]["failed_expectations"] == 0
+    assert payload["expectations"]["total"] == 12
+    assert payload["expectations"]["passed"] == 12
+    assert payload["expectations"]["failed"] == 0
+    assert payload["failed_expectations"] == []
+
+    records = payload["expectations"]["records"]
+    assert len(records) == 12
+    assert {
+        record["expectation_type"] for record in records
+    } == {
+        "mode",
+        "payload_lifecycle",
+        "command_status",
+        "event",
+        "telemetry",
+        "data_flow",
+        "scenario_status",
+    }
+    assert all(record["result"] == "passed" for record in records)
+
+    data_flow_record = next(
+        record for record in records if record["expectation_type"] == "data_flow"
+    )
+    assert data_flow_record["target"] == "payload.radiation_histogram"
+    assert data_flow_record["expected"]["triggered_by_command"] == (
+        "payload.start_acquisition"
+    )
+    assert data_flow_record["actual"]["triggered_by_command"] == (
+        "payload.start_acquisition"
+    )
+    assert data_flow_record["message"] == "expectation passed"
+
+
+def test_failed_simulation_report_keeps_legacy_failed_expectations(
+    tmp_path: Path,
+) -> None:
+    scenario_path = _copy_data_flow_scenario_with_failing_telemetry(tmp_path)
+    loaded = ScenarioLoader().load(scenario_path)
+    result = ScenarioRunner().run(loaded)
+
+    payload = simulation_result_to_dict(result)
+
+    assert payload["result"] == "failed"
+    assert payload["summary"]["expectations"] == 12
+    assert payload["summary"]["passed_expectations"] == 10
+    assert payload["summary"]["failed_expectations"] == 2
+    assert payload["expectations"]["total"] == 12
+    assert payload["expectations"]["passed"] == 10
+    assert payload["expectations"]["failed"] == 2
+    assert payload["failed_expectations"] == [
+        "expected telemetry payload.acquisition.active=false but got true",
+        "expected scenario status PASSED but got FAILED",
+    ]
+
+    failed_records = [
+        record
+        for record in payload["expectations"]["records"]
+        if record["result"] == "failed"
+    ]
+    assert [record["expectation_type"] for record in failed_records] == [
+        "telemetry",
+        "scenario_status",
+    ]
+    assert failed_records[0] == {
+        "t": 8,
+        "expectation_type": "telemetry",
+        "target": "payload.acquisition.active",
+        "expected": False,
+        "actual": True,
+        "result": "failed",
+        "message": "expected telemetry payload.acquisition.active=false but got true",
+    }
+
+
 def test_sim_command_writes_json_report(tmp_path: Path) -> None:
     output_path = tmp_path / "battery_low_report.json"
 
@@ -110,8 +194,12 @@ def test_sim_command_writes_json_report(tmp_path: Path) -> None:
     assert payload["result"] == "passed"
     assert payload["summary"]["failed_expectations"] == 0
     assert payload["summary"]["data_flow_evidence"] == 1
-    assert payload["data_flow_evidence"][0]["data_product_id"] == "payload.radiation_histogram"
-    assert payload["data_flow_evidence"][0]["triggered_by_command"] == "payload.start_acquisition"
+    assert payload["data_flow_evidence"][0]["data_product_id"] == (
+        "payload.radiation_histogram"
+    )
+    assert payload["data_flow_evidence"][0]["triggered_by_command"] == (
+        "payload.start_acquisition"
+    )
 
 
 def test_sim_command_writes_data_flow_evidence_json_report(tmp_path: Path) -> None:
@@ -137,6 +225,32 @@ def test_sim_command_writes_data_flow_evidence_json_report(tmp_path: Path) -> No
     assert payload["result"] == "passed"
     assert payload["summary"]["data_flow_evidence"] == 1
     assert payload["summary"]["failed_expectations"] == 0
+    assert payload["summary"]["expectations"] == 12
+    assert payload["summary"]["passed_expectations"] == 12
+    assert payload["expectations"]["failed"] == 0
     assert payload["data_flow_evidence"][0]["data_product_id"] == (
         "payload.radiation_histogram"
     )
+
+
+def _copy_data_flow_scenario_with_failing_telemetry(tmp_path: Path) -> Path:
+    source = Path("examples/demo-3u")
+    demo_dir = tmp_path / "demo-3u"
+    shutil.copytree(source, demo_dir)
+
+    scenario_path = demo_dir / "scenarios" / "payload_data_flow_evidence.yaml"
+    scenario = scenario_path.read_text(encoding="utf-8")
+    scenario_path.write_text(
+        scenario.replace(
+            "  - t: 8\n"
+            "    expect_telemetry:\n"
+            "      payload.acquisition.active: true\n",
+            "  - t: 8\n"
+            "    expect_telemetry:\n"
+            "      payload.acquisition.active: false\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    return scenario_path


### PR DESCRIPTION
## Summary

Adds additive structured expectation accounting to OrbitFabric simulation JSON reports.

This PR introduces:

- `SimulationState.expectations` structured records;
- structured expectation recording in the scenario runner;
- top-level `expectations` object in simulation JSON reports;
- additive `summary.expectations` and `summary.passed_expectations` counters;
- documentation updates for simulation report expectation accounting;
- tests for passed expectation accounting, failed expectation accounting and legacy compatibility.

## Simulation JSON additive fields

The simulation report now includes:

```json
{
  "summary": {
    "expectations": 12,
    "passed_expectations": 12,
    "failed_expectations": 0
  },
  "expectations": {
    "total": 12,
    "passed": 12,
    "failed": 0,
    "records": []
  }
}
```

Each expectation record includes:

```text
t
expectation_type
target
expected
actual
result
message
```

## Compatibility

This is an additive simulation JSON report extension.

The existing top-level `failed_expectations` array is preserved for compatibility and continues to contain human-readable failed expectation messages.

Existing consumers that only read `failed_expectations` should continue to work.

New consumers can read the structured `expectations` object for passed and failed accounting.

## Mission Data Contract impact

No Mission Data Contract semantic impact.

This PR does not add, remove or rename Mission Model fields, scenario YAML fields, model domains, controlled values, reference rules or lint diagnostics.

It records expectations that were already evaluated by the simulator.

## Architectural boundary

This PR does not introduce:

- coverage metrics;
- model completeness scoring;
- mission health scoring;
- formal verification;
- runtime behavior;
- ground behavior;
- relationship graph behavior;
- dependency graph behavior;
- plugin discovery, loading or execution;
- Studio-specific APIs.

## Validation

Not run locally in this environment.

Expected checks:

```text
ruff check .
pytest tests/test_sim_json_report.py
pytest
mkdocs build --strict
```

Manual smoke test:

```text
orbitfabric sim examples/demo-3u/scenarios/payload_data_flow_evidence.yaml \
  --json generated/reports/payload_data_flow_evidence_report.json
```

Then inspect the `expectations` object in the generated report.