### PR TITLE
fix: make generated artifact defaults workspace-relative

### DIFF
--- a/src/orbitfabric/cli.py
+++ b/src/orbitfabric/cli.py
@@ -141,15 +141,21 @@ def gen_docs(
         ),
     ],
     output_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--output-dir",
             help="Directory where generated Markdown documentation will be written.",
         ),
-    ] = Path("generated/docs"),
+    ] = None,
 ) -> None:
     """Generate Markdown documentation from a Mission Model."""
     typer.echo(f"OrbitFabric Docs Generator {__version__}")
+
+    output_dir = _mission_workspace_default_path(
+        mission_dir,
+        output_dir,
+        "generated/docs",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -192,15 +198,21 @@ def gen_data_flow(
         ),
     ],
     output_file: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--output-file",
             help="Markdown file where data-flow documentation will be written.",
         ),
-    ] = Path("generated/docs/data_flow.md"),
+    ] = None,
 ) -> None:
     """Generate Markdown data-flow documentation from a Mission Model."""
     typer.echo(f"OrbitFabric Data Flow Docs Generator {__version__}")
+
+    output_file = _mission_workspace_default_path(
+        mission_dir,
+        output_file,
+        "generated/docs/data_flow.md",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -236,12 +248,12 @@ def gen_runtime(
         ),
     ],
     output_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--output-dir",
             help="Directory where runtime generation artifacts will be written.",
         ),
-    ] = Path("generated/runtime"),
+    ] = None,
     profile: Annotated[
         str,
         typer.Option(
@@ -252,6 +264,12 @@ def gen_runtime(
 ) -> None:
     """Generate runtime-facing contract artifacts from a Mission Model."""
     typer.echo(f"OrbitFabric Runtime Generator {__version__}")
+
+    output_dir = _mission_workspace_default_path(
+        mission_dir,
+        output_dir,
+        "generated/runtime",
+    )
 
     if profile != "cpp17":
         typer.echo(f"\nUnsupported runtime generation profile: {profile}")
@@ -307,12 +325,12 @@ def gen_ground(
         ),
     ],
     output_dir: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--output-dir",
             help="Directory where ground generation artifacts will be written.",
         ),
-    ] = Path("generated/ground"),
+    ] = None,
     profile: Annotated[
         str,
         typer.Option(
@@ -323,6 +341,12 @@ def gen_ground(
 ) -> None:
     """Generate ground-facing contract artifacts from a Mission Model."""
     typer.echo(f"OrbitFabric Ground Generator {__version__}")
+
+    output_dir = _mission_workspace_default_path(
+        mission_dir,
+        output_dir,
+        "generated/ground",
+    )
 
     if profile != "generic":
         typer.echo(f"\nUnsupported ground generation profile: {profile}")
@@ -379,15 +403,21 @@ def export_model_summary(
         ),
     ],
     json_output: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--json",
             help="Write the machine-readable model summary to this JSON file.",
         ),
-    ] = Path("generated/reports/model_summary.json"),
+    ] = None,
 ) -> None:
     """Export a Core-owned read-only Mission Model summary."""
     typer.echo(f"OrbitFabric Model Summary Export {__version__}")
+
+    json_output = _mission_workspace_default_path(
+        mission_dir,
+        json_output,
+        "generated/reports/model_summary.json",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -416,15 +446,21 @@ def export_entity_index(
         ),
     ],
     json_output: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--json",
             help="Write the machine-readable entity index to this JSON file.",
         ),
-    ] = Path("generated/reports/entity_index.json"),
+    ] = None,
 ) -> None:
     """Export a Core-owned read-only Mission Model entity index."""
     typer.echo(f"OrbitFabric Entity Index Export {__version__}")
+
+    json_output = _mission_workspace_default_path(
+        mission_dir,
+        json_output,
+        "generated/reports/entity_index.json",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -453,15 +489,21 @@ def export_relationship_manifest(
         ),
     ],
     json_output: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--json",
             help="Write the candidate relationship manifest to this JSON file.",
         ),
-    ] = Path("generated/reports/relationship_manifest.json"),
+    ] = None,
 ) -> None:
     """Export a candidate Core-owned relationship manifest."""
     typer.echo(f"OrbitFabric Relationship Manifest Export {__version__}")
+
+    json_output = _mission_workspace_default_path(
+        mission_dir,
+        json_output,
+        "generated/reports/relationship_manifest.json",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -495,15 +537,21 @@ def export_dashboard_summary(
         ),
     ],
     json_output: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--json",
             help="Write the candidate dashboard summary to this JSON file.",
         ),
-    ] = Path("generated/reports/dashboard_summary.json"),
+    ] = None,
 ) -> None:
     """Export a candidate Core-owned dashboard foundation summary."""
     typer.echo(f"OrbitFabric Dashboard Summary Export {__version__}")
+
+    json_output = _mission_workspace_default_path(
+        mission_dir,
+        json_output,
+        "generated/reports/dashboard_summary.json",
+    )
 
     try:
         model = MissionModelLoader().load(mission_dir)
@@ -576,7 +624,7 @@ def export_coverage_summary(
         ),
     ],
     entity_index_file: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--entity-index",
             exists=True,
@@ -585,9 +633,9 @@ def export_coverage_summary(
             readable=True,
             help="Core entity_index.json file used as the coverage denominator.",
         ),
-    ] = Path("generated/reports/entity_index.json"),
+    ] = None,
     relationship_manifest_file: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--relationship-manifest",
             exists=True,
@@ -596,9 +644,9 @@ def export_coverage_summary(
             readable=True,
             help="Core relationship_manifest.json file used as relationship denominator.",
         ),
-    ] = Path("generated/reports/relationship_manifest.json"),
+    ] = None,
     scenario_run_index_file: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--scenario-run-index",
             exists=True,
@@ -607,17 +655,38 @@ def export_coverage_summary(
             readable=True,
             help="Core scenario_run_index.json file used to locate simulation reports.",
         ),
-    ] = Path("generated/reports/scenario_run_index.json"),
+    ] = None,
     json_output: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "--json",
             help="Write the candidate coverage summary to this JSON file.",
         ),
-    ] = Path("generated/reports/coverage_summary.json"),
+    ] = None,
 ) -> None:
     """Export a candidate Core-owned coverage summary."""
     typer.echo(f"OrbitFabric Coverage Summary Export {__version__}")
+
+    entity_index_file = _mission_workspace_default_path(
+        mission_dir,
+        entity_index_file,
+        "generated/reports/entity_index.json",
+    )
+    relationship_manifest_file = _mission_workspace_default_path(
+        mission_dir,
+        relationship_manifest_file,
+        "generated/reports/relationship_manifest.json",
+    )
+    scenario_run_index_file = _mission_workspace_default_path(
+        mission_dir,
+        scenario_run_index_file,
+        "generated/reports/scenario_run_index.json",
+    )
+    json_output = _mission_workspace_default_path(
+        mission_dir,
+        json_output,
+        "generated/reports/coverage_summary.json",
+    )
 
     try:
         written_file = write_coverage_summary(
@@ -756,6 +825,23 @@ def sim(
 
     if not result.passed:
         raise typer.Exit(code=1)
+
+
+def _mission_workspace_default_path(
+    mission_dir: Path,
+    explicit_path: Path | None,
+    default_relative_path: str,
+) -> Path:
+    """Resolve default generated artifact paths under the mission workspace.
+
+    Explicit CLI paths are intentionally returned unchanged. Only omitted CLI
+    paths are resolved relative to the mission workspace directory, conventionally
+    the parent directory of the Mission Model directory.
+    """
+    if explicit_path is not None:
+        return explicit_path
+
+    return mission_dir.parent / default_relative_path
 
 
 def _print_model_error(exc: MissionModelError) -> None:

--- a/tests/test_workspace_relative_cli_defaults.py
+++ b/tests/test_workspace_relative_cli_defaults.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from orbitfabric.cli import app
+
+runner = CliRunner()
+
+
+def test_generation_defaults_are_mission_workspace_relative(tmp_path: Path) -> None:
+    workspace = _copy_demo_workspace(tmp_path)
+    mission_dir = workspace / "mission"
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
+        cwd_generated_dir = Path(isolated_cwd) / "generated"
+
+        docs_result = runner.invoke(app, ["gen", "docs", str(mission_dir)])
+        assert docs_result.exit_code == 0, docs_result.output
+        assert (workspace / "generated" / "docs" / "telemetry.md").exists()
+        assert (workspace / "generated" / "docs" / "data_flow.md").exists()
+
+        data_flow_result = runner.invoke(app, ["gen", "data-flow", str(mission_dir)])
+        assert data_flow_result.exit_code == 0, data_flow_result.output
+        assert (workspace / "generated" / "docs" / "data_flow.md").exists()
+
+        runtime_result = runner.invoke(app, ["gen", "runtime", str(mission_dir)])
+        assert runtime_result.exit_code == 0, runtime_result.output
+        assert (
+            workspace
+            / "generated"
+            / "runtime"
+            / "cpp17"
+            / "runtime_contract_manifest.json"
+        ).exists()
+
+        ground_result = runner.invoke(app, ["gen", "ground", str(mission_dir)])
+        assert ground_result.exit_code == 0, ground_result.output
+        assert (
+            workspace
+            / "generated"
+            / "ground"
+            / "generic"
+            / "ground_contract_manifest.json"
+        ).exists()
+
+        assert not cwd_generated_dir.exists()
+
+
+def test_export_defaults_are_mission_workspace_relative(tmp_path: Path) -> None:
+    workspace = _copy_demo_workspace(tmp_path)
+    mission_dir = workspace / "mission"
+    reports_dir = workspace / "generated" / "reports"
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
+        cwd_generated_dir = Path(isolated_cwd) / "generated"
+
+        model_summary_result = runner.invoke(
+            app,
+            ["export", "model-summary", str(mission_dir)],
+        )
+        assert model_summary_result.exit_code == 0, model_summary_result.output
+        assert (reports_dir / "model_summary.json").exists()
+
+        entity_index_result = runner.invoke(
+            app,
+            ["export", "entity-index", str(mission_dir)],
+        )
+        assert entity_index_result.exit_code == 0, entity_index_result.output
+        assert (reports_dir / "entity_index.json").exists()
+
+        relationship_manifest_result = runner.invoke(
+            app,
+            ["export", "relationship-manifest", str(mission_dir)],
+        )
+        assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
+        assert (reports_dir / "relationship_manifest.json").exists()
+
+        dashboard_summary_result = runner.invoke(
+            app,
+            ["export", "dashboard-summary", str(mission_dir)],
+        )
+        assert dashboard_summary_result.exit_code == 0, dashboard_summary_result.output
+        assert (reports_dir / "dashboard_summary.json").exists()
+
+        assert not cwd_generated_dir.exists()
+
+
+def test_coverage_summary_defaults_are_mission_workspace_relative(
+    tmp_path: Path,
+) -> None:
+    workspace = _copy_demo_workspace(tmp_path)
+    mission_dir = workspace / "mission"
+    scenario_file = workspace / "scenarios" / "payload_data_flow_evidence.yaml"
+    reports_dir = workspace / "generated" / "reports"
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
+        cwd_generated_dir = Path(isolated_cwd) / "generated"
+
+        entity_index_result = runner.invoke(
+            app,
+            ["export", "entity-index", str(mission_dir)],
+        )
+        assert entity_index_result.exit_code == 0, entity_index_result.output
+
+        relationship_manifest_result = runner.invoke(
+            app,
+            ["export", "relationship-manifest", str(mission_dir)],
+        )
+        assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
+
+        simulation_report = reports_dir / "payload_data_flow_evidence_report.json"
+        sim_result = runner.invoke(
+            app,
+            ["sim", str(scenario_file), "--json", str(simulation_report)],
+        )
+        assert sim_result.exit_code == 0, sim_result.output
+        assert simulation_report.exists()
+
+        scenario_run_index_result = runner.invoke(
+            app,
+            [
+                "export",
+                "scenario-run-index",
+                "--simulation-reports",
+                str(reports_dir),
+                "--json",
+                str(reports_dir / "scenario_run_index.json"),
+            ],
+        )
+        assert scenario_run_index_result.exit_code == 0, scenario_run_index_result.output
+
+        coverage_summary_result = runner.invoke(
+            app,
+            ["export", "coverage-summary", str(mission_dir)],
+        )
+        assert coverage_summary_result.exit_code == 0, coverage_summary_result.output
+        assert (reports_dir / "coverage_summary.json").exists()
+
+        assert not cwd_generated_dir.exists()
+
+
+def test_explicit_relative_output_path_remains_cwd_relative(tmp_path: Path) -> None:
+    workspace = _copy_demo_workspace(tmp_path)
+    mission_dir = workspace / "mission"
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
+        explicit_output = Path("explicit/generated/docs")
+
+        result = runner.invoke(
+            app,
+            [
+                "gen",
+                "docs",
+                str(mission_dir),
+                "--output-dir",
+                str(explicit_output),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (Path(isolated_cwd) / explicit_output / "telemetry.md").exists()
+        assert not (workspace / "explicit" / "generated" / "docs").exists()
+
+
+def _copy_demo_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "demo-3u"
+    shutil.copytree(Path("examples/demo-3u"), workspace)
+    return workspace

--- a/tests/test_workspace_relative_cli_defaults.py
+++ b/tests/test_workspace_relative_cli_defaults.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 from orbitfabric.cli import app
@@ -10,159 +11,178 @@ from orbitfabric.cli import app
 runner = CliRunner()
 
 
-def test_generation_defaults_are_mission_workspace_relative(tmp_path: Path) -> None:
+def test_generation_defaults_are_mission_workspace_relative(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     workspace = _copy_demo_workspace(tmp_path)
     mission_dir = workspace / "mission"
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
-        cwd_generated_dir = Path(isolated_cwd) / "generated"
+    isolated_cwd = tmp_path / "cwd"
+    isolated_cwd.mkdir()
+    monkeypatch.chdir(isolated_cwd)
+    cwd_generated_dir = isolated_cwd / "generated"
 
-        docs_result = runner.invoke(app, ["gen", "docs", str(mission_dir)])
-        assert docs_result.exit_code == 0, docs_result.output
-        assert (workspace / "generated" / "docs" / "telemetry.md").exists()
-        assert (workspace / "generated" / "docs" / "data_flow.md").exists()
+    docs_result = runner.invoke(app, ["gen", "docs", str(mission_dir)])
+    assert docs_result.exit_code == 0, docs_result.output
+    assert (workspace / "generated" / "docs" / "telemetry.md").exists()
+    assert (workspace / "generated" / "docs" / "data_flow.md").exists()
 
-        data_flow_result = runner.invoke(app, ["gen", "data-flow", str(mission_dir)])
-        assert data_flow_result.exit_code == 0, data_flow_result.output
-        assert (workspace / "generated" / "docs" / "data_flow.md").exists()
+    data_flow_result = runner.invoke(app, ["gen", "data-flow", str(mission_dir)])
+    assert data_flow_result.exit_code == 0, data_flow_result.output
+    assert (workspace / "generated" / "docs" / "data_flow.md").exists()
 
-        runtime_result = runner.invoke(app, ["gen", "runtime", str(mission_dir)])
-        assert runtime_result.exit_code == 0, runtime_result.output
-        assert (
-            workspace
-            / "generated"
-            / "runtime"
-            / "cpp17"
-            / "runtime_contract_manifest.json"
-        ).exists()
+    runtime_result = runner.invoke(app, ["gen", "runtime", str(mission_dir)])
+    assert runtime_result.exit_code == 0, runtime_result.output
+    assert (
+        workspace
+        / "generated"
+        / "runtime"
+        / "cpp17"
+        / "runtime_contract_manifest.json"
+    ).exists()
 
-        ground_result = runner.invoke(app, ["gen", "ground", str(mission_dir)])
-        assert ground_result.exit_code == 0, ground_result.output
-        assert (
-            workspace
-            / "generated"
-            / "ground"
-            / "generic"
-            / "ground_contract_manifest.json"
-        ).exists()
+    ground_result = runner.invoke(app, ["gen", "ground", str(mission_dir)])
+    assert ground_result.exit_code == 0, ground_result.output
+    assert (
+        workspace
+        / "generated"
+        / "ground"
+        / "generic"
+        / "ground_contract_manifest.json"
+    ).exists()
 
-        assert not cwd_generated_dir.exists()
+    assert not cwd_generated_dir.exists()
 
 
-def test_export_defaults_are_mission_workspace_relative(tmp_path: Path) -> None:
+def test_export_defaults_are_mission_workspace_relative(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     workspace = _copy_demo_workspace(tmp_path)
     mission_dir = workspace / "mission"
     reports_dir = workspace / "generated" / "reports"
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
-        cwd_generated_dir = Path(isolated_cwd) / "generated"
+    isolated_cwd = tmp_path / "cwd"
+    isolated_cwd.mkdir()
+    monkeypatch.chdir(isolated_cwd)
+    cwd_generated_dir = isolated_cwd / "generated"
 
-        model_summary_result = runner.invoke(
-            app,
-            ["export", "model-summary", str(mission_dir)],
-        )
-        assert model_summary_result.exit_code == 0, model_summary_result.output
-        assert (reports_dir / "model_summary.json").exists()
+    model_summary_result = runner.invoke(
+        app,
+        ["export", "model-summary", str(mission_dir)],
+    )
+    assert model_summary_result.exit_code == 0, model_summary_result.output
+    assert (reports_dir / "model_summary.json").exists()
 
-        entity_index_result = runner.invoke(
-            app,
-            ["export", "entity-index", str(mission_dir)],
-        )
-        assert entity_index_result.exit_code == 0, entity_index_result.output
-        assert (reports_dir / "entity_index.json").exists()
+    entity_index_result = runner.invoke(
+        app,
+        ["export", "entity-index", str(mission_dir)],
+    )
+    assert entity_index_result.exit_code == 0, entity_index_result.output
+    assert (reports_dir / "entity_index.json").exists()
 
-        relationship_manifest_result = runner.invoke(
-            app,
-            ["export", "relationship-manifest", str(mission_dir)],
-        )
-        assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
-        assert (reports_dir / "relationship_manifest.json").exists()
+    relationship_manifest_result = runner.invoke(
+        app,
+        ["export", "relationship-manifest", str(mission_dir)],
+    )
+    assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
+    assert (reports_dir / "relationship_manifest.json").exists()
 
-        dashboard_summary_result = runner.invoke(
-            app,
-            ["export", "dashboard-summary", str(mission_dir)],
-        )
-        assert dashboard_summary_result.exit_code == 0, dashboard_summary_result.output
-        assert (reports_dir / "dashboard_summary.json").exists()
+    dashboard_summary_result = runner.invoke(
+        app,
+        ["export", "dashboard-summary", str(mission_dir)],
+    )
+    assert dashboard_summary_result.exit_code == 0, dashboard_summary_result.output
+    assert (reports_dir / "dashboard_summary.json").exists()
 
-        assert not cwd_generated_dir.exists()
+    assert not cwd_generated_dir.exists()
 
 
 def test_coverage_summary_defaults_are_mission_workspace_relative(
     tmp_path: Path,
+    monkeypatch: MonkeyPatch,
 ) -> None:
     workspace = _copy_demo_workspace(tmp_path)
     mission_dir = workspace / "mission"
     scenario_file = workspace / "scenarios" / "payload_data_flow_evidence.yaml"
     reports_dir = workspace / "generated" / "reports"
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
-        cwd_generated_dir = Path(isolated_cwd) / "generated"
+    isolated_cwd = tmp_path / "cwd"
+    isolated_cwd.mkdir()
+    monkeypatch.chdir(isolated_cwd)
+    cwd_generated_dir = isolated_cwd / "generated"
 
-        entity_index_result = runner.invoke(
-            app,
-            ["export", "entity-index", str(mission_dir)],
-        )
-        assert entity_index_result.exit_code == 0, entity_index_result.output
+    entity_index_result = runner.invoke(
+        app,
+        ["export", "entity-index", str(mission_dir)],
+    )
+    assert entity_index_result.exit_code == 0, entity_index_result.output
 
-        relationship_manifest_result = runner.invoke(
-            app,
-            ["export", "relationship-manifest", str(mission_dir)],
-        )
-        assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
+    relationship_manifest_result = runner.invoke(
+        app,
+        ["export", "relationship-manifest", str(mission_dir)],
+    )
+    assert relationship_manifest_result.exit_code == 0, relationship_manifest_result.output
 
-        simulation_report = reports_dir / "payload_data_flow_evidence_report.json"
-        sim_result = runner.invoke(
-            app,
-            ["sim", str(scenario_file), "--json", str(simulation_report)],
-        )
-        assert sim_result.exit_code == 0, sim_result.output
-        assert simulation_report.exists()
+    simulation_report = reports_dir / "payload_data_flow_evidence_report.json"
+    sim_result = runner.invoke(
+        app,
+        ["sim", str(scenario_file), "--json", str(simulation_report)],
+    )
+    assert sim_result.exit_code == 0, sim_result.output
+    assert simulation_report.exists()
 
-        scenario_run_index_result = runner.invoke(
-            app,
-            [
-                "export",
-                "scenario-run-index",
-                "--simulation-reports",
-                str(reports_dir),
-                "--json",
-                str(reports_dir / "scenario_run_index.json"),
-            ],
-        )
-        assert scenario_run_index_result.exit_code == 0, scenario_run_index_result.output
+    scenario_run_index_result = runner.invoke(
+        app,
+        [
+            "export",
+            "scenario-run-index",
+            "--simulation-reports",
+            str(reports_dir),
+            "--json",
+            str(reports_dir / "scenario_run_index.json"),
+        ],
+    )
+    assert scenario_run_index_result.exit_code == 0, scenario_run_index_result.output
 
-        coverage_summary_result = runner.invoke(
-            app,
-            ["export", "coverage-summary", str(mission_dir)],
-        )
-        assert coverage_summary_result.exit_code == 0, coverage_summary_result.output
-        assert (reports_dir / "coverage_summary.json").exists()
+    coverage_summary_result = runner.invoke(
+        app,
+        ["export", "coverage-summary", str(mission_dir)],
+    )
+    assert coverage_summary_result.exit_code == 0, coverage_summary_result.output
+    assert (reports_dir / "coverage_summary.json").exists()
 
-        assert not cwd_generated_dir.exists()
+    assert not cwd_generated_dir.exists()
 
 
-def test_explicit_relative_output_path_remains_cwd_relative(tmp_path: Path) -> None:
+def test_explicit_relative_output_path_remains_cwd_relative(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
     workspace = _copy_demo_workspace(tmp_path)
     mission_dir = workspace / "mission"
 
-    with runner.isolated_filesystem(temp_dir=tmp_path) as isolated_cwd:
-        explicit_output = Path("explicit/generated/docs")
+    isolated_cwd = tmp_path / "cwd"
+    isolated_cwd.mkdir()
+    monkeypatch.chdir(isolated_cwd)
 
-        result = runner.invoke(
-            app,
-            [
-                "gen",
-                "docs",
-                str(mission_dir),
-                "--output-dir",
-                str(explicit_output),
-            ],
-        )
+    explicit_output = Path("explicit/generated/docs")
 
-        assert result.exit_code == 0, result.output
-        assert (Path(isolated_cwd) / explicit_output / "telemetry.md").exists()
-        assert not (workspace / "explicit" / "generated" / "docs").exists()
+    result = runner.invoke(
+        app,
+        [
+            "gen",
+            "docs",
+            str(mission_dir),
+            "--output-dir",
+            str(explicit_output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (isolated_cwd / explicit_output / "telemetry.md").exists()
+    assert not (workspace / "explicit" / "generated" / "docs").exists()
 
 
 def _copy_demo_workspace(tmp_path: Path) -> Path:


### PR DESCRIPTION
Fixes #206.

## Summary
- Resolve implicit generated artifact defaults relative to the mission workspace instead of the current working directory.
- Preserve explicit user-provided output paths unchanged.
- Add regression coverage for docs, data-flow docs, runtime, ground, model summary, entity index, relationship manifest, dashboard summary, and coverage summary defaults.

## Validation
- python -m pytest tests/test_workspace_relative_cli_defaults.py
- python -m pytest

Result: 260 passed.