### PR TITLE
docs: consolidate post-v1 candidate integration surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project follows a lightweight changelog style for the Mission Model, contra
 
 ## [Unreleased]
 
+### Changed
+
+- Consolidated post-v1 candidate integration surface documentation across README, documentation home, roadmap and reference pages.
+- Added a dedicated post-v1 candidate integration surfaces index page to keep stable, candidate, Core-owned and downstream-owned boundaries explicit.
+- Reclassified the Dashboard and Coverage Foundation reference from a proposed future boundary to the implemented post-v1 candidate surface boundary.
+
+### Fixed
+
+- Fixed generated artifact default paths for mission-based CLI commands so omitted output paths resolve under the mission workspace instead of the current working directory.
+- Documented that explicit user-provided output paths are preserved unchanged.
+
 ### Added
 
 - Added the candidate `dashboard_summary.json` Core-owned structured surface.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,45 @@ entity_index.json           -> What contract entities are defined?
 relationship_manifest.json  -> How are indexed contract entities related?
 ```
 
+The post-v1 candidate Core-owned integration surface chain is:
+
+```text
+dashboard_summary.json      -> Dashboard-ready aggregation of existing Core facts
+scenario_run_index.json     -> Index of Core simulation JSON report runs
+coverage_summary.json       -> Limited coverage derived from Core structured outputs
+simulation JSON expectations -> Additive structured expectation accounting
+```
+
+These post-v1 surfaces are **candidate**, not part of the original v1.0.0 stable surface.
+
+They are Core-owned read-only structured outputs intended for downstream inspection tools.
+
+They do not make OrbitFabric Core a dashboard backend, flight software framework, ground segment, runtime framework, graph engine, Studio API or OpenOBSW/OpenSVF-specific generator.
+
+The ownership boundary is:
+
+```text
+Core defines, computes and emits contract-significant structured surfaces.
+Studio and other downstream tools consume, link, navigate and render them.
+Downstream tools must not invent private coverage, health or completeness semantics.
+```
+
+Generated artifact default paths are mission-workspace relative for mission-based commands.
+
+For example:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+writes to:
+
+```text
+examples/demo-3u/generated/ground/generic/
+```
+
+Explicit user-provided output paths are preserved unchanged.
+
 The stable v1.0 posture is:
 
 ```text
@@ -246,6 +285,16 @@ mkdocs build --strict
 
 ## Common Commands
 
+Mission-based commands write omitted generated artifact paths under the mission workspace.
+
+For `examples/demo-3u/mission/`, omitted report outputs resolve under:
+
+```text
+examples/demo-3u/generated/reports/
+```
+
+Pass `--json`, `--output-dir` or `--output-file` explicitly when a different destination is required.
+
 ```bash
 orbitfabric lint examples/demo-3u/mission/ \
   --json generated/reports/lint_report.json
@@ -258,6 +307,14 @@ orbitfabric export entity-index examples/demo-3u/mission/ \
 
 orbitfabric export relationship-manifest examples/demo-3u/mission/ \
   --json generated/reports/relationship_manifest.json
+
+orbitfabric export dashboard-summary examples/demo-3u/mission/
+
+orbitfabric export scenario-run-index \
+  --simulation-reports generated/reports \
+  --json generated/reports/scenario_run_index.json
+
+orbitfabric export coverage-summary examples/demo-3u/mission/
 
 orbitfabric gen docs examples/demo-3u/mission/
 
@@ -328,6 +385,10 @@ Useful entry points:
 - `docs/reference/v1-compatibility-migration-notes.md`
 - `docs/reference/golden-output-regression-confidence.md`
 - `docs/reference/extensibility-boundary-contract.md`
+- `docs/reference/post-v1-candidate-integration-surfaces.md`
+- `docs/reference/dashboard-summary-surface.md`
+- `docs/reference/scenario-run-index-surface.md`
+- `docs/reference/coverage-summary-surface.md`
 - `docs/releases/v1.0.0.md`
 
 Build the documentation site locally:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # OrbitFabric - Roadmap
 
 Version: v1.0.0  
-Status: Stable Mission Data Contract released  
-Scope: completed path to v1.0.0 and post-v1.0 direction
+Status: Stable Mission Data Contract released; post-v1 candidate surface consolidation in progress  
+Scope: completed path to v1.0.0, post-v1 candidate Core-owned integration surfaces and v1.1.0 consolidation direction
 
 ---
 
@@ -52,10 +52,11 @@ v0.10.1 Documentation and Published Site Consistency             completed
 v0.11.0 Extensibility Boundary Contract, no execution            completed
 v0.12.0 v1.0 Release Candidate Hardening                         completed
 v1.0.0  Stable Mission Data Contract                             completed
-post-v1  Narrow evolution of Core and downstream integrations     future
+post-v1  Candidate Core-owned integration surfaces                in progress
+v1.1.0   Candidate surface consolidation release                  planned
 ```
 
-The current completed milestone is:
+The current stable completed milestone is:
 
 ```text
 v1.0.0 - Stable Mission Data Contract
@@ -138,7 +139,70 @@ Studio-specific API
 
 ---
 
-## 5. Post-v1.0 Direction
+## 5. Post-v1 Candidate Core-owned Integration Surfaces
+
+After v1.0.0, OrbitFabric Core introduced a narrow set of candidate Core-owned integration surfaces:
+
+```text
+dashboard_summary.json
+scenario_run_index.json
+coverage_summary.json
+simulation JSON structured expectation accounting
+```
+
+These surfaces are intended to support downstream inspection without moving Mission Data Contract semantics into downstream tools.
+
+The ownership rule is:
+
+```text
+Core defines, computes and emits.
+Studio and other downstream tools consume, navigate and render.
+Downstream tools must not invent private coverage, health or completeness semantics.
+```
+
+These surfaces remain candidate until a later compatibility decision promotes selected fields or surfaces.
+
+They do not change the v1.0.0 stable Mission Data Contract.
+
+They do not introduce:
+
+```text
+new Mission Model semantics
+new YAML fields
+runtime behavior
+ground behavior
+mission health scoring
+model completeness scoring
+formal verification
+relationship graph behavior
+dependency graph behavior
+plugin execution
+Studio-specific APIs
+OpenOBSW/OpenSVF-specific generation
+Projection Profiles implementation
+OSRA/SAVOIR implementation
+```
+
+---
+
+## 6. v1.1.0 Consolidation Direction
+
+OrbitFabric Core v1.1.0 should be a consolidation release, not a conceptual expansion release.
+
+The v1.1.0 preparation scope is:
+
+```text
+document candidate Core-owned integration surfaces
+clarify stable vs candidate boundaries
+keep generated artifact defaults mission-workspace relative
+preserve explicit user-provided output paths
+add release notes and checklist in a later release-metadata PR
+avoid Projection Profiles implementation until a separate RFC/design decision
+```
+
+---
+
+## 7. Post-v1.0 Direction
 
 Post-v1.0 work must preserve the same discipline:
 
@@ -168,7 +232,7 @@ plugin discovery/loading/execution, only after a separate architectural decision
 
 ---
 
-## 6. Backlog Parking Lot
+## 8. Backlog Parking Lot
 
 These ideas are valid but are not part of the v1.0.0 stable release boundary:
 
@@ -216,7 +280,7 @@ plugin execution
 
 ---
 
-## 7. Final Roadmap Statement
+## 9. Final Roadmap Statement
 
 OrbitFabric v1.0.0 stabilizes OrbitFabric Core as a Mission Data Contract framework.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,40 @@ entity_index.json           -> entity navigation
 relationship_manifest.json  -> relationship navigation
 ```
 
+The current post-v1 candidate Core-owned integration surfaces are:
+
+```text
+dashboard_summary.json      -> dashboard-ready aggregation of existing Core facts
+scenario_run_index.json     -> simulation JSON run index
+coverage_summary.json       -> limited coverage from Core structured outputs
+simulation JSON expectations -> additive structured expectation accounting
+```
+
+These surfaces are candidate post-v1 outputs.
+
+They are Core-owned and read-only, but they are not part of the original v1.0.0 stable surface.
+
+They exist so downstream tools can inspect Core evidence without becoming a second source of Mission Data Contract semantics.
+
+The boundary is:
+
+```text
+Core owns Mission Data Contract semantics.
+Core emits structured surfaces.
+Downstream tools consume and render them.
+Downstream tools do not invent coverage, health or completeness semantics.
+```
+
+Generated artifact defaults for mission-based commands are mission-workspace relative.
+
+For `examples/demo-3u/mission/`, omitted generated outputs are written under:
+
+```text
+examples/demo-3u/generated/
+```
+
+Explicit output paths remain explicit and are not rewritten.
+
 The stable v1.0 posture is:
 
 ```text

--- a/docs/reference/coverage-summary-surface.md
+++ b/docs/reference/coverage-summary-surface.md
@@ -24,11 +24,20 @@ orbitfabric export coverage-summary examples/demo-3u/mission/ \
   --json generated/reports/coverage_summary.json
 ```
 
-Default output path:
+If the input and output options are omitted, the default paths are mission-workspace relative.
+
+For `examples/demo-3u/mission/`, the default paths are:
 
 ```text
-generated/reports/coverage_summary.json
+examples/demo-3u/generated/reports/entity_index.json
+examples/demo-3u/generated/reports/relationship_manifest.json
+examples/demo-3u/generated/reports/scenario_run_index.json
+examples/demo-3u/generated/reports/coverage_summary.json
 ```
+
+Explicit `--entity-index`, `--relationship-manifest`, `--scenario-run-index` and `--json` paths are preserved unchanged.
+
+`coverage-summary` is mission-based and therefore follows the workspace-relative generated artifact default rule.
 
 ---
 

--- a/docs/reference/dashboard-coverage-foundation.md
+++ b/docs/reference/dashboard-coverage-foundation.md
@@ -1,14 +1,14 @@
 # Dashboard and Coverage Foundation
 
-Status: Proposed post-v1 Core boundary  
-Scope: dashboard and coverage enablement for downstream tools  
+Status: Implemented post-v1 candidate Core boundary  
+Scope: dashboard and coverage enablement through candidate Core-owned structured surfaces  
 Applies to: OrbitFabric Core after `v1.0.0 - Stable Mission Data Contract`
 
-This page defines the boundary for future dashboard and coverage work in OrbitFabric Core.
+This page defines the implemented boundary for dashboard and coverage work in OrbitFabric Core after v1.0.0.
 
-It is a documentation boundary only.
+It began as a proposed boundary and now describes the candidate Core-owned surfaces that implement that boundary.
 
-It does not introduce new Mission Model semantics, new YAML fields, new CLI commands, new JSON report fields, new generated surfaces, runtime behavior, ground behavior, plugin execution, graph behavior, mission control behavior or Studio-specific APIs.
+It does not promote those surfaces to the original v1.0.0 stable surface and does not introduce new Mission Model semantics, new YAML fields, runtime behavior, ground behavior, plugin execution, graph behavior, mission control behavior or Studio-specific APIs.
 
 ---
 
@@ -98,9 +98,9 @@ Coverage must be derived from Core-owned structured outputs, for example:
 entity_index.json
 relationship_manifest.json
 simulation JSON reports
-future scenario_run_index.json
-future structured expectation accounting
-future coverage_summary.json
+scenario_run_index.json
+structured expectation accounting
+coverage_summary.json
 ```
 
 Coverage must not be derived from:
@@ -116,7 +116,7 @@ raw YAML parsing in downstream tools
 naming heuristics in downstream tools
 ```
 
-Until Core emits a coverage summary, downstream tools must show coverage as unavailable or requiring Core output.
+When Core does not emit a specific coverage value, downstream tools must show that value as unavailable or requiring Core output.
 
 ---
 
@@ -149,17 +149,17 @@ No downstream tool should invent such a score.
 
 ---
 
-## 6. Required Core sequence
+## 6. Implemented Core sequence
 
-The preferred post-v1 sequence is:
+The post-v1 sequence is now:
 
 ```text
-1. document dashboard and coverage boundaries
-2. add a Core-owned dashboard_summary.json report
-3. add a Core-owned scenario_run_index.json report
-4. add structured scenario expectation accounting
-5. add a Core-owned coverage_summary.json report
-6. protect selected mature fields with golden signatures
+1. documented dashboard and coverage boundaries
+2. added a Core-owned dashboard_summary.json report
+3. added a Core-owned scenario_run_index.json report
+4. added structured scenario expectation accounting
+5. added a Core-owned coverage_summary.json report
+6. added selected regression confidence for candidate contract-significant fields
 ```
 
 The sequence is intentionally staged.
@@ -172,7 +172,7 @@ Coverage must come after Core can index scenario runs and account for expectatio
 
 ## 7. dashboard_summary.json boundary
 
-A future `dashboard_summary.json` report should aggregate existing Core facts without introducing coverage semantics.
+`dashboard_summary.json` aggregates existing Core facts without introducing coverage semantics.
 
 Candidate identity:
 
@@ -213,7 +213,7 @@ This prevents downstream tools from inventing coverage while still allowing a re
 
 ## 8. scenario_run_index.json boundary
 
-A future `scenario_run_index.json` report should aggregate simulation JSON reports produced by Core.
+`scenario_run_index.json` aggregates simulation JSON reports produced by Core.
 
 Candidate identity:
 
@@ -246,11 +246,11 @@ This report would support recent-run dashboards and prepare coverage derivation.
 
 ## 9. Structured expectation accounting boundary
 
-Current simulation JSON reports expose failed expectations, but they do not expose a complete structured list of evaluated expectations.
+Current simulation JSON reports expose additive structured expectation accounting while preserving the legacy `failed_expectations` compatibility list.
 
-Future expectation accounting should be additive.
+Expectation accounting is additive.
 
-It should preserve existing `failed_expectations` compatibility and add a structured section for evaluated expectations.
+It preserves existing `failed_expectations` compatibility and adds a structured section for evaluated expectations.
 
 Candidate content may include:
 
@@ -270,7 +270,7 @@ This is required before Core can provide defensible expectation coverage.
 
 ## 10. coverage_summary.json boundary
 
-A future `coverage_summary.json` report should be the first Core-owned coverage surface.
+`coverage_summary.json` is the first Core-owned coverage surface.
 
 Candidate identity:
 

--- a/docs/reference/dashboard-summary-surface.md
+++ b/docs/reference/dashboard-summary-surface.md
@@ -21,11 +21,17 @@ orbitfabric export dashboard-summary examples/demo-3u/mission/ \
   --json generated/reports/dashboard_summary.json
 ```
 
-Default output path:
+If `--json` is omitted, the default output path is mission-workspace relative.
+
+For `examples/demo-3u/mission/`, the default output path is:
 
 ```text
-generated/reports/dashboard_summary.json
+examples/demo-3u/generated/reports/dashboard_summary.json
 ```
+
+An explicit `--json` path is preserved unchanged.
+
+`dashboard-summary` is mission-based and therefore follows the workspace-relative generated artifact default rule.
 
 ---
 

--- a/docs/reference/post-v1-candidate-integration-surfaces.md
+++ b/docs/reference/post-v1-candidate-integration-surfaces.md
@@ -1,0 +1,213 @@
+# Post-v1 Candidate Integration Surfaces
+
+Status: Active post-v1 reference  
+Scope: candidate Core-owned integration surfaces after `v1.0.0 - Stable Mission Data Contract`  
+Applies to: OrbitFabric Core after v1.0.0 and before any future promotion decision
+
+This page is the public index for candidate Core-owned integration surfaces introduced after the v1.0.0 stable Mission Data Contract release.
+
+It exists to keep the boundary explicit:
+
+```text
+Core is the contract authority.
+Downstream tools are read-only consumers.
+Candidate surfaces are not automatically stable surfaces.
+```
+
+---
+
+## 1. Current stable v1.0.0 Core-owned structured surfaces
+
+The original v1.0.0 stable Core-owned structured surface chain remains:
+
+```text
+model_summary.json
+entity_index.json
+relationship_manifest.json
+```
+
+Those surfaces are derived from the validated Mission Model and protected by selected golden signatures.
+
+The Mission Model remains the source of truth.
+
+---
+
+## 2. Current post-v1 candidate Core-owned integration surfaces
+
+The current candidate post-v1 surfaces are:
+
+```text
+dashboard_summary.json
+scenario_run_index.json
+coverage_summary.json
+simulation JSON structured expectation accounting
+```
+
+They are Core-owned because Core defines their fields, computes their values and declares their boundary flags.
+
+They are candidate because they were introduced after v1.0.0 and have not yet been promoted to a stronger compatibility class.
+
+---
+
+## 3. Surface inventory
+
+| Surface | Status | Purpose | Source of truth |
+|---|---|---|---|
+| `dashboard_summary.json` | Candidate | Dashboard-ready aggregation of existing Core facts | Mission Model and Core structured surfaces |
+| `scenario_run_index.json` | Candidate | Index simulation JSON report runs | Simulation JSON reports |
+| `coverage_summary.json` | Candidate | Limited coverage metrics from Core structured outputs | Entity index, relationship manifest, scenario run index and referenced simulation JSON reports |
+| Simulation JSON `expectations` object | Additive candidate extension | Structured passed/failed expectation accounting | Scenario execution evidence |
+
+---
+
+## 4. Ownership boundary
+
+The ownership boundary is:
+
+```text
+Core defines structured semantics.
+Core computes and emits structured reports.
+Studio and other downstream tools consume, navigate and render those reports.
+Downstream tools do not invent private Mission Data Contract semantics.
+```
+
+Downstream tools may derive UI navigation state from these reports.
+
+Downstream tools must not compute private substitutes for:
+
+```text
+coverage
+mission health
+model completeness
+relationship graph behavior
+dependency graph behavior
+runtime behavior
+ground behavior
+formal verification
+```
+
+If a value is not emitted by Core, downstream tools should display one of:
+
+```text
+Unavailable
+Requires Core output
+Not defined by Core
+```
+
+---
+
+## 5. Generated artifact default paths
+
+Mission-based CLI commands resolve omitted generated artifact paths under the mission workspace.
+
+For example:
+
+```bash
+orbitfabric export dashboard-summary examples/demo-3u/mission/
+```
+
+writes by default to:
+
+```text
+examples/demo-3u/generated/reports/dashboard_summary.json
+```
+
+and:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+writes by default to:
+
+```text
+examples/demo-3u/generated/ground/generic/
+```
+
+Explicit user-provided paths remain explicit.
+
+For example:
+
+```bash
+orbitfabric gen docs examples/demo-3u/mission/ --output-dir custom/docs
+```
+
+continues to write to:
+
+```text
+custom/docs
+```
+
+relative to the current working directory unless the user provides an absolute path.
+
+---
+
+## 6. Compatibility posture
+
+The post-v1 candidate surfaces do not change the original v1.0.0 stable Mission Data Contract.
+
+They do not add, remove or rename Mission Model fields, model domains, controlled values, reference rules or scenario expectation syntax.
+
+Structured expectation accounting is additive inside simulation JSON reports and preserves the legacy top-level `failed_expectations` array.
+
+Future promotion of any candidate field or surface requires a separate reviewed decision and, where appropriate, selected regression or golden-signature protection.
+
+---
+
+## 7. Explicit non-goals
+
+The post-v1 candidate integration surfaces do not introduce:
+
+```text
+Projection Profiles implementation
+OSRA/SAVOIR implementation
+OpenOBSW/OpenSVF-specific generation
+Studio-specific APIs
+mission health scoring
+model completeness scoring
+flight readiness scoring
+runtime telemetry behavior
+ground execution behavior
+relationship graph behavior
+dependency graph behavior
+plugin discovery
+plugin loading
+plugin execution
+CCSDS/PUS/CFDP framing
+transport behavior
+flight software framework behavior
+ground segment behavior
+```
+
+---
+
+## 8. v1.1.0 release implication
+
+Core v1.1.0 should consolidate these candidate surfaces.
+
+It should not turn candidate surfaces into a broad new framework.
+
+The release should communicate:
+
+```text
+what is stable
+what is candidate
+what is Core-owned
+what is downstream-consumer-owned
+what remains explicitly out of scope
+```
+
+---
+
+## 9. Final statement
+
+The post-v1 candidate integration surfaces are valid Core surfaces because they keep Mission Data Contract semantics inside Core.
+
+They are deliberately narrow:
+
+```text
+emit structured evidence
+preserve provenance
+declare boundaries
+avoid downstream semantic invention
+```

--- a/docs/reference/scenario-run-index-surface.md
+++ b/docs/reference/scenario-run-index-surface.md
@@ -10,7 +10,7 @@ It does not read plain-text logs.
 
 It does not introduce coverage metrics.
 
-It does not introduce structured expectation accounting.
+It does not compute structured expectation accounting; it preserves simulation summary values already emitted by simulation JSON reports.
 
 It does not introduce runtime behavior, ground behavior, graph behavior, plugin execution or Studio-specific APIs.
 
@@ -169,6 +169,8 @@ events
 commands
 mode_transitions
 data_flow_evidence
+expectations
+passed_expectations
 failed_expectations
 ```
 
@@ -244,7 +246,7 @@ The scenario run index does not provide:
 coverage metrics
 model completeness score
 mission health score
-structured expectation accounting
+new structured expectation accounting
 runtime facts
 live telemetry
 command uplink

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - Golden Output and Regression Confidence Policy: reference/golden-output-regression-confidence.md
       - v1.0 Compatibility and Migration Notes: reference/v1-compatibility-migration-notes.md
       - Dashboard and Coverage Foundation: reference/dashboard-coverage-foundation.md
+      - Post-v1 Candidate Integration Surfaces: reference/post-v1-candidate-integration-surfaces.md
       - Dashboard Summary Surface: reference/dashboard-summary-surface.md
       - Scenario Run Index Surface: reference/scenario-run-index-surface.md
       - Coverage Summary Surface: reference/coverage-summary-surface.md


### PR DESCRIPTION
## Summary
- Document post-v1 candidate Core-owned integration surfaces.
- Clarify stable vs candidate boundaries.
- Clarify Core-owned vs downstream-consumer-owned responsibilities.
- Reclassify the Dashboard and Coverage Foundation page from proposed boundary to implemented candidate boundary.
- Document mission-workspace-relative generated artifact defaults from PR #218.
- Update scenario run index documentation for structured expectation summary fields.

## Scope
Documentation only.

## Out of scope
- No package version bump.
- No release tag.
- No v1.1.0 release notes.
- No Projection Profiles implementation.
- No Studio-specific APIs.
- No OpenOBSW/OpenSVF-specific code.

## Validation
- mkdocs build --strict
- python -m pytest