### PR TITLE
chore: prepare v1.1.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project follows a lightweight changelog style for the Mission Model, contra
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [v1.1.0] - 2026-06-13
+
 ### Changed
 
 - Consolidated post-v1 candidate integration surface documentation across README, documentation home, roadmap and reference pages.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ future extension-owned outputs
 OrbitFabric is currently released at:
 
 ```text
-v1.0.0 - Stable Mission Data Contract
+v1.1.0 - Candidate Integration Surface Consolidation
 ```
 
-v1.0.0 stabilizes a deliberately narrow Core surface around the Mission Model, validation, linting, scenario evidence, machine-readable JSON reports, Core-owned structured surfaces, release compatibility governance and the extensibility boundary.
+v1.1.0 consolidates the post-v1 candidate Core-owned integration surfaces while preserving the deliberately narrow v1.0.0 Stable Mission Data Contract.
 
 The stable surface is intentionally limited.
 
-OrbitFabric v1.0.0 is not a flight software framework, not a ground segment, not a mission control system, not a spacecraft dynamics simulator, not a plugin execution platform and not a tool-specific integration layer.
+OrbitFabric v1.1.0 is not a flight software framework, not a ground segment, not a mission control system, not a spacecraft dynamics simulator, not a plugin execution platform and not a tool-specific integration layer.
 
 The stable Core-owned structured surface chain is:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # OrbitFabric - Roadmap
 
-Version: v1.0.0  
-Status: Stable Mission Data Contract released; post-v1 candidate surface consolidation in progress  
+Version: v1.1.0  
+Status: Candidate Integration Surface Consolidation released  
 Scope: completed path to v1.0.0, post-v1 candidate Core-owned integration surfaces and v1.1.0 consolidation direction
 
 ---
@@ -52,14 +52,14 @@ v0.10.1 Documentation and Published Site Consistency             completed
 v0.11.0 Extensibility Boundary Contract, no execution            completed
 v0.12.0 v1.0 Release Candidate Hardening                         completed
 v1.0.0  Stable Mission Data Contract                             completed
-post-v1  Candidate Core-owned integration surfaces                in progress
-v1.1.0   Candidate surface consolidation release                  planned
+post-v1  Candidate Core-owned integration surfaces                completed
+v1.1.0   Candidate surface consolidation release                  completed
 ```
 
-The current stable completed milestone is:
+The current completed milestone is:
 
 ```text
-v1.0.0 - Stable Mission Data Contract
+v1.1.0 - Candidate Integration Surface Consolidation
 ```
 
 ---
@@ -196,7 +196,7 @@ document candidate Core-owned integration surfaces
 clarify stable vs candidate boundaries
 keep generated artifact defaults mission-workspace relative
 preserve explicit user-provided output paths
-add release notes and checklist in a later release-metadata PR
+release notes and checklist added in the v1.1.0 release metadata PR
 avoid Projection Profiles implementation until a separate RFC/design decision
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,14 +11,14 @@ From that contract, OrbitFabric validates consistency, generates documentation, 
 OrbitFabric is currently at:
 
 ```text
-v1.0.0 - Stable Mission Data Contract
+v1.1.0 - Candidate Integration Surface Consolidation
 ```
 
-v1.0.0 stabilizes a deliberately narrow Core surface around the Mission Model, validation, linting, scenario evidence, machine-readable JSON reports, Core-owned structured surfaces, release compatibility governance and the extensibility boundary.
+v1.1.0 consolidates the post-v1 candidate Core-owned integration surfaces while preserving the deliberately narrow v1.0.0 Stable Mission Data Contract.
 
 The stable surface is intentionally limited.
 
-OrbitFabric v1.0.0 is not a flight software framework, not a ground segment, not a mission control system, not a spacecraft dynamics simulator, not a plugin execution platform and not a tool-specific integration layer.
+OrbitFabric v1.1.0 is not a flight software framework, not a ground segment, not a mission control system, not a spacecraft dynamics simulator, not a plugin execution platform and not a tool-specific integration layer.
 
 ## Core idea
 

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,167 @@
+# OrbitFabric v1.1.0 - Candidate Integration Surface Consolidation
+
+Release date: 2026-06-13  
+Status: Released metadata candidate, pending tag and GitHub release publication  
+Scope: Core post-v1 candidate integration surface consolidation
+
+---
+
+## Summary
+
+OrbitFabric v1.1.0 is a consolidation release after `v1.0.0 - Stable Mission Data Contract`.
+
+It keeps the v1.0.0 Mission Data Contract stable while consolidating a narrow set of post-v1 Core-owned candidate integration surfaces:
+
+```text
+dashboard_summary.json
+scenario_run_index.json
+coverage_summary.json
+simulation JSON structured expectation accounting
+```
+
+This release does not turn OrbitFabric Core into a dashboard backend, ground segment, runtime framework, flight software framework, Studio API or OpenOBSW/OpenSVF-specific generator.
+
+---
+
+## Stable v1.0.0 surface remains unchanged
+
+The original stable v1.0.0 Core-owned structured surface chain remains:
+
+```text
+model_summary.json
+entity_index.json
+relationship_manifest.json
+```
+
+The Mission Model remains the source of truth.
+
+The v1.1.0 consolidation does not add, remove or rename Mission Model fields.
+
+---
+
+## Candidate surfaces consolidated in v1.1.0
+
+The post-v1 candidate surface chain is:
+
+```text
+dashboard_summary.json      -> dashboard-ready aggregation of existing Core facts
+scenario_run_index.json     -> simulation JSON report run index
+coverage_summary.json       -> limited coverage derived from Core structured outputs
+simulation JSON expectations -> additive structured expectation accounting
+```
+
+These surfaces are Core-owned because Core defines, computes and emits them.
+
+They remain candidate because they were introduced after v1.0.0 and have not yet been promoted to the original stable compatibility class.
+
+---
+
+## Generated artifact defaults
+
+Mission-based CLI commands now resolve omitted generated artifact output paths under the mission workspace.
+
+For example:
+
+```bash
+orbitfabric gen ground examples/demo-3u/mission/
+```
+
+writes by default to:
+
+```text
+examples/demo-3u/generated/ground/generic/
+```
+
+and:
+
+```bash
+orbitfabric export dashboard-summary examples/demo-3u/mission/
+```
+
+writes by default to:
+
+```text
+examples/demo-3u/generated/reports/dashboard_summary.json
+```
+
+Explicit user-provided output paths remain explicit.
+
+---
+
+## Compatibility posture
+
+v1.1.0 preserves:
+
+```text
+Mission Model semantics
+v1.0.0 stable structured surface posture
+legacy simulation JSON failed_expectations compatibility
+explicit user-provided CLI output paths
+Core as the Mission Data Contract authority
+```
+
+Structured expectation accounting is additive.
+
+The top-level `failed_expectations` compatibility list remains available.
+
+---
+
+## Explicit non-goals
+
+v1.1.0 does not introduce:
+
+```text
+Projection Profiles implementation
+OSRA/SAVOIR implementation
+OpenOBSW/OpenSVF-specific generation
+Studio-specific APIs
+mission health scoring
+model completeness scoring
+flight readiness scoring
+runtime telemetry behavior
+ground execution behavior
+relationship graph behavior
+dependency graph behavior
+plugin discovery
+plugin loading
+plugin execution
+CCSDS/PUS/CFDP framing
+transport behavior
+flight software framework behavior
+ground segment behavior
+```
+
+---
+
+## Validation checklist
+
+Before publishing the final tag and GitHub release, run:
+
+```bash
+mkdocs build --strict
+python -m pytest
+```
+
+Expected result:
+
+```text
+documentation build succeeds
+full test suite passes
+```
+
+---
+
+## Release publication checklist
+
+For final publication:
+
+```text
+1. Merge the release metadata PR.
+2. Confirm main is clean and up to date.
+3. Run mkdocs build --strict.
+4. Run python -m pytest.
+5. Create the v1.1.0 tag only after explicit approval.
+6. Publish GitHub release notes using this page as source material.
+```
+
+Do not create the tag as part of the release metadata PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - v0.11.0 Extensibility Boundary Contract, no execution: releases/v0.11.0.md
       - v0.12.0 v1.0 Release Candidate Hardening: releases/v0.12.0.md
       - v1.0.0 Stable Mission Data Contract: releases/v1.0.0.md
+      - v1.1.0 Candidate Integration Surface Consolidation: releases/v1.1.0.md
   - Communication:
       - Payload Contract Model Announcement: comms/payload-contract-model-announcement.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orbitfabric"
-version = "1.0.0"
+version = "1.1.0"
 description = "A model-first Mission Data Fabric for small spacecraft."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/orbitfabric/__init__.py
+++ b/src/orbitfabric/__init__.py
@@ -3,4 +3,4 @@
 OrbitFabric is a model-first Mission Data Fabric for small spacecraft.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
## Summary
- Bump package metadata to v1.1.0.
- Promote the accumulated changelog entries to v1.1.0.
- Add v1.1.0 release notes.
- Add v1.1.0 to documentation navigation.
- Update README, documentation home and roadmap release metadata.

## Scope
Release metadata only.

## Out of scope
- No release tag.
- No GitHub release publication.
- No functional code changes.
- No Projection Profiles implementation.
- No Studio-specific APIs.
- No OpenOBSW/OpenSVF-specific code.

## Validation
- mkdocs build --strict
- python -m pytest